### PR TITLE
Add timeout to Anker cloud HTTP API calls

### DIFF
--- a/libflagship/httpapi.py
+++ b/libflagship/httpapi.py
@@ -86,7 +86,7 @@ class AnkerHTTPApi:
             full_headers["Gtoken"] = hashlib.md5(self._user_id.encode("utf-8")).hexdigest()
         if headers:
             full_headers.update(headers)
-        return requests.get(f"{self._base}{self.scope}{url}", headers=full_headers, verify=self._verify)
+        return requests.get(f"{self._base}{self.scope}{url}", headers=full_headers, verify=self._verify, timeout=(10, 30))
 
     @unwrap_api
     def _post(self, url, headers=None, data=None):
@@ -95,7 +95,7 @@ class AnkerHTTPApi:
             full_headers["Gtoken"] = hashlib.md5(self._user_id.encode("utf-8")).hexdigest()
         if headers:
             full_headers.update(headers)
-        return requests.post(f"{self._base}{self.scope}{url}", headers=full_headers, verify=self._verify, json=data)
+        return requests.post(f"{self._base}{self.scope}{url}", headers=full_headers, verify=self._verify, json=data, timeout=(10, 30))
 
 
 class AnkerHTTPAppApiV1(AnkerHTTPApi):


### PR DESCRIPTION
## Summary

`AnkerHTTPApi._get()` and `._post()` call `requests.get()` and
`requests.post()` without a `timeout` parameter. The `requests`
library defaults to no timeout, meaning a DNS hang, TCP half-open
connection, or unresponsive server blocks the calling thread
indefinitely.

These methods are called during login and config-import flows from
both CLI threads and Flask request threads. A stalled cloud API
call on a Flask thread holds the request open until the client
gives up, and on the MQTT worker thread it blocks all printer
communication.

Adds `timeout=(10, 30)` to both calls: 10-second connect timeout,
30-second read timeout.

## Test plan

- [x] No unit test needed (timeout is a `requests` library feature,
  not application logic)
- [x] Full suite: no regressions
