### PR TITLE
Harden Service base class against lifecycle edge cases

### DIFF
--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -324,3 +324,10 @@ def test_filetransfer_notify_upload_swallow_and_error_paths(monkeypatch):
     assert any(item.get("status") == "error" and "broken" in item.get("error", "") for item in uploads)
     assert {"status": "stopped"} in uploads
     assert notifier_events == []
+
+
+def test_holdoff_passed_safe_when_not_reset():
+    """Holdoff.passed must not crash when deadline has never been set."""
+    from web.lib.service import Holdoff
+    h = Holdoff()
+    assert h.passed is True

--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -21,7 +21,7 @@ class Holdoff:
 
     @property
     def passed(self):
-        return datetime.now() > self.deadline
+        return self.deadline is None or datetime.now() > self.deadline
 
 
 class ServiceError(Exception):
@@ -196,7 +196,7 @@ class Service(Thread):
         pass
 
     def notify(self, data):
-        for handler in self.handlers:
+        for handler in list(self.handlers):
             handler(data)
 
     @contextlib.contextmanager


### PR DESCRIPTION
## Summary

Two defensive fixes in the Service base class (`web/lib/service.py`):

`Holdoff.passed` raises `TypeError` when `deadline` is `None`. This
happens when a service restarts after `worker_init()` fails before
`reset()` sets a deadline. The fix returns `True` when `deadline` is
`None`, treating an unset holdoff as expired so the service can
proceed with its restart attempt.

`Service.notify()` iterates `self.handlers` directly while Flask
request threads can add or remove handlers via `tap()`. Under
concurrent access, this can skip a handler or raise during iteration.
The fix iterates a `list()` snapshot, matching the copy-then-iterate
pattern already used in `PPPPService._drain_xzyh`.

## Test plan

New test added:
- [x] `test_holdoff_passed_safe_when_not_reset`: Holdoff().passed
  returns True without prior reset()

Existing tests:
- [x] All 9 service recovery tests pass
- [x] Full suite: 233 passed, no regressions
