### PR TITLE
Fix file handle leaks in config reader and file upload

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -78,7 +78,8 @@ class BaseConfigManager:
         if not path.exists():
             return default
 
-        return json.load(path.open(), object_hook=self._load_json)
+        with path.open() as f:
+            return json.load(f, object_hook=self._load_json)
 
     def save(self, name, value):
         path = self.config_path(name)
@@ -269,7 +270,8 @@ def merge_config_preferences(existing, new_config):
 
 def attempt_config_upgrade(config, profile, insecure):
     path = config.config_path("default")
-    data = json.load(path.open())
+    with path.open() as f:
+        data = json.load(f)
     cfg = load_config_from_api(
         data["account"]["auth_token"],
         data["account"]["region"],

--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -54,7 +54,8 @@ class FileUploadInfo:
 
     @classmethod
     def from_file(cls, filename, user_name, user_id, machine_id, type=0):
-        data = open(filename, "rb").read()
+        with open(filename, "rb") as f:
+            data = f.read()
         return cls.from_data(data, filename, user_name, user_id, machine_id, type=0)
 
     @classmethod


### PR DESCRIPTION
## Summary

Three instances of `open()` without context managers, each leaking a file descriptor:

- `cli/config.py:81` — `json.load(path.open())` in config load (called on every config read)
- `cli/config.py:272` — `json.load(path.open())` in config upgrade
- `libflagship/ppppapi.py:57` — `open(filename, "rb").read()` in `FileUploadInfo.from_file()` (called on every GCode upload)

Wrapped all three in `with` statements.

## Impact

The config reader leak is the most impactful — the web server reads config repeatedly, so file descriptors accumulate over time and can eventually exhaust the process limit.

## Test plan

- [x] Syntax check passes
- [x] Web server starts and loads config correctly
- [x] GCode file upload path exercises without errors