### PR TITLE
Add error handling to config_import() for malformed login files

### DIFF
--- a/web/config.py
+++ b/web/config.py
@@ -18,6 +18,8 @@ Functions:
 Returns:
 - config_output: A formatted string containing the configuration information.
 """
+import json
+
 import libflagship.httpapi
 import libflagship.logincache
 
@@ -98,10 +100,22 @@ def config_import(login_file: object, config: object):
     - config_output: A formatted string containing the configuration information.
     """
     # get the login data
-    cache = libflagship.logincache.load(login_file.stream.read())["data"]
+    try:
+        cache = libflagship.logincache.load(login_file.stream.read())
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as err:
+        raise ConfigImportError(f"Failed to parse login file: {err}")
+
+    if not isinstance(cache, dict) or "data" not in cache:
+        raise ConfigImportError("Invalid login file: missing 'data' field")
 
     # load remaining configuration items from the server
-    cli.config.import_config_from_server(config, cache, False)
+    try:
+        cli.config.import_config_from_server(config, cache["data"], False)
+    except libflagship.httpapi.APIError as err:
+        raise ConfigImportError(
+            f"API request failed: {err} "
+            "(auth token might be expired: try 'ankerctl config login' to refresh)"
+        )
 
 
 def config_login(email: str, password: str, country: str, captcha_id: str, captcha_answer: str, config: object):


### PR DESCRIPTION
## Summary

- `config_import()` in `web/config.py` did bare dict access on `logincache.load()` output with no error handling — malformed or corrupted `login.json` files produced confusing tracebacks
- Now catches parse errors (`JSONDecodeError`, `UnicodeDecodeError`, `ValueError`), validates the `"data"` key exists, and wraps `APIError` with a hint about expired auth tokens
- All exceptions surface as `ConfigImportError`, which the Flask route already handles with user-friendly feedback

## Notes

- `config_login()` in the same file already followed this pattern — this brings `config_import()` in line
- Exception types are narrowed to realistic failures from `logincache.load()` to avoid masking unrelated bugs

## Test plan

- [x] `python3 -c "import web.config; print('OK')"` — imports cleanly
- [x] Verified syntax with `ast.parse()`
- [ ] Manual: upload a corrupted `login.json` via web UI → should show specific error instead of generic traceback