### PR TITLE
Fix socket leak and silent exception swallowing in PPPP probe

### DIFF
--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -27,21 +27,31 @@ def probe_pppp(config, printer_index) -> bool:
 
         deadline = datetime.now() + timedelta(seconds=5)
         api = AnkerPPPPAsyncApi.open_lan(Duid.from_string(printer.p2p_duid), host=ip_addr)
-        api.connect_lan_search()
+        try:
+            api.connect_lan_search()
 
-        while api.state != PPPPState.Connected:
-            remaining = (deadline - datetime.now()).total_seconds()
-            if remaining <= 0:
-                return False
+            while api.state != PPPPState.Connected:
+                remaining = (deadline - datetime.now()).total_seconds()
+                if remaining <= 0:
+                    return False
+                try:
+                    msg = api.recv(timeout=remaining)
+                    api.process(msg)
+                except (TimeoutError, ConnectionResetError):
+                    return False
+
             try:
-                msg = api.recv(timeout=remaining)
-                api.process(msg)
-            except StopIteration:
-                return False
-
-        api.send(PktClose())
-        return True
-    except Exception:
+                api.send(PktClose())
+            except Exception:
+                pass
+            return True
+        finally:
+            try:
+                api.sock.close()
+            except Exception:
+                pass
+    except Exception as e:
+        log.debug(f"PPPP probe failed unexpectedly: {e}")
         return False
 
 
@@ -101,7 +111,7 @@ class PPPPService(Service):
             try:
                 msg = api.recv(timeout=remaining)
                 api.process(msg)
-            except StopIteration:
+            except ConnectionResetError:
                 raise ConnectionRefusedError("Connection rejected by device")
 
         log.info("Established pppp connection")


### PR DESCRIPTION
## Summary

Partial fix for #10 — `probe_pppp()` leaks a UDP socket on every call (success or failure) and silently swallows all exceptions, making probe failures undiagnosable.

- **Socket leak:** `open_lan()` creates a UDP socket that was never closed. After repeated failed probes (every 15-60s), file descriptors accumulate. Now wrapped in `try/finally` with `api.sock.close()`, matching the pattern used by `probe_printer_ip()` and `lan_search()` in `cli/pppp.py`.
- **Silent exceptions:** The broad `except Exception: return False` discarded all diagnostic info. Now logs at debug level so probe failures are visible with `-v`.
- **Dead code:** Removed `StopIteration` from exception handlers in both `probe_pppp()` and `worker_start()` — it is never raised anywhere in the PPPP library.

The remaining issue from #10 (uncoordinated per-WebSocket-client probe loops causing a connection storm) needs more design work and will ship in a separate PR.

## Test plan

- [x] `python3 -c "import py_compile; py_compile.compile('web/service/pppp.py', doraise=True)"` — syntax OK
- [x] `grep -n "open_lan\|sock.close" web/service/pppp.py` — every `open_lan` has a matching `sock.close`
- [x] `./ankerctl.py pppp lan-search` — finds printer, no errors
- [x] `./ankerctl.py webserver run` — starts cleanly, no exceptions