### PR TITLE
docs: update remaining AnkerMake Slicer references to eufyMake Studio

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -90,7 +90,7 @@ The CLI is run via `ankerctl.py`.
 ## Configuration
 
 *   **Storage:** Configuration is stored in a `default.json` file managed by `ankerctl`.
-*   **Import:** Configuration is typically imported from the official AnkerMake Slicer's `login.json` or `user_info` file.
+*   **Import:** Configuration is typically imported from the official eufyMake Studio's (formerly AnkerMake Slicer) `login.json` or `user_info` file.
 *   **CLI Config:** `cli/config.py` handles loading and saving configuration.
 
 ## Key Files & Directories

--- a/documentation/developer-docs/example-file-usage/example-file-prerequistes.md
+++ b/documentation/developer-docs/example-file-usage/example-file-prerequistes.md
@@ -2,9 +2,9 @@
 
 In order to run the example scripts, you'll need to install some supporting software onto your machine. 
 
-You'll need Python 3, some pip packages, and the AnkerMake slicer. 
+You'll need Python 3, some pip packages, and eufyMake Studio.
 
-If you're on Linux, all these tools are natively supported. To install/run the AnkerMake slicer, you'll need some type of translation layer software such as [Wine](https://www.winehq.org/) or [Proton-Caller](https://github.com/caverym/proton-caller).
+If you're on Linux, all these tools are natively supported. To install/run eufyMake Studio, you'll need some type of translation layer software such as [Wine](https://www.winehq.org/) or [Proton-Caller](https://github.com/caverym/proton-caller).
 
 We also include the [Transwarp Compiler](https://github.com/chrivers/transwarp) in our `requirements.txt` file for convenience should you want to generate new library files from templates.
 
@@ -12,9 +12,9 @@ We also include the [Transwarp Compiler](https://github.com/chrivers/transwarp) 
 
 ### Windows
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Make sure you open it and login.
+1. Install [eufyMake Studio](https://www.eufymake.com/software). Make sure you open it and login.
    **NOTE:** The slicer app does not need to be open for the rest of these steps.
-   
+
 2. Using `git` or [GitHub Desktop](https://desktop.github.com/), clone this repository into a location of your choice and then navigate to that location in File Explorer.
 
 3. Hold down the "Shift" key and right-click on some empty space in the repository top level folder. Select "Open in Terminal" from the context menu dropdown. (If the following commands do not work, try re-opening your terminal window as administrator and use the `cd` command to navigate to where you cloned this repository to)
@@ -55,7 +55,7 @@ We also include the [Transwarp Compiler](https://github.com/chrivers/transwarp) 
 
 ### MacOS
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Make sure you open it and login.
+1. Install [eufyMake Studio](https://www.eufymake.com/software). Make sure you open it and login.
    **NOTE:** The slicer app does not need to be open for the rest of these steps.
 
 2. Using `git` or [GitHub Desktop](https://desktop.github.com/), clone this repository into a location of your choice and then navigate to that location in Finder.
@@ -74,7 +74,7 @@ We also include the [Transwarp Compiler](https://github.com/chrivers/transwarp) 
 
 ### Linux
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Alternatively, you can install the slicer on a officially supported operating system that you have access to (Windows or MacOS) and use the `login.json` file from that machine. Either way you choose, make sure you open the slicer and login.
+1. Install [eufyMake Studio](https://www.eufymake.com/software). Alternatively, you can install the slicer on a officially supported operating system that you have access to (Windows or MacOS) and use the `login.json` file from that machine. Either way you choose, make sure you open the slicer and login.
 
    **NOTE:** The slicer app does not need to be open for the rest of these steps.
 

--- a/documentation/developer-docs/example-file-usage/extract-auth-token-example-file-usage.md
+++ b/documentation/developer-docs/example-file-usage/extract-auth-token-example-file-usage.md
@@ -1,6 +1,6 @@
 # Extracting your Authentication Token
 
-**NOTE:** You need to have to have logged into the AnkerMake slicer in order for this to work, but it doesn't need to be open during this.
+**NOTE:** You need to have to have logged into eufyMake Studio in order for this to work, but it doesn't need to be open during this.
 
 1. Navigate to wherever you cloned this repository to and into the `examples` folder in your terminal.
 

--- a/documentation/install-from-docker.md
+++ b/documentation/install-from-docker.md
@@ -2,9 +2,9 @@
 
 ## login.json pre-requisites for Linux Install
 
-### AnkerMake Slicer installed on another Machine
+### eufyMake Studio installed on another Machine
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software) on a supported Operating System.  Make sure you open it and login via the “Account” dropdown in the top toolbar.
+1. Install [eufyMake Studio](https://www.eufymake.com/software) on a supported Operating System.  Make sure you open it and login via the “Account” dropdown in the top toolbar.
 
 2. Retreive the ```login.json``` file (Windows: ```user_info```) from the supported operating system:
 
@@ -24,7 +24,7 @@
 
 ### Native Linux
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software) on Linux via emulation such as Wine.  Make sure you open it and login via the “Account” dropdown in the top toolbar.
+1. Install [eufyMake Studio](https://www.eufymake.com/software) on Linux via emulation such as Wine.  Make sure you open it and login via the “Account” dropdown in the top toolbar.
    
 2. Retreive the ```login.json``` file (Windows: ```user_info```) ```~/.wine/drive_c/users/$USER/AppData/Roaming/eufyMake Studio Profile/cache/offline/user_info```
 

--- a/documentation/install-from-git.md
+++ b/documentation/install-from-git.md
@@ -5,9 +5,9 @@
 
 ## Windows
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Make sure you open it and login via the “Account” dropdown in the top toolbar.
+1. Install [eufyMake Studio](https://www.eufymake.com/software). Make sure you open it and login via the “Account” dropdown in the top toolbar.
    **NOTE:** The slicer app does not need to be open for the rest of these steps.
-   
+
 2. Using `git` or [GitHub Desktop](https://desktop.github.com/), clone this repository into a location of your choice and then navigate to that location in File Explorer.
 
 3. Hold down the "Shift" key and right-click on some empty space in the repository top level folder. Select "Open in Terminal" (Windows 11) or  "Open PowerShell window here" (Windows 10) from the context menu dropdown. (If the following commands do not work, try re-opening your terminal window as administrator and use the `cd` command to navigate to where you cloned this repository)
@@ -48,7 +48,7 @@
 
 ## MacOS
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Make sure you open it and login via the “Account” dropdown in the top toolbar.
+1. Install [eufyMake Studio](https://www.eufymake.com/software). Make sure you open it and login via the “Account” dropdown in the top toolbar.
    **NOTE:** The slicer app does not need to be open for the rest of these steps.
 
 2. Using `git` or [GitHub Desktop](https://desktop.github.com/), clone this repository into a location of your choice and then navigate to that location in Finder.
@@ -69,7 +69,7 @@
 
 ## Linux
 
-1. Install the [AnkerMake slicer](https://www.ankermake.com/software). Alternatively, you can install the slicer on a officially supported operating system that you have access to (Windows or MacOS) and use the `login.json` file from that machine. Either way you choose, make sure you open the slicer and login via the “Account” dropdown in the top toolbar.
+1. Install [eufyMake Studio](https://www.eufymake.com/software). Alternatively, you can install the slicer on a officially supported operating system that you have access to (Windows or MacOS) and use the `login.json` file from that machine. Either way you choose, make sure you open the slicer and login via the “Account” dropdown in the top toolbar.
 
    **NOTE:** The slicer app does not need to be open for the rest of these steps.
 


### PR DESCRIPTION
## Summary

Completes the documentation rebranding started in PR #11 (which updated runtime strings).

- Software name references updated to **eufyMake Studio** across 5 documentation files
- Download URLs updated from `ankermake.com/software` to `eufymake.com/software` (the canonical URL; old URL 301-redirects)
- First mention in GEMINI.md uses "eufyMake Studio's (formerly AnkerMake Slicer)" for discoverability

### Unchanged (intentionally)
- **CHANGELOG.md** — historical record
- **Filesystem paths** (`AnkerMake/AnkerMake_64bit_fp/`) — real directories on users' machines
- **API/MQTT hostnames** — backend infrastructure
- **Files already updated by PR #11** — `docker-import.sh`, `examples/extract-auth-token.py`, `libflagship/logincache.py`

## Files changed
- `GEMINI.md`
- `documentation/install-from-docker.md`
- `documentation/install-from-git.md`
- `documentation/developer-docs/example-file-usage/example-file-prerequistes.md`
- `documentation/developer-docs/example-file-usage/extract-auth-token-example-file-usage.md`

## Test plan
- [x] `grep -ri 'ankermake slicer' documentation/ GEMINI.md` returns zero results
- [x] `grep -ri 'ankermake.com/software' documentation/ GEMINI.md` returns zero results
- [x] Only `.md` files touched — no runtime code changes