### PR TITLE
Handle intermittently missing target temperature on M5C

### DIFF
--- a/documentation/MQTT_COMMANDS.md
+++ b/documentation/MQTT_COMMANDS.md
@@ -84,8 +84,8 @@ The following `commandType` values are emitted by the printer as unsolicited sta
 | :--- | :--- | :--- | :--- |
 | `1000` | `0x03e8` | `value` | Printer state machine: `0` = idle/finished, `1` = active/printing, `2` = paused, `8` = aborted (user cancelled via touchscreen or calibration phase) |
 | `1001` | `0x03e9` | `time` | Remaining print time in seconds |
-| `1003` | `0x03eb` | `currentTemp`, `targetTemp` | Nozzle temperature (units: 1/100 °C) |
-| `1004` | `0x03ec` | `currentTemp`, `targetTemp` | Hotbed temperature (units: 1/100 °C) |
+| `1003` | `0x03eb` | `currentTemp`, `targetTemp` | Nozzle temperature (units: 1/100 °C), `targetTemp` intermittently missing on M5C |
+| `1004` | `0x03ec` | `currentTemp`, `targetTemp` | Hotbed temperature (units: 1/100 °C), `targetTemp` intermittently missing on M5C |
 | `1006` | `0x03ee` | `value` | Print speed in mm/s |
 | `1007` | `0x03ef` | `value` | Auto-leveling probe progress — emitted after each probe point during G29; `value` = current point index (50 total: 1 initial center probe + 7×7 grid). Use this to display a live progress bar. |
 | `1044` | `0x0414` | `filePath` | GCode file path — sent when a print job starts; basename is used as the filename |

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -45,11 +45,20 @@ $(function () {
 
     /**
      * Get temperature from input
-     * @param {number} temp Temperature in Celsius
-     * @returns {number} Rounded temperature
+     * @param {number} temp Temperature in 1/100 °C
+     * @returns {number} temperature in °C, null if temp is not a number
      */
     function getTemp(temp) {
-        return Math.round(temp / 100);
+        return (typeof(temp) === "number") ? (temp / 100) : null;
+    }
+
+    /**
+     * Get rounded temperature from input
+     * @param {number} temp Temperature in 1/100 °C
+     * @returns {number} Rounded temperature in °C, null if temp is not a number
+     */
+    function getTempRounded(temp) {
+        return (typeof(temp) === "number") ? Math.round(temp / 100) : null;
     }
 
     /**
@@ -318,22 +327,26 @@ $(function () {
                 }
             } else if (data.commandType == 1003) {
                 // Returns Nozzle Temp
-                const current = getTemp(data.currentTemp);
-                const target = getTemp(data.targetTemp);
+                const current = getTempRounded(data.currentTemp);
                 $("#nozzle-temp").text(`${current}°C`);
-                if (!$("#set-nozzle-temp").is(":focus")) {
-                    $("#set-nozzle-temp").val(target);
+                if (data.hasOwnProperty('targetTemp')) {
+                    const target = getTempRounded(data.targetTemp);
+                    if (!$("#set-nozzle-temp").is(":focus")) {
+                        $("#set-nozzle-temp").val(target);
+                    }
                 }
-                pushTempData("nozzle", current, target);
+                pushTempData("nozzle", getTemp(data.currentTemp), getTemp(data.targetTemp));
             } else if (data.commandType == 1004) {
                 // Returns Bed Temp
-                const current = getTemp(data.currentTemp);
-                const target = getTemp(data.targetTemp);
+                const current = getTempRounded(data.currentTemp);
                 $("#bed-temp").text(`${current}°C`);
-                if (!$("#set-bed-temp").is(":focus")) {
-                    $("#set-bed-temp").val(target);
+                if (data.hasOwnProperty('targetTemp')) {
+                    const target = getTempRounded(data.targetTemp);
+                    if (!$("#set-bed-temp").is(":focus")) {
+                        $("#set-bed-temp").val(target);
+                    }
                 }
-                pushTempData("bed", current, target);
+                pushTempData("bed", getTemp(data.currentTemp), getTemp(data.targetTemp));
             } else if (data.commandType == 1006) {
                 // Returns Print Speed
                 const X = getSpeedFactor(data.value);
@@ -1612,8 +1625,14 @@ $(function () {
     let _pendingBed = { c: null, t: null };
 
     function pushTempData(type, current, target) {
-        if (type === "nozzle") { _pendingNozzle = { c: current, t: target }; }
-        else if (type === "bed") { _pendingBed = { c: current, t: target }; }
+        if (type === "nozzle") {
+            _pendingNozzle.c = current;
+            if (target !== null) { _pendingNozzle.t = target; }
+        }
+        else if (type === "bed") {
+            _pendingBed.c = current;
+            if (target !== null) { _pendingBed.t = target; }
+        }
 
         const now = Date.now();
         if (now - lastTempPush < 1000) return; // 1s throttle
@@ -2926,4 +2945,3 @@ $(function () {
     });
 
 });
-


### PR DESCRIPTION
With constant target temperatures bigger than 0 the M5C often only sends the current temperature without the target temperature. With this PR the code is now able to deal with this and keeps the previously received target temperature. This is done for both the text input fields and the line graph.

In addition I changed the temperature values pushed to the line chart to exact floating point numbers get get smoother lines.

Before:
<img width="1312" height="447" alt="grafik" src="https://github.com/user-attachments/assets/248c0674-91a5-4890-92f6-2c9a33ed3c2c" />

After:
<img width="857" height="361" alt="grafik" src="https://github.com/user-attachments/assets/b22587e1-1fee-490a-b338-7025456b5e44" />