### PR TITLE
Fix thread safety issues and tighten exception handling

### DIFF
--- a/cli/pppp.py
+++ b/cli/pppp.py
@@ -79,8 +79,8 @@ def probe_printer_ip(printer, ip_addr, timeout=2.0):
     finally:
         try:
             api.sock.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(f"PPPP socket close failed: {exc}")
 
 
 def lan_search(config, timeout=1.0, dumpfile=None):
@@ -113,8 +113,8 @@ def lan_search(config, timeout=1.0, dumpfile=None):
     finally:
         try:
             api.sock.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(f"PPPP socket close failed: {exc}")
 
     return discovered
 

--- a/tests/test_homeassistant_service.py
+++ b/tests/test_homeassistant_service.py
@@ -109,8 +109,9 @@ def test_homeassistant_on_connect_and_light_command(monkeypatch):
     app.svc = SimpleNamespace(svcs={"videoqueue": SimpleNamespace(api_light_state=lambda state: light_calls.append(state))})
 
     class FakeThread:
-        def __init__(self, target=None, daemon=None, name=None):
+        def __init__(self, target=None, args=None, daemon=None, name=None):
             self.target = target
+            self.args = args or ()
             self.daemon = daemon
             self.name = name
             self.started = False
@@ -197,3 +198,31 @@ def test_homeassistant_disconnect_and_publish_failures_are_non_fatal():
     svc._on_disconnect(None, None, 1)
 
     assert svc._connected is False
+
+
+def test_rapid_reconnect_no_thread_leak():
+    """Rapid _on_connect calls should not accumulate availability threads.
+    The generation counter ensures stale threads self-terminate."""
+    import threading
+    import time
+
+    svc = HomeAssistantService(FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer")
+    svc._enabled = True
+    svc._connected = True
+    svc._client = SimpleNamespace(
+        subscribe=lambda *a, **kw: None,
+        publish=lambda *a, **kw: None,
+    )
+    svc._publish_discovery = lambda: None
+
+    for _ in range(5):
+        svc._on_connect(svc._client, None, None, 0)
+
+    assert svc._availability_generation == 5
+    time.sleep(0.2)
+    alive = [t for t in threading.enumerate() if t.name == "ha-mqtt-avail"]
+    assert len(alive) <= 1, f"Expected <=1 availability threads, found {len(alive)}"
+
+    svc._stop_event.set()
+    if svc._availability_thread:
+        svc._availability_thread.join(timeout=2)

--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -99,6 +99,7 @@ def test_video_queue_worker_start_stop_and_handler(monkeypatch):
         _api=fake_api,
         connected=True,
         xzyh_handlers=[],
+        _handler_lock=__import__("threading").Lock(),
         api_command=lambda command, data=None: commands.append((command, data)),
     )
 
@@ -211,6 +212,7 @@ def test_pppp_service_api_command_and_connected_property():
 
 def test_pppp_service_drains_xzyh_and_tolerates_handler_errors(monkeypatch):
     svc = object.__new__(PPPPService)
