### PR TITLE
Raise ValueError on invalid printer index instead of falling through

### DIFF
--- a/cli/mqtt.py
+++ b/cli/mqtt.py
@@ -19,7 +19,7 @@ def mqtt_open(config, printer_index, insecure):
 
     with config.open() as cfg:
         if printer_index >= len(cfg.printers):
-            log.critical(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1} ")
+            raise ValueError(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1}")
         printer = cfg.printers[printer_index]
         acct = cfg.account
         server = servertable[acct.region]

--- a/cli/pppp.py
+++ b/cli/pppp.py
@@ -27,7 +27,7 @@ def pppp_open(config, printer_index, timeout=None, dumpfile=None):
 
     with config.open() as cfg:
         if printer_index >= len(cfg.printers):
-            log.critical(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1} ")
+            raise ValueError(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1}")
         printer = cfg.printers[printer_index]
         ip_addr = pppp_resolve_printer_ip(config, printer, printer_index, dumpfile=dumpfile)
         if not ip_addr:

--- a/tests/test_ankerctl_cli.py
+++ b/tests/test_ankerctl_cli.py
@@ -108,3 +108,37 @@ def test_config_password_commands_validate_generate_and_remove(monkeypatch):
     assert removed.exit_code == 0
     assert fake_config.api_keys == ["RANDOMKEY1234567890"]
     assert fake_config.removed == 1
+
+
+class FakeConfigContext:
+    """Minimal config manager for testing mqtt_open/pppp_open bounds checks."""
+    def __init__(self, printers):
+        self._printers = printers
+
+    def open(self):
+        return self
+
+    def __enter__(self):
+        return SimpleNamespace(
+            printers=self._printers,
+            account=SimpleNamespace(region="eu", auth_token="fake", user_id="fake"),
+        )
+
+    def __exit__(self, *args):
+        pass
+
+
+def test_mqtt_open_raises_on_invalid_printer_index():
+    import cli.mqtt
+    config = FakeConfigContext(printers=[])
+    import pytest
+    with pytest.raises(ValueError, match="out of range"):
+        cli.mqtt.mqtt_open(config, printer_index=0, insecure=False)
+
+
+def test_pppp_open_raises_on_invalid_printer_index():
+    import cli.pppp
+    config = FakeConfigContext(printers=[])
+    import pytest
+    with pytest.raises(ValueError, match="out of range"):
+        cli.pppp.pppp_open(config, printer_index=0)


### PR DESCRIPTION
## Summary

`mqtt_open()` and `pppp_open()` check whether the printer index is
within range and log a critical message if not, but then fall through
to the next line which indexes into the printers list anyway. The
result is an unhelpful `IndexError` traceback instead of a clear
error message.

Both functions are called from the web service layer (`filetransfer.py`,
`mqtt.py` worker, Flask routes in `web/__init__.py`), so `sys.exit()`
would kill the entire server. `ValueError` with a descriptive message
is the correct choice: CLI callers see a clean error, and web callers
can catch and handle it.

## Test plan

New tests added:
- [x] `test_mqtt_open_raises_on_invalid_printer_index`: empty printer
  list with index 0 raises ValueError
- [x] `test_pppp_open_raises_on_invalid_printer_index`: same

Existing tests:
- [x] All 6 CLI tests pass
- [x] Full suite: no regressions
