### PR TITLE
Add pyproject.toml with requires-python constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "ankerctl"
+version = "0.1.0"
+description = "CLI and web UI for AnkerMake M5 3D printers"
+readme = "README.md"
+license = {text = "GPL-3.0-only"}
+requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Adds a minimal `pyproject.toml` with `requires-python = ">=3.10"` so pip, uv, IDEs, and other tooling can discover the Python version constraint before installation
- Currently the `>=3.10` requirement is only enforced at runtime (`cli/checkver.py`) and documented in `README.md` — package managers have no way to check it

## Notes

- No `[build-system]` or `dependencies` table — this is an application, not a pip-installable package
- Uses PEP 621 table format for `license` field (`{text = "GPL-3.0-only"}`) for broad tooling compatibility
- `requirements.txt` remains unchanged as the dependency source

## Test plan

- [x] `python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb')))"` — parses cleanly
- [x] No impact on existing functionality (file is only read by tooling, not by ankerctl itself)