+    svc._handler_lock = __import__("threading").Lock()
     captured = []
     svc.xzyh_handlers = [
         lambda item: (_ for _ in ()).throw(RuntimeError("ignore")),

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -223,3 +223,32 @@ def test_timelapse_take_snapshot_retries_and_restores_light(monkeypatch, tmp_pat
     assert light_calls == [True, False]
     assert svc._frame_count == 1
     assert os.path.exists(os.path.join(svc._current_dir, "frame_00000.jpg"))
+
+
+def test_capture_thread_crash_clears_ref(tmp_path):
+    """If _capture_loop() crashes from an uncaught exception, the
+    try/finally should clear _capture_thread so start_capture() knows
+    the thread is dead."""
+    import threading
+    from types import SimpleNamespace
+
+    class CaptureLoopCrash(BaseException):
+        """Uncatchable by except Exception — simulates a fatal crash."""
+
+    config_mgr = SimpleNamespace(config_root=str(tmp_path))
+    svc = TimelapseService(config_mgr, captures_dir=str(tmp_path))
+    svc._interval = 0.01
+
+    call_count = [0]
+
+    def crashing_snapshot():
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            raise CaptureLoopCrash("Simulated fatal crash")
+
+    svc._take_snapshot = crashing_snapshot
+    svc._capture_thread = threading.Thread(target=svc._capture_loop, daemon=True)
+    svc._capture_thread.start()
+    svc._capture_thread.join(timeout=2)
+
+    assert svc._capture_thread is None, "_capture_thread should be None after crash"

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -230,8 +230,8 @@ def _stop_switchable_services():
         vq.stop()
         try:
             vq.await_stopped()
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(f"VideoQueue stop wait failed: {exc}")
 
     pppp = app.svc.svcs.get("pppp")
     if pppp:
@@ -692,8 +692,8 @@ def _validate_ws_auth(sock):
         return True
     try:
         sock.send(json.dumps({"error": "unauthorized"}))
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug(f"WS auth rejection send failed (client may have disconnected): {exc}")
     return False
 
 
@@ -899,8 +899,8 @@ def pppp_state(sock):
         try:
             with app.pppp_probe_lock:
                 app.pppp_probe["client_count"] -= 1
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(f"PPPP state cleanup failed: {exc}")
         log.info("PPPP state websocket handler ending")
 
 
@@ -1852,8 +1852,8 @@ def _disconnect_mqtt_client(client):
         return
     try:
         mqtt_client.disconnect()
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug(f"MQTT client disconnect failed: {exc}")
 
 
 def _clean_printer_report_output(raw_output):
@@ -2593,8 +2593,8 @@ def register_services(app):
         svc.stop()
         try:
             svc.await_stopped()
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(f"Service {name} stop wait failed: {exc}")
         app.svc.unregister(name)
 
     if not supported_indexes:

--- a/web/notifications.py
+++ b/web/notifications.py
@@ -92,6 +92,7 @@ class AppriseNotifier:
         self._snapshot_timer = None
         self._snapshot_hold_until = 0.0
         self._snapshot_enabled_by_notifier = False
+        self._load_lock = threading.Lock()
 
     def _load(self):
         if self._explicit_settings:
@@ -102,31 +103,37 @@ class AppriseNotifier:
         if self._client and (now - self._last_load) < self._reload_interval:
             return
 
-        try:
-            with self._config_manager.open() as cfg:
-                if not cfg:
-                    self._client = None
-                    self._settings = None
-                    self._last_load = now
-                    return
-                notifications = merge_dict_defaults(
-                    getattr(cfg, "notifications", None),
-                    default_notifications_config(),
-                )
-                apprise_config = merge_dict_defaults(
-                    notifications.get("apprise"),
-                    default_apprise_config(),
-                )
-        except Exception as err:
-            log.warning(f"Failed to load apprise config: {err}")
-            self._client = None
-            self._settings = None
-            self._last_load = now
-            return
+        with self._load_lock:
+            # Re-check after acquiring lock (another thread may have loaded)
+            now = time.monotonic()
+            if self._client and (now - self._last_load) < self._reload_interval:
+                return
 
-        self._client = AppriseClient(apprise_config)
-        self._settings = self._client.settings
-        self._last_load = now
+            try:
+                with self._config_manager.open() as cfg:
+                    if not cfg:
+                        self._client = None
+                        self._settings = None
+                        self._last_load = now
+                        return
+                    notifications = merge_dict_defaults(
+                        getattr(cfg, "notifications", None),
+                        default_notifications_config(),
+                    )
+                    apprise_config = merge_dict_defaults(
+                        notifications.get("apprise"),
+                        default_apprise_config(),
+                    )
+            except Exception as err:
+                log.warning(f"Failed to load apprise config: {err}")
+                self._client = None
+                self._settings = None
+                self._last_load = now
+                return
+
+            self._client = AppriseClient(apprise_config)
+            self._settings = self._client.settings
+            self._last_load = now
 
     def client(self):
         self._load()

--- a/web/service/homeassistant.py
+++ b/web/service/homeassistant.py
@@ -44,6 +44,7 @@ class HomeAssistantService:
         self._lock = threading.Lock()
         self._availability_thread = None
         self._stop_event = threading.Event()
+        self._availability_generation = 0
 
         # Cached state for publishing
         self._state = {
@@ -208,13 +209,18 @@ class HomeAssistantService:
         client.subscribe(light_cmd_topic, qos=1)
         log.info(f"HA MQTT: subscribed to {light_cmd_topic}")
 
-        # Start availability heartbeat — stop any existing thread first to avoid leaks
+        # Start availability heartbeat — stop any existing thread first to avoid leaks.
+        # Bump generation so stale threads self-terminate even if they miss the
+        # stop event (prevents thread accumulation on rapid reconnects).
         if self._availability_thread and self._availability_thread.is_alive():
             self._stop_event.set()
             self._availability_thread.join(timeout=2)
+            self._availability_thread = None
+        self._availability_generation += 1
         self._stop_event.clear()
+        gen = self._availability_generation
         self._availability_thread = threading.Thread(
-            target=self._availability_loop, daemon=True, name="ha-mqtt-avail"
+            target=self._availability_loop, args=(gen,), daemon=True, name="ha-mqtt-avail"
         )
         self._availability_thread.start()
 
@@ -295,9 +301,12 @@ class HomeAssistantService:
     def _state_topic(self):
         return f"{self._topic_prefix}/{self._printer_sn}/state"
 
-    def _availability_loop(self):
+    def _availability_loop(self, my_generation):
         """Periodically publish availability to keep HA happy."""
         while not self._stop_event.is_set():
+            if self._availability_generation != my_generation:
+                log.debug("HA MQTT: stale availability thread exiting")
+                return
             self._publish(self._availability_topic(), "online", retain=True)
             self._stop_event.wait(_AVAILABILITY_TIMEOUT)
 

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -1,5 +1,6 @@
 import json
 import logging as log
+import threading
 
 from datetime import datetime, timedelta
 
@@ -37,6 +38,7 @@ class PPPPService(Service):
 
     def __init__(self):
         self.xzyh_handlers = []
+        self._handler_lock = threading.Lock()
         super().__init__()
 
     def api_command(self, commandType, **kwargs):
@@ -118,7 +120,9 @@ class PPPPService(Service):
                     return
                 xzyh.data = pkt[16:]
 
-            for handler in self.xzyh_handlers[:]:
+            with self._handler_lock:
+                handlers = self.xzyh_handlers[:]
+            for handler in handlers:
                 try:
                     handler((chan, xzyh))
                 except Exception as e:

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -397,12 +397,18 @@ class TimelapseService:
 
     def _capture_loop(self):
         """Periodically capture snapshots from the video stream."""
-        while not self._stop_event.is_set():
-            try:
-                self._take_snapshot()
-            except Exception as err:
-                log.warning(f"Timelapse: snapshot failed: {err}")
-            self._stop_event.wait(self._interval)
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    self._take_snapshot()
+                except Exception as err:
+                    log.warning(f"Timelapse: snapshot failed: {err}")
+                self._stop_event.wait(self._interval)
+        except Exception as err:
+            log.warning(f"Timelapse: capture loop crashed: {err}")
+        finally:
+            with self._lock:
+                self._capture_thread = None
 
     def _take_snapshot(self):
         """Capture a single frame using ffmpeg."""

--- a/web/service/video.py
+++ b/web/service/video.py
@@ -193,8 +193,9 @@ class VideoQueue(Service):
 
         self.api_id = id(self.pppp._api)
 
-        if self._handler not in self.pppp.xzyh_handlers:
-            self.pppp.xzyh_handlers.append(self._handler)
+        with self.pppp._handler_lock:
+            if self._handler not in self.pppp.xzyh_handlers:
+                self.pppp.xzyh_handlers.append(self._handler)
         self._start_live_if_needed(force=False)
 
         if self.saved_light_state is not None:
@@ -219,18 +220,25 @@ class VideoQueue(Service):
                 time.sleep(0.5)
                 return
 
-        if not getattr(self.pppp, "connected", False):
+        # Snapshot the PPPP reference to avoid TOCTOU races if the service
+        # restarts between checks.  All subsequent accesses use this local.
+        pppp = self.pppp
+        if pppp is None:
+            raise ServiceRestartSignal("PPPP reference lost during video session")
+
+        if not getattr(pppp, "connected", False):
             raise ServiceRestartSignal("No pppp connection")
 
         if getattr(self, "api_id", None) is None:
-            if not hasattr(self.pppp, "_api"):
+            if not hasattr(pppp, "_api"):
                 log.info("VideoQueue: PPPP connected but API not ready yet")
                 time.sleep(0.5)
                 return
 
-            self.api_id = id(self.pppp._api)
-            if self._handler not in self.pppp.xzyh_handlers:
-                self.pppp.xzyh_handlers.append(self._handler)
+            self.api_id = id(pppp._api)
+            with pppp._handler_lock:
+                if self._handler not in pppp.xzyh_handlers:
+                    pppp.xzyh_handlers.append(self._handler)
 
             started = self._start_live_if_needed(force=False)
             if not started:
@@ -251,10 +259,10 @@ class VideoQueue(Service):
             log.info("VideoQueue: Live video started after PPPP became ready")
             return
 
-        if not hasattr(self.pppp, "_api"):
+        if not hasattr(pppp, "_api"):
             raise ServiceRestartSignal("PPPP lost during video session")
 
-        if id(self.pppp._api) != self.api_id:
+        if id(pppp._api) != self.api_id:
             raise ServiceRestartSignal("New pppp connection detected, restarting video feed")
 
         if self.handlers:
@@ -269,7 +277,7 @@ class VideoQueue(Service):
                             self._live_active = False
                             self.api_stop_live()
                             time.sleep(0.5)
-                            if not self.pppp or not getattr(self.pppp, "connected", False):
+                            if not pppp or not getattr(pppp, "connected", False):
                                 log.warning("VideoQueue: PPPP unavailable during live refresh")
                                 time.sleep(0.5)
                                 return
@@ -299,7 +307,7 @@ class VideoQueue(Service):
                             self._live_active = False
                             self.api_stop_live()
                             time.sleep(0.5)
-                            if not self.pppp or not getattr(self.pppp, "connected", False):
+                            if not pppp or not getattr(pppp, "connected", False):
                                 log.warning("VideoQueue: PPPP unavailable during initial-frame refresh")
                                 time.sleep(0.5)
                                 return
@@ -323,8 +331,10 @@ class VideoQueue(Service):
         except Exception as E:
             log.warning(f"{self.name}: Failed to send stop command ({E})")
 
-        if self.pppp and self._handler in self.pppp.xzyh_handlers:
-            self.pppp.xzyh_handlers.remove(self._handler)
+        if self.pppp:
+            with self.pppp._handler_lock:
+                if self._handler in self.pppp.xzyh_handlers:
+                    self.pppp.xzyh_handlers.remove(self._handler)
 
         if self.pppp:
             app.svc.put("pppp")


### PR DESCRIPTION
## Summary

While reviewing the code around PR #36, I noticed a handful of thread safety issues in the service layer and went down a rabbit hole fixing them.

**Thread safety:**
- **HA MQTT availability thread leak:** Rapid broker reconnects can accumulate orphaned threads because `_stop_event.clear()` races with the old thread. Added a generation counter so stale threads notice they have been superseded and exit on their own.
- **Timelapse capture thread crash:** If the capture loop hits an unexpected exception, the thread dies but `_capture_thread` is never cleared -- `start_capture()` then thinks it is still running. Wrapped the loop in try/finally.
- **PPPP handler list:** `xzyh_handlers` gets appended/removed from one thread and iterated from another with no lock. Added a lock with copy-then-iterate so callbacks run outside the lock (avoids deadlock if a callback modifies the list).
- **VideoQueue PPPP reference:** `worker_run()` reads `self.pppp` multiple times per iteration. If PPPP restarts between reads, the reference goes stale. Snapshot it once at the top.
- **Notifications config reload:** `_load()` has a TOCTOU race on the reload-interval timestamp. Two threads can pass the check and both reload. Added double-checked locking.

**Exception logging:**
I also noticed the bare `except Exception: pass` we shipped in #36 and went through the rest of the codebase -- there were 6 more. Replaced them all with `log.debug()` so swallowed errors are at least visible when you need them.

## Test plan

- [x] New test: `test_rapid_reconnect_no_thread_leak` -- simulates 5 rapid HA reconnects, verifies generation counter and at most 1 thread alive
- [x] New test: `test_capture_thread_crash_clears_ref` -- crashes the capture loop, verifies thread ref is cleared
- [x] Updated test fakes to include `_handler_lock` for PPPP handler dispatch tests
- [x] Full test suite: 210 passed, no regressions (24 pre-existing werkzeug failures unrelated)
