### PR TITLE
Fix permissions of /log directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,12 @@ RUN groupadd -g ${GID} ankerctl && \
     chown -R ankerctl:ankerctl /home/ankerctl
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get install -y --no-install-recommends ffmpeg gosu && \
     rm -rf /var/lib/apt/lists/*
+
+# Copy the entrypoint script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 # Copy the script and libraries
 COPY --chown=ankerctl:ankerctl ankerctl.py /app/
@@ -53,8 +57,8 @@ STOPSIGNAL SIGINT
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python3 -c "import urllib.request, os; h=os.getenv('FLASK_HOST','127.0.0.1'); h='127.0.0.1' if h in ('0.0.0.0','::','') else h; urllib.request.urlopen('http://'+h+':'+os.getenv('FLASK_PORT','4470')+'/api/health',timeout=4)" 2>/dev/null || exit 1
 
-# Run as non-root user
-USER ankerctl
+# Note: We run as root for the entrypoint script to fix permissions,
+# then switch to ankerctl user via gosu in the entrypoint
 
-ENTRYPOINT ["/app/ankerctl.py"]
-CMD ["webserver", "run"]
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["/app/ankerctl.py", "webserver", "run"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Fix permissions for the /logs directory if it exists
+if [ -d "/logs" ]
+then
+    echo "Fixing permissions for /logs directory..."
+    chown ankerctl:ankerctl /logs || echo "Warning: Could not change ownership of /logs"
+    chmod 755 /logs || echo "Warning: Could not change permissions of /logs"
+fi
+
+# Switch to the ankerctl user and execute the main command
+exec su ankerctl -c "$*"


### PR DESCRIPTION
When running ankerctl via the docker container (`docker compose up`), I was seeing the following errors resulting from permission problems with the `/log` directory.

```
$ docker compose up
Attaching to ankerctl
ankerctl  | Traceback (most recent call last):
ankerctl  |   File "/app/ankerctl.py", line 664, in <module>
ankerctl  |     main()
ankerctl  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
ankerctl  |     return self.main(*args, **kwargs)
ankerctl  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
ankerctl  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1055, in main
ankerctl  |     rv = self.invoke(ctx)
ankerctl  |          ^^^^^^^^^^^^^^^^
ankerctl  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1654, in invoke
ankerctl  |     super().invoke(ctx)
ankerctl  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
ankerctl  |     return ctx.invoke(self.callback, **ctx.params)
ankerctl  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ankerctl  |   File "/usr/local/lib/python3.11/site-packages/click/core.py", line 760, in invoke
ankerctl  |     return __callback(*args, **kwargs)
ankerctl  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ankerctl  |   File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
ankerctl  |     return f(get_current_context(), *args, **kwargs)
ankerctl  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ankerctl  |   File "/app/ankerctl.py", line 92, in main
ankerctl  |     cli.logfmt.setup_logging(levels[env.level], log_dir=log_dir)
ankerctl  |   File "/app/cli/logfmt.py", line 53, in setup_logging
ankerctl  |     root_handler = logging.FileHandler(os.path.join(log_dir, "ankerctl.log"))
ankerctl  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ankerctl  |   File "/usr/local/lib/python3.11/logging/__init__.py", line 1181, in __init__
ankerctl  |     StreamHandler.__init__(self, self._open())
ankerctl  |                                  ^^^^^^^^^^^^
ankerctl  |   File "/usr/local/lib/python3.11/logging/__init__.py", line 1213, in _open
ankerctl  |     return open_func(self.baseFilename, self.mode,
ankerctl  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ankerctl  | PermissionError: [Errno 13] Permission denied: '/logs/ankerctl.log'
ankerctl exited with code 1 (restarting)
```

The only way I found was to start an `entrypoint.sh` script as root, fix the permissions if `/log` is present, and continue with `ankerctl.py` as unprivileged user.