### PR TITLE
Guard PPPPService.worker_stop against missing _api

### DIFF
--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -324,3 +324,12 @@ def test_filetransfer_notify_upload_swallow_and_error_paths(monkeypatch):
     assert any(item.get("status") == "error" and "broken" in item.get("error", "") for item in uploads)
     assert {"status": "stopped"} in uploads
     assert notifier_events == []
+
+
+def test_pppp_worker_stop_safe_without_api():
+    """worker_stop must not crash when worker_start failed before assigning _api."""
+    from web.service.pppp import PPPPService
+    svc = PPPPService.__new__(PPPPService)
+    # Simulate state after a failed worker_start (no _api attribute)
+    assert not hasattr(svc, "_api")
+    svc.worker_stop()  # should not raise

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -178,8 +178,9 @@ class PPPPService(Service):
             self._drain_xzyh(chan=msg.chan)
 
     def worker_stop(self):
-        self._api.send(PktClose())
-        del self._api
+        if hasattr(self, "_api"):
+            self._api.send(PktClose())
+            del self._api
 
     @property
     def connected(self):


### PR DESCRIPTION
## Summary

If `worker_start` fails before assigning `self._api` (e.g. printer
unreachable on the network, DNS resolution timeout, or LAN search
returning no results), the service framework calls `worker_stop()`
as part of its retry cycle. `worker_stop()` unconditionally accesses
`self._api.send(PktClose())`, which raises `AttributeError`. The
exception is caught by the service framework retry handler, which
sets a 1-second holdoff and tries again, creating an infinite loop
that logs an error every second.

The fix guards both `send()` and `del` with `hasattr(self, "_api")`
so `worker_stop()` is a no-op when `_api` was never assigned.

## Test plan

New test added:
- [x] `test_pppp_worker_stop_safe_without_api`: calls worker_stop()
  on a PPPPService instance that never had worker_start() called,
  verifies no exception

Existing tests:
- [x] All 9 service recovery tests pass
- [x] Full suite: no regressions
