### PR TITLE
Fix KeyError when constructing dataclass instances with missing keys

### DIFF
--- a/cli/model.py
+++ b/cli/model.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, MISSING
 from platformdirs import PlatformDirs
 from libflagship.util import unhex, enhex
 
@@ -95,7 +95,11 @@ class Serialize:
     def from_dict(cls, data):
         res = {}
         for k, v in cls.__dataclass_fields__.items():
-            res[k] = data[k]
+            if (k not in data) and (v.default is not MISSING):
+                # prevent KeyErrors if there is a default value
+                res[k] = v.default
+            else:
+                res[k] = data[k]
             if v.type == bytes:
                 res[k] = unhex(res[k])
             elif v.type == datetime:


### PR DESCRIPTION
When creating dataclass instances from dictionaries (via `from_dict()`), default values for missing keys are not taken into account. This PR adds this functionality and as a consequence prevents KeyError exceptions during `from_dict()`.

Reference: This was already present in @anselor's ankerctl fork in my [commit 664a4d5e](https://github.com/anselor/ankermake-m5-protocol/commit/664a4d5e#diff-39fb2d3875a289180a13d54ed3c8098104fd7e73f5b5afe9ce2bb41714549be3).

Fixes #7.