### PR TITLE
Stabilize printer controls, homing, video, timelapse, and service reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,7 +437,7 @@ Manages the LAN (PPPP) connection. Registered as `"pppp"`. Reference-counted: st
 H.264 video from printer camera over PPPP channel 1. Registered as `"videoqueue"`.
 Key methods: `api_light_state(bool)`, `api_video_profile(id)`, `set_video_enabled(bool)`.
 Video profiles: `"sd"` (848×480), `"hd"` (1280×720, default), `"fhd"` (1920×1080, snapshot-only).
-Stall detection: no frames for 60 seconds → soft restart; after 3 consecutive failures → `ServiceRestartSignal`.
+Stall detection: no frames for 5 seconds → soft restart; after 3 consecutive failures → `ServiceRestartSignal`.
 
 ### FileTransferService (`web/service/filetransfer.py`)
 

--- a/ankerctl.py
+++ b/ankerctl.py
@@ -36,6 +36,14 @@ from libflagship.pppp import PktLanSearch, PktPunchPkt, P2PCmdType, P2PSubCmdTyp
 from libflagship.ppppapi import FileUploadInfo, PPPPError
 
 
+def mqtt_topic_direction(topic):
+    if "/device/maker/" in topic:
+        return "app->printer"
+    if "/phone/maker/" in topic:
+        return "printer->app"
+    return "unknown"
+
+
 class Environment:
     def __init__(self):
         pass
@@ -114,29 +122,47 @@ def mqtt(env):
 
 
 @mqtt.command("monitor")
+@click.option(
+    "--command-topics",
+    is_flag=True,
+    help="Also subscribe to app-to-printer command/query topics when broker ACLs permit it.",
+)
+@click.option(
+    "--sniff-topics",
+    is_flag=True,
+    help="Also subscribe to broad app-to-printer topic wildcards when broker ACLs permit it.",
+)
 @pass_env
-def mqtt_monitor(env):
+def mqtt_monitor(env, command_topics, sniff_topics):
     """
     Connect to mqtt broker, and show low-level events in realtime.
     """
 
     client = cli.mqtt.mqtt_open(env.config, env.printer_index, env.insecure)
+    if command_topics or sniff_topics:
+        extra_topics = client.subscribe_device_topics(wildcard=sniff_topics)
+        for topic in extra_topics:
+            log.info(f"Extra MQTT subscription requested: {topic}")
 
     for msg, body in client.fetchloop():
-        log.info(f"TOPIC [{msg.topic}]")
+        direction = mqtt_topic_direction(msg.topic)
+        log.info(f"TOPIC [{msg.topic}] ({direction})")
         log.debug(enhex(msg.payload[:]))
 
         for obj in body:
+            if not isinstance(obj, dict) or "commandType" not in obj:
+                print(f"  {obj}")
+                continue
+
+            payload = dict(obj)
+            cmdtype = payload.pop("commandType")
             try:
-                cmdtype = obj["commandType"]
                 name = MqttMsgType(cmdtype).name
                 if name.startswith("ZZ_MQTT_CMD_"):
                     name = name[len("ZZ_MQTT_CMD_"):].lower()
-
-                del obj["commandType"]
-                print(f"  [{cmdtype:4}] {name:20} {obj}")
             except Exception:
-                print(f"  {obj}")
+                name = "unknown"
+            print(f"  [{cmdtype:4}] {name:20} {payload}")
 
 
 @mqtt.command("send")

--- a/libflagship/__init__.py
+++ b/libflagship/__init__.py
@@ -19,7 +19,7 @@ def resolve_root_dir(*, frozen=None, meipass=None, executable=None, file_path=No
         return Path(meipass).resolve()
     if frozen and executable:
         return Path(executable).resolve().parent
-    return Path(file_path).resolve().parent.parent
+    return Path(file_path).parent.parent
 
 
 ROOT_DIR = resolve_root_dir()

--- a/libflagship/mqttapi.py
+++ b/libflagship/mqttapi.py
@@ -130,6 +130,19 @@ class AnkerMQTTBaseClient:
     def command(self, msg):
         return self.send(f"/device/maker/{self.sn}/command", msg)
 
+    def subscribe_device_topics(self, wildcard=False):
+        """Also listen to app-to-printer topics when broker ACLs permit it."""
+        topics = [
+            f"/device/maker/{self.sn}/command",
+            f"/device/maker/{self.sn}/query",
+        ]
+        if wildcard:
+            topics.append(f"/device/maker/{self.sn}/#")
+
+        for topic in topics:
+            self._mqtt.subscribe(topic)
+        return topics
+
     def loop(self):
         self._mqtt.loop_forever()
 

--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -183,7 +183,7 @@ class Channel:
         self._rx_gap_report_packets += gap
         now = time.monotonic()
         if now - self._rx_gap_report_at >= 10.0:
-            log.info(
+            log.debug(
                 f"Channel {self.index}: realtime receive-gap recovery "
                 f"({self._rx_gap_report_packets} packet(s) skipped across "
                 f"{self._rx_gap_report_skips} gap(s))"

--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -3,6 +3,7 @@ import socket
 import string
 import hashlib
 import logging as log
+import time
 
 from enum import Enum
 from multiprocessing import Pipe
@@ -127,6 +128,9 @@ class Channel:
         self.max_in_flight = max_in_flight
         self.max_age_warn = max_age_warn
         self.lock = Lock()
+        self._rx_gap_report_at = 0.0
+        self._rx_gap_report_skips = 0
+        self._rx_gap_report_packets = 0
 
     def rx_ack(self, acks):
         # remove all ACKed packets from transmission queue
@@ -158,6 +162,49 @@ class Channel:
             del self.rxqueue[self.rx_ctr]
             self.rx_ctr += 1
             self.rx.write(data)
+
+    def skip_rx_gap(self, max_queued=16):
+        """Drop a stale receive gap and resume at the oldest queued packet.
+
+        Video is a realtime stream carried over UDP. If one DRW packet never
+        arrives, waiting forever for perfect ordering freezes every later frame.
+        This intentionally sacrifices the damaged bytes so higher layers can
+        resync at the next XZYH frame boundary.
+        """
+        if self.rx_ctr in self.rxqueue or len(self.rxqueue) < max_queued:
+            return False
+
+        next_index = min(
+            self.rxqueue,
+            key=lambda idx: int(CyclicU16(idx) - self.rx_ctr),
+        )
+        gap = int(CyclicU16(next_index) - self.rx_ctr)
+        self._rx_gap_report_skips += 1
+        self._rx_gap_report_packets += gap
+        now = time.monotonic()
+        if now - self._rx_gap_report_at >= 10.0:
+            log.info(
+                f"Channel {self.index}: realtime receive-gap recovery "
+                f"({self._rx_gap_report_packets} packet(s) skipped across "
+                f"{self._rx_gap_report_skips} gap(s))"
+            )
+            self._rx_gap_report_at = now
+            self._rx_gap_report_skips = 0
+            self._rx_gap_report_packets = 0
+        else:
+            log.debug(
+                f"Channel {self.index}: skipping stale receive gap of {gap} packet(s) "
+                f"after {len(self.rxqueue)} queued packet(s)"
+            )
+        self.rx_ctr = CyclicU16(next_index)
+        self.rx.buf.clear()
+
+        while self.rx_ctr in self.rxqueue:
+            data = self.rxqueue[self.rx_ctr]
+            del self.rxqueue[self.rx_ctr]
+            self.rx_ctr += 1
+            self.rx.write(data)
+        return True
 
     def poll(self):
         # signal event to make blocking reads check status again

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1357,7 +1357,6 @@ $(function () {
      */
     function sendPrinterGCode(gcode) {
         if (!gcode) return;
-        console.log("Sending GCode:", gcode);
         fetch("/api/printer/gcode", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -1367,7 +1366,6 @@ $(function () {
 
     function sendPrinterHome(axis) {
         const targetAxis = axis || "all";
-        console.log("Sending Home:", targetAxis);
         fetch("/api/printer/home", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -1376,7 +1374,6 @@ $(function () {
     }
 
     function sendPrintControl(value) {
-        console.log("Sending Print Control:", value);
         fetch("/api/printer/control", {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1391,6 +1391,7 @@ $(function () {
     const PRINT_STATE = { IDLE: 0, PRINTING: 1, PAUSED: 2, CALIBRATING: 8, STOPPING: 9, PENDING_START: 10 };
 
     let _currentPrintState = PRINT_STATE.IDLE;
+    let _lastStopCommandAt = 0;
 
     function _normalizePrintStateValue(value) {
         // Some firmware reports resume as ct=1000 value=3, while others report printing (1).
@@ -2237,7 +2238,8 @@ $(function () {
         return false;
     });
     $("#print-stop").on("click", function () {
-        if (_currentPrintState === PRINT_STATE.STOPPING) {
+        const now = Date.now();
+        if (now - _lastStopCommandAt < 1000) {
             return false;
         }
         const preparing = _currentPrintState === PRINT_STATE.CALIBRATING;
@@ -2246,13 +2248,10 @@ $(function () {
             ? "Cancel the printer prepare phase before the print starts?"
             : pendingStart
                 ? "Cancel the pending print before it starts?"
-                : "Are you sure you want to stop the print? This will also turn off heaters.";
+                : "Are you sure you want to stop the print?";
         if (confirm(confirmText)) {
+            _lastStopCommandAt = now;
             sendPrintControl(PRINT_CONTROL.STOP);
-            if (!preparing && !pendingStart) {
-                sendPrinterGCode("M104 S0\nM140 S0\nM106 S0");
-            }
-            _updatePrintControlButtons(PRINT_STATE.STOPPING);
         }
         return false;
     });

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -555,32 +555,93 @@ $(function () {
         reconnect: 2000,
 
         open: function () {
+            this.videoQueue = [];
+            this.videoBufferMinPackets = 4;
+            this.videoBufferDelayMs = 300;
+            this.videoBufferMaxPackets = 300;
+            this.videoPumpMaxPacketsPerTick = 12;
+            this.videoBuffering = true;
             this.jmuxer = new JMuxer({
                 node: "player",
                 mode: "video",
                 flushingTime: 0,
                 fps: 15,
                 // debug: true,
-                onReady: function (data) {
-                    console.log(data);
-                },
                 onError: function (data) {
-                    console.log(data);
+                    console.warn("JMuxer video error", data);
                 },
             });
+            this.videoPump = window.setInterval(() => {
+                if (!this.jmuxer)
+                    return;
+
+                const now = (window.performance && window.performance.now) ? window.performance.now() : Date.now();
+                if (this.videoBuffering) {
+                    const firstPacket = this.videoQueue[0];
+                    const firstPacketAge = firstPacket ? now - firstPacket.receivedAt : 0;
+                    if (this.videoQueue.length < this.videoBufferMinPackets && firstPacketAge < this.videoBufferDelayMs) {
+                        return;
+                    }
+                    this.videoBuffering = false;
+                }
+
+                let fedPackets = 0;
+                while (this.videoQueue.length && fedPackets < this.videoPumpMaxPacketsPerTick) {
+                    const packet = this.videoQueue[0];
+                    const packetAge = now - packet.receivedAt;
+                    if (packetAge < this.videoBufferDelayMs && this.videoQueue.length <= this.videoBufferMinPackets) {
+                        break;
+                    }
+                    this.videoQueue.shift();
+                    try {
+                        this.jmuxer.feed({
+                            video: new Uint8Array(packet.data),
+                        });
+                    } catch (err) {
+                        console.log({ type: "video", name: err?.name || "feed", error: err?.message || String(err) });
+                        this.videoBuffering = true;
+                        return;
+                    }
+                    fedPackets++;
+                }
+
+                if (!fedPackets && !this.videoQueue.length) {
+                    this.videoBuffering = true;
+                }
+            }, 16);
         },
 
         message: function (event) {
-            this.jmuxer.feed({
-                video: new Uint8Array(event.data),
+            if (!(event.data instanceof ArrayBuffer) || event.data.byteLength === 0) {
+                return;
+            }
+            if (!this.videoQueue) {
+                this.videoQueue = [];
+            }
+            const now = (window.performance && window.performance.now) ? window.performance.now() : Date.now();
+            this.videoQueue.push({
+                data: event.data.slice(0),
+                receivedAt: now,
             });
+            if (this.videoQueue.length > this.videoBufferMaxPackets) {
+                this.videoQueue.splice(0, this.videoQueue.length - this.videoBufferMaxPackets);
+                this.videoBuffering = true;
+            }
         },
 
         close: function () {
+            if (this.videoPump) {
+                window.clearInterval(this.videoPump);
+                this.videoPump = null;
+            }
+            this.videoQueue = [];
+            this.videoBuffering = true;
+
             if (!this.jmuxer)
                 return;
 
             this.jmuxer.destroy();
+            this.jmuxer = null;
 
             /* Clear video source (to show loading animation) */
             $("#player").attr("src", "");
@@ -607,10 +668,42 @@ $(function () {
         videoPlayer.addEventListener("resize", updateVideoResolution);
     }
 
+    const ctrlPendingMessages = [];
+    function sendCtrlMessage(payload) {
+        const message = JSON.stringify(payload);
+        if (sockets.ctrl.ws && sockets.ctrl.ws.readyState === WebSocket.OPEN) {
+            try {
+                sockets.ctrl.ws.send(message);
+                return true;
+            } catch (err) {
+                console.warn("ctrl socket: send failed, queueing message", err);
+            }
+        }
+        ctrlPendingMessages.push(message);
+        return false;
+    }
+
+    function flushCtrlMessages() {
+        if (!sockets.ctrl.ws || sockets.ctrl.ws.readyState !== WebSocket.OPEN) {
+            return;
+        }
+        while (ctrlPendingMessages.length) {
+            const message = ctrlPendingMessages.shift();
+            try {
+                sockets.ctrl.ws.send(message);
+            } catch (err) {
+                ctrlPendingMessages.unshift(message);
+                console.warn("ctrl socket: failed to flush queued message", err);
+                return;
+            }
+        }
+    }
+
     sockets.ctrl = new AutoWebSocket({
         name: "Control socket",
         url: `${location.protocol.replace("http", "ws")}//${location.host}/ws/ctrl`,
         badge: "#badge-ctrl",
+        opened: flushCtrlMessages,
         message: function (event) {
             let data = null;
             try {
@@ -618,6 +711,7 @@ $(function () {
             } catch (err) {
                 return;
             }
+            flushCtrlMessages();
             if (data.video_profile) {
                 setVideoProfileActive(data.video_profile);
             }
@@ -731,9 +825,7 @@ $(function () {
         if (videoEnabled) {
             $("#vplayer").show();
             $(this).html('<i class="bi bi-camera-video-off"></i> Disable Video');
-            if (sockets.ctrl.ws) {
-                sockets.ctrl.ws.send(JSON.stringify({ video_enabled: true }));
-            }
+            sendCtrlMessage({ video_enabled: true });
             sockets.video.autoReconnect = true;
             if (!sockets.video.ws) {
                 sockets.video.connect();
@@ -741,9 +833,7 @@ $(function () {
         } else {
             $("#vplayer").hide();
             $(this).html('<i class="bi bi-camera-video"></i> Enable Video');
-            if (sockets.ctrl.ws) {
-                sockets.ctrl.ws.send(JSON.stringify({ video_enabled: false }));
-            }
+            sendCtrlMessage({ video_enabled: false });
             sockets.video.autoReconnect = false;
             if (sockets.video.ws) {
                 try {
@@ -768,7 +858,7 @@ $(function () {
      * On click of element with id "light-on", sends JSON data to wsctrl to turn light on
      */
     $("#light-on").on("click", function () {
-        sockets.ctrl.ws.send(JSON.stringify({ light: true }));
+        sendCtrlMessage({ light: true });
         setLightActive(true);
         return false;
     });
@@ -777,7 +867,7 @@ $(function () {
      * On click of element with id "light-off", sends JSON data to wsctrl to turn light off
      */
     $("#light-off").on("click", function () {
-        sockets.ctrl.ws.send(JSON.stringify({ light: false }));
+        sendCtrlMessage({ light: false });
         setLightActive(false);
         return false;
     });
@@ -788,9 +878,7 @@ $(function () {
     $(".video-profile-btn").on("click", function () {
         const profile = $(this).data("video-profile");
         setVideoProfileActive(profile);
-        if (sockets.ctrl.ws) {
-            sockets.ctrl.ws.send(JSON.stringify({ video_profile: profile }));
-        }
+        sendCtrlMessage({ video_profile: profile });
         return false;
     });
 

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -445,8 +445,8 @@ $(function () {
                 return;
             }
             if (data.commandType == 1000) {
-                // Printer state machine: value=0 idle, value=1 printing, value=2 paused
-                _updatePrintControlButtons(data.value);
+                // Printer state machine: normalize firmware resume acknowledgements for UI controls.
+                _updatePrintControlButtons(_normalizePrintStateValue(data.value));
                 if (typeof _onMqttStateChange === "function") {
                     _onMqttStateChange(data.value);
                 }
@@ -1365,6 +1365,16 @@ $(function () {
         }).catch(err => console.error("Failed to send GCode:", err));
     }
 
+    function sendPrinterHome(axis) {
+        const targetAxis = axis || "all";
+        console.log("Sending Home:", targetAxis);
+        fetch("/api/printer/home", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ axis: targetAxis })
+        }).catch(err => console.error("Failed to send home command:", err));
+    }
+
     function sendPrintControl(value) {
         console.log("Sending Print Control:", value);
         fetch("/api/printer/control", {
@@ -1375,7 +1385,6 @@ $(function () {
     }
 
     const PRINT_CONTROL = {
-        PREPARE_CANCEL: 0,
         PAUSE: 2,
         RESUME: 3,
         STOP: 4,
@@ -1386,13 +1395,22 @@ $(function () {
 
     let _currentPrintState = PRINT_STATE.IDLE;
 
+    function _normalizePrintStateValue(value) {
+        // Some firmware reports resume as ct=1000 value=3, while others report printing (1).
+        if (value === 3) {
+            return PRINT_STATE.PRINTING;
+        }
+        return value;
+    }
+
     function _updatePrintControlButtons(state) {
-        _currentPrintState = state;
-        const printing = state === PRINT_STATE.PRINTING;
-        const paused = state === PRINT_STATE.PAUSED;
-        const stopping = state === PRINT_STATE.STOPPING;
-        const preparing = state === PRINT_STATE.CALIBRATING;
-        const pendingStart = state === PRINT_STATE.PENDING_START;
+        const normalizedState = _normalizePrintStateValue(state);
+        _currentPrintState = normalizedState;
+        const printing = normalizedState === PRINT_STATE.PRINTING;
+        const paused = normalizedState === PRINT_STATE.PAUSED;
+        const stopping = normalizedState === PRINT_STATE.STOPPING;
+        const preparing = normalizedState === PRINT_STATE.CALIBRATING;
+        const pendingStart = normalizedState === PRINT_STATE.PENDING_START;
         const active = printing || paused || preparing || stopping || pendingStart;
         $("#print-pause").toggleClass("d-none", !printing || stopping);
         $("#print-resume").toggleClass("d-none", !paused || stopping);
@@ -1403,6 +1421,18 @@ $(function () {
     }
 
     const getStepDist = () => $('input[name="step-dist"]:checked').val() || "1";
+    let _lastHomeCommandAt = 0;
+    let _lastHomeCommand = null;
+
+    function sendHomeCommand(axis) {
+        const now = Date.now();
+        if (_lastHomeCommand === axis && now - _lastHomeCommandAt < 1000) {
+            return;
+        }
+        _lastHomeCommandAt = now;
+        _lastHomeCommand = axis;
+        sendPrinterHome(axis);
+    }
 
     $("#move-x-plus").on("click", function () { sendPrinterGCode(`G91\nG0 X${getStepDist()} F3000\nG90`); return false; });
     $("#move-x-minus").on("click", function () { sendPrinterGCode(`G91\nG0 X-${getStepDist()} F3000\nG90`); return false; });
@@ -1411,9 +1441,9 @@ $(function () {
     $("#move-z-plus").on("click", function () { sendPrinterGCode(`G91\nG0 Z${getStepDist()} F600\nG90`); return false; });
     $("#move-z-minus").on("click", function () { sendPrinterGCode(`G91\nG0 Z-${getStepDist()} F600\nG90`); return false; });
 
-    $("#control-home-xy").on("click", function () { sendPrinterGCode("G28 X Y"); return false; });
-    $("#control-home-z").on("click", function () { sendPrinterGCode("G28 Z"); return false; });
-    $("#control-home-all").on("click", function () { sendPrinterGCode("G28"); return false; });
+    $("#control-home-xy").on("click", function () { sendHomeCommand("xy"); return false; });
+    $("#control-home-z").on("click", function () { sendHomeCommand("z"); return false; });
+    $("#control-home-all").on("click", function () { sendHomeCommand("all"); return false; });
 
     // ------------------------------------------------------------------
     // Bed Level Map — shared rendering utilities
@@ -2212,7 +2242,7 @@ $(function () {
                 ? "Cancel the pending print before it starts?"
                 : "Are you sure you want to stop the print? This will also turn off heaters.";
         if (confirm(confirmText)) {
-            sendPrintControl((preparing || pendingStart) ? PRINT_CONTROL.PREPARE_CANCEL : PRINT_CONTROL.STOP);
+            sendPrintControl(PRINT_CONTROL.STOP);
             if (!preparing && !pendingStart) {
                 sendPrinterGCode("M104 S0\nM140 S0\nM106 S0");
             }

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -2038,24 +2038,30 @@ $(function () {
     /**
      * Snapshot Button
      */
-    $("#snapshot-btn").on("click", function () {
+    $("#snapshot-btn").on("click", async function () {
         const btn = $(this);
         btn.prop("disabled", true);
-        fetch("/api/snapshot")
-            .then(resp => {
-                if (!resp.ok) throw new Error("Snapshot failed");
-                return resp.blob();
-            })
-            .then(blob => {
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement("a");
-                a.href = url;
-                a.download = `ankerctl_snapshot_${Date.now()}.jpg`;
-                a.click();
-                URL.revokeObjectURL(url);
-            })
-            .catch(err => alert("Snapshot failed: " + err.message))
-            .finally(() => btn.prop("disabled", false));
+        try {
+            const resp = await fetch("/api/snapshot");
+            if (!resp.ok) {
+                const data = await resp.json().catch(() => ({}));
+                const msg = data.error || `HTTP ${resp.status}`;
+                flash_message(`Snapshot failed: ${msg}`, "warning");
+                return;
+            }
+
+            const blob = await resp.blob();
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `ankerctl_snapshot_${Date.now()}.jpg`;
+            a.click();
+            URL.revokeObjectURL(url);
+        } catch (err) {
+            flash_message(`Snapshot failed: ${err.message || err}`, "warning");
+        } finally {
+            btn.prop("disabled", false);
+        }
     });
 
     /**

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -2046,7 +2046,8 @@ $(function () {
             if (!resp.ok) {
                 const data = await resp.json().catch(() => ({}));
                 const msg = data.error || `HTTP ${resp.status}`;
-                flash_message(`Snapshot failed: ${msg}`, "warning");
+                const banner = /^snapshot\b/i.test(msg) ? msg : `Snapshot failed: ${msg}`;
+                flash_message(banner, "warning");
                 return;
             }
 
@@ -2058,7 +2059,9 @@ $(function () {
             a.click();
             URL.revokeObjectURL(url);
         } catch (err) {
-            flash_message(`Snapshot failed: ${err.message || err}`, "warning");
+            const msg = err.message || String(err);
+            const banner = /^snapshot\b/i.test(msg) ? msg : `Snapshot failed: ${msg}`;
+            flash_message(banner, "warning");
         } finally {
             btn.prop("disabled", false);
         }

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -33,7 +33,7 @@
                     <div class="card-header d-flex align-items-center justify-content-between">
                         <span class="fs-6">Printer Control</span>
                         <div>
-                            <button class="btn btn-sm btn-outline-danger" id="control-home-all" title="Home All">
+                            <button type="button" class="btn btn-sm btn-outline-danger" id="control-home-all" title="Home All">
                                 {{ macro.bi_icon("house-fill") }} Home All
                             </button>
                         </div>
@@ -45,30 +45,30 @@
                                 <div class="fw-bold mb-3 small text-muted">XY Axis (Bed / Extruder)</div>
                                 <div class="d-inline-block position-relative" style="width: 160px; height: 160px;">
                                     <!-- Y+ (Bed Back) -->
-                                    <button
+                                    <button type="button"
                                         class="btn btn-secondary position-absolute top-0 start-50 translate-middle-x"
                                         id="move-y-plus" style="width: 50px; height: 45px;" title="Bed Back">
                                         {{ macro.bi_icon("chevron-up") }}
                                     </button>
                                     <!-- Y- (Bed Front) -->
-                                    <button
+                                    <button type="button"
                                         class="btn btn-secondary position-absolute bottom-0 start-50 translate-middle-x"
                                         id="move-y-minus" style="width: 50px; height: 45px;" title="Bed Front">
                                         {{ macro.bi_icon("chevron-down") }}
                                     </button>
                                     <!-- X- (Extruder Left) -->
-                                    <button
+                                    <button type="button"
                                         class="btn btn-secondary position-absolute top-50 start-0 translate-middle-y"
                                         id="move-x-minus" style="width: 50px; height: 45px;" title="Extruder Left">
                                         {{ macro.bi_icon("chevron-left") }}
                                     </button>
                                     <!-- X+ (Extruder Right) -->
-                                    <button class="btn btn-secondary position-absolute top-50 end-0 translate-middle-y"
+                                    <button type="button" class="btn btn-secondary position-absolute top-50 end-0 translate-middle-y"
                                         id="move-x-plus" style="width: 50px; height: 45px;" title="Extruder Right">
                                         {{ macro.bi_icon("chevron-right") }}
                                     </button>
                                     <!-- Home XY -->
-                                    <button class="btn btn-primary position-absolute top-50 start-50 translate-middle"
+                                    <button type="button" class="btn btn-primary position-absolute top-50 start-50 translate-middle"
                                         id="control-home-xy" style="width: 50px; height: 45px;" title="Home XY">
                                         {{ macro.bi_icon("house") }}
                                     </button>
@@ -80,17 +80,17 @@
                                 <div class="d-inline-flex flex-column gap-2 align-items-center justify-content-center"
                                     style="height: 160px;">
                                     <!-- Z+ (Extruder Up) -->
-                                    <button class="btn btn-secondary" id="move-z-plus"
+                                    <button type="button" class="btn btn-secondary" id="move-z-plus"
                                         style="width: 60px; height: 50px;" title="Extruder Up">
                                         {{ macro.bi_icon("chevron-double-up") }}
                                     </button>
                                     <!-- Home Z -->
-                                    <button class="btn btn-primary" id="control-home-z"
+                                    <button type="button" class="btn btn-primary" id="control-home-z"
                                         style="width: 60px; height: 45px;" title="Home Z">
                                         {{ macro.bi_icon("house") }}
                                     </button>
                                     <!-- Z- (Extruder Down) -->
-                                    <button class="btn btn-secondary" id="move-z-minus"
+                                    <button type="button" class="btn btn-secondary" id="move-z-minus"
                                         style="width: 60px; height: 50px;" title="Extruder Down">
                                         {{ macro.bi_icon("chevron-double-down") }}
                                     </button>

--- a/tests/test_ankerctl_cli.py
+++ b/tests/test_ankerctl_cli.py
@@ -59,6 +59,74 @@ def test_mqtt_send_blocks_dangerous_commands_without_force(monkeypatch):
     assert opened == []
 
 
+def test_mqtt_monitor_can_subscribe_to_command_topics(monkeypatch):
+    runner = CliRunner()
+    fake_config = FakeConfigManager()
+    fake_client = SimpleNamespace(subscribed=False, wildcard=None)
+
+    def subscribe_device_topics(wildcard=False):
+        fake_client.subscribed = True
+        fake_client.wildcard = wildcard
+        return ["/device/maker/SN123/command", "/device/maker/SN123/query"]
+
+    def fetchloop():
+        yield (
+            SimpleNamespace(topic="/device/maker/SN123/command", payload=b"payload"),
+            [{"commandType": 1026, "axis": "xy"}],
+        )
+
+    fake_client.subscribe_device_topics = subscribe_device_topics
+    fake_client.fetchloop = fetchloop
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr("ankerctl.Environment.upgrade_config_if_needed", lambda self: None)
+    monkeypatch.setattr("ankerctl.Environment.load_config", lambda self, required=True: None)
+    monkeypatch.setattr("ankerctl.cli.mqtt.mqtt_open", lambda *args, **kwargs: fake_client)
+
+    result = runner.invoke(ankerctl.main, ["mqtt", "monitor", "--command-topics"])
+
+    assert result.exit_code == 0
+    assert fake_client.subscribed is True
+    assert fake_client.wildcard is False
+    assert "[1026] move_zero" in result.output
+    assert "{'axis': 'xy'}" in result.output
+
+
+def test_mqtt_monitor_can_sniff_wildcard_command_topics(monkeypatch):
+    runner = CliRunner()
+    fake_config = FakeConfigManager()
+    fake_client = SimpleNamespace(subscribed=False, wildcard=None)
+
+    def subscribe_device_topics(wildcard=False):
+        fake_client.subscribed = True
+        fake_client.wildcard = wildcard
+        return ["/device/maker/SN123/command", "/device/maker/SN123/query", "/device/maker/SN123/#"]
+
+    def fetchloop():
+        yield (
+            SimpleNamespace(topic="/device/maker/SN123/command", payload=b"payload"),
+            [{"commandType": 1025, "value": 3}],
+        )
+
+    fake_client.subscribe_device_topics = subscribe_device_topics
+    fake_client.fetchloop = fetchloop
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr("ankerctl.Environment.upgrade_config_if_needed", lambda self: None)
+    monkeypatch.setattr("ankerctl.Environment.load_config", lambda self, required=True: None)
+    monkeypatch.setattr("ankerctl.cli.mqtt.mqtt_open", lambda *args, **kwargs: fake_client)
+
+    result = runner.invoke(ankerctl.main, ["mqtt", "monitor", "--sniff-topics"])
+
+    assert result.exit_code == 0
+    assert fake_client.subscribed is True
+    assert fake_client.wildcard is True
+    assert ankerctl.mqtt_topic_direction("/device/maker/SN123/command") == "app->printer"
+    assert "[1025] move_direction" in result.output
+
+
 def test_http_calc_sec_code_and_webserver_run_dispatch(monkeypatch):
     runner = CliRunner()
     fake_config = FakeConfigManager()

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -136,6 +136,26 @@ def test_handle_notification_start_finish_and_failure_paths(monkeypatch):
     ]
 
 
+def test_deferred_filename_starts_timelapse_after_print_state(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    monkeypatch.setattr("web.service.mqtt.time.monotonic", lambda: 100.0)
+
+    queue._handle_notification({"commandType": 1000, "value": 1})
+
+    assert queue._state == PrintState.PRINTING
+    assert queue._pending_history_start is True
+    assert history_calls == []
+    assert timelapse_calls == []
+
+    queue._handle_notification({"commandType": 1044, "filePath": "/tmp/deferred.gcode"})
+
+    assert queue._pending_history_start is False
+    assert history_calls == [("start", ("deferred.gcode",), {"task_id": None})]
+    assert timelapse_calls == [("start", "deferred.gcode")]
+
+
 def test_handle_notification_aborts_active_print_on_value_8(monkeypatch):
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -179,6 +179,64 @@ def test_send_print_control_shotgun_during_prepare_state():
     assert queue._stop_requested is True
 
 
+def test_send_pause_resume_print_control_uses_nested_and_flat_payloads():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    sent = []
+    queue.client = SimpleNamespace(command=lambda payload: sent.append(payload))
+    queue._state = PrintState.PRINTING
+
+    queue.send_print_control(2)
+    queue._state = PrintState.PAUSED
+    queue.send_print_control(3)
+
+    assert sent == [
+        {"commandType": 1008, "data": {"value": 2, "userName": "tester@example.com"}},
+        {"commandType": 1008, "value": 2},
+        {"commandType": 1008, "data": {"value": 3, "userName": "tester@example.com"}},
+        {"commandType": 1008, "value": 3},
+    ]
+    assert queue._stop_requested is False
+
+
+def test_send_gcode_dedupes_identical_g28_commands(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    sent = []
+    queue.client = SimpleNamespace(command=lambda payload: sent.append(payload))
+    now = [100.0]
+    monkeypatch.setattr("web.service.mqtt.time.monotonic", lambda: now[0])
+    monkeypatch.setattr("web.service.mqtt.time.sleep", lambda seconds: None)
+
+    queue.send_gcode("G28")
+    queue.send_gcode("G28")
+    queue.send_gcode("G28 Z")
+    now[0] += 10.1
+    queue.send_gcode("G28")
+
+    assert [cmd["cmdData"] for cmd in sent] == ["G28", "G28 Z", "G28"]
+
+
+def test_send_home_uses_axis_specific_gcode_command():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    sent = []
+    queue.client = SimpleNamespace(command=lambda payload: sent.append(payload))
+
+    queue.send_home("xy")
+    queue.send_home("z")
+    queue.send_home("all")
+
+    assert sent == [
+        {"commandType": 1043, "cmdData": "G28 X0 Y0", "cmdLen": 9},
+        {"commandType": 1043, "cmdData": "G28 Z0", "cmdLen": 6},
+        {"commandType": 1043, "cmdData": "G28", "cmdLen": 3},
+    ]
+
+
 def test_1044_captures_filename_without_marking_prepare_state():
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []
@@ -568,6 +626,30 @@ def test_pause_and_resume():
     assert any(u.get("print_status") == "printing" for u in ha_updates), "HA should report printing after resume"
 
 
+def test_pause_and_resume_when_resume_ack_is_printing_value():
+    """Some firmware confirms resume with ct=1000 value=1 instead of value=3."""
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue._handle_notification({"commandType": 1044, "filePath": "/tmp/cube.gcode"})
+    queue._handle_notification({"commandType": 1000, "value": 1})
+    queue._handle_notification({"commandType": 1000, "value": 2})
+    assert queue._state == PrintState.PAUSED
+
+    history_calls.clear()
+    timelapse_calls.clear()
+    events.clear()
+    ha_updates.clear()
+    queue._handle_notification({"commandType": 1000, "value": 1})
+
+    assert queue._state == PrintState.PRINTING
+    assert any(u.get("print_status") == "printing" for u in ha_updates), "HA should report printing after resume"
+    assert history_calls == []
+    assert timelapse_calls == []
+    assert events == []
+
+
 def test_pause_only_from_printing():
     """value=2 is ignored if not currently PRINTING."""
     global ha_updates, history_calls, timelapse_calls, events
@@ -780,3 +862,4 @@ def test_get_state_during_pause():
     assert state["active"] is True
     assert state["in_pre_print_window"] is False
     assert state["preparing"] is False, "is_preparing_print should be False during PAUSED"
+    assert state["state_label"] == "preparing_or_aborted"

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -239,21 +239,23 @@ def test_send_gcode_dedupes_identical_g28_commands(monkeypatch):
     assert [cmd["cmdData"] for cmd in sent] == ["G28", "G28 Z", "G28"]
 
 
-def test_send_home_uses_axis_specific_gcode_command():
+def test_send_home_uses_native_move_zero_payloads(monkeypatch):
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []
     queue = _queue()
     sent = []
     queue.client = SimpleNamespace(command=lambda payload: sent.append(payload))
+    monkeypatch.setattr("web.service.mqtt.time.sleep", lambda seconds: None)
 
     queue.send_home("xy")
     queue.send_home("z")
     queue.send_home("all")
 
     assert sent == [
-        {"commandType": 1043, "cmdData": "G28 X0 Y0", "cmdLen": 9},
-        {"commandType": 1043, "cmdData": "G28 Z0", "cmdLen": 6},
-        {"commandType": 1043, "cmdData": "G28", "cmdLen": 3},
+        {"commandType": 1026, "value": 0},
+        {"commandType": 1026, "value": 2},
+        {"commandType": 1026, "value": 0},
+        {"commandType": 1026, "value": 2},
     ]
 
 

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -220,6 +220,23 @@ def test_send_pause_resume_print_control_uses_nested_and_flat_payloads():
     assert queue._stop_requested is False
 
 
+def test_send_stop_print_control_uses_nested_and_flat_payloads_for_active_print():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    sent = []
+    queue.client = SimpleNamespace(command=lambda payload: sent.append(payload))
+    queue._state = PrintState.PRINTING
+
+    queue.send_print_control(4)
+
+    assert sent == [
+        {"commandType": 1008, "data": {"value": 4, "userName": "tester@example.com"}},
+        {"commandType": 1008, "value": 4},
+    ]
+    assert queue._stop_requested is True
+
+
 def test_send_gcode_dedupes_identical_g28_commands(monkeypatch):
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -239,13 +239,12 @@ def test_send_gcode_dedupes_identical_g28_commands(monkeypatch):
     assert [cmd["cmdData"] for cmd in sent] == ["G28", "G28 Z", "G28"]
 
 
-def test_send_home_uses_native_move_zero_payloads(monkeypatch):
+def test_send_home_uses_native_move_zero_payloads():
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []
     queue = _queue()
     sent = []
     queue.client = SimpleNamespace(command=lambda payload: sent.append(payload))
-    monkeypatch.setattr("web.service.mqtt.time.sleep", lambda seconds: None)
 
     queue.send_home("xy")
     queue.send_home("z")
@@ -254,7 +253,6 @@ def test_send_home_uses_native_move_zero_payloads(monkeypatch):
     assert sent == [
         {"commandType": 1026, "value": 0},
         {"commandType": 1026, "value": 2},
-        {"commandType": 1026, "value": 0},
         {"commandType": 1026, "value": 2},
     ]
 

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -128,10 +128,12 @@ def test_printer_gcode_route_normalizes_safe_commands_and_blocks_motion_while_pr
 def test_printer_control_and_autolevel_routes_validate_and_dispatch():
     control_calls = []
     autolevel_calls = []
+    home_calls = []
     mqtt = SimpleNamespace(
         is_printing=False,
         send_print_control=lambda value: control_calls.append(value),
         send_auto_leveling=lambda: autolevel_calls.append(True),
+        send_home=lambda axis: home_calls.append(axis),
     )
     client = app.test_client()
     old_values, old_svc = _install_app_state(mqtt=mqtt)
@@ -151,9 +153,24 @@ def test_printer_control_and_autolevel_routes_validate_and_dispatch():
             "/api/printer/autolevel",
             headers={"X-Api-Key": API_KEY},
         )
+        home = client.post(
+            "/api/printer/home",
+            json={"axis": "xy"},
+            headers={"X-Api-Key": API_KEY},
+        )
+        bad_home = client.post(
+            "/api/printer/home",
+            json={"axis": "bad"},
+            headers={"X-Api-Key": API_KEY},
+        )
         mqtt.is_printing = True
         blocked = client.post(
             "/api/printer/autolevel",
+            headers={"X-Api-Key": API_KEY},
+        )
+        blocked_home = client.post(
+            "/api/printer/home",
+            json={"axis": "z"},
             headers={"X-Api-Key": API_KEY},
         )
     finally:
@@ -162,9 +179,13 @@ def test_printer_control_and_autolevel_routes_validate_and_dispatch():
     assert invalid.status_code == 400
     assert control.status_code == 200
     assert allowed.status_code == 200
+    assert home.status_code == 200
+    assert bad_home.status_code == 400
     assert blocked.status_code == 409
+    assert blocked_home.status_code == 409
     assert control_calls == [2]
     assert autolevel_calls == [True]
+    assert home_calls == ["xy"]
 
 
 def test_printer_z_offset_routes_refresh_set_and_nudge():

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime
+import subprocess
 from types import SimpleNamespace
 
 from cli.model import Account, Config, Printer
@@ -330,11 +331,42 @@ def test_snapshot_route_reports_expected_error_paths(monkeypatch):
     finally:
         _restore_app_state(old_values, old_svc)
 
+    monkeypatch.setattr("web._video_has_recent_frame", lambda vq: False)
+    old_values, old_svc = _install_app_state(
+        video_supported=True,
+        videoqueue=SimpleNamespace(video_enabled=True, last_frame_at=None),
+    )
+    try:
+        no_frames = client.get("/api/snapshot", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    monkeypatch.setattr("web._video_has_recent_frame", lambda vq: True)
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+        ),
+    )
+    old_values, old_svc = _install_app_state(
+        video_supported=True,
+        videoqueue=SimpleNamespace(video_enabled=True, last_frame_at=123.0),
+    )
+    try:
+        timeout = client.get("/api/snapshot", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
     assert not_supported.status_code == 400
     assert no_ffmpeg.status_code == 500
     assert no_service.status_code == 503
     assert video_disabled.status_code == 409
     assert "Enable video" in video_disabled.get_json()["error"]
+    assert no_frames.status_code == 409
+    assert "no live camera frames" in no_frames.get_json()["error"]
+    assert timeout.status_code == 504
+    assert "timed out" in timeout.get_json()["error"]
+    assert "Command" not in timeout.get_json()["error"]
 
 
 def test_unsupported_device_guard_blocks_printer_control_routes():

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -307,23 +307,34 @@ def test_snapshot_route_reports_expected_error_paths(monkeypatch):
     finally:
         _restore_app_state(old_values, old_svc)
 
-    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr("web._ffmpeg_path", lambda: None)
     old_values, old_svc = _install_app_state(video_supported=True, videoqueue=object())
     try:
         no_ffmpeg = client.get("/api/snapshot", headers={"X-Api-Key": API_KEY})
     finally:
         _restore_app_state(old_values, old_svc)
 
-    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr("web._ffmpeg_path", lambda: "/usr/bin/ffmpeg")
     old_values, old_svc = _install_app_state(video_supported=True, videoqueue=None)
     try:
         no_service = client.get("/api/snapshot", headers={"X-Api-Key": API_KEY})
     finally:
         _restore_app_state(old_values, old_svc)
 
+    old_values, old_svc = _install_app_state(
+        video_supported=True,
+        videoqueue=SimpleNamespace(video_enabled=False),
+    )
+    try:
+        video_disabled = client.get("/api/snapshot", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
     assert not_supported.status_code == 400
     assert no_ffmpeg.status_code == 500
     assert no_service.status_code == 503
+    assert video_disabled.status_code == 409
+    assert "Enable video" in video_disabled.get_json()["error"]
 
 
 def test_unsupported_device_guard_blocks_printer_control_routes():

--- a/tests/test_protocol_pppp.py
+++ b/tests/test_protocol_pppp.py
@@ -162,3 +162,15 @@ def test_channel_write_poll_and_acknowledge():
 
     assert chan.tx_ack == CyclicU16(2)
     assert chan.txqueue == []
+
+
+def test_channel_can_skip_stale_receive_gap_for_realtime_streams():
+    chan = Channel(index=1)
+
+    chan.rx_drw(CyclicU16(1), b"middle")
+    chan.rx_drw(CyclicU16(2), b"end")
+
+    assert chan.peek(1, timeout=0.0) is None
+    assert chan.skip_rx_gap(max_queued=2) is True
+    assert chan.read(9, timeout=0.0) == b"middleend"
+    assert chan.rx_ctr == CyclicU16(3)

--- a/tests/test_reports_video_and_webserver.py
+++ b/tests/test_reports_video_and_webserver.py
@@ -66,7 +66,7 @@ class FakeVideoServices:
         self.refs = {"videoqueue": 0}
         self._payloads = payloads
 
-    def stream(self, name):
+    def stream(self, name, **kwargs):
         assert name == "videoqueue"
         for payload in self._payloads:
             yield SimpleNamespace(data=payload)

--- a/tests/test_service_crash_recovery.py
+++ b/tests/test_service_crash_recovery.py
@@ -213,7 +213,7 @@ class TestVideoServiceStallRecovery:
 
     @patch('web.service.video.VideoQueue')
     def test_video_stall_detection_triggers_soft_restart(self, mock_vq):
-        """No frames for 60s triggers soft restart"""
+        """No frames past the configured timeout triggers soft restart"""
         from web.service.video import VideoQueue, _STALL_TIMEOUT
 
         vq = VideoQueue()

--- a/tests/test_service_framework.py
+++ b/tests/test_service_framework.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from queue import Queue
 from threading import Timer
 from types import SimpleNamespace
 
@@ -115,3 +116,14 @@ def test_service_manager_restart_all_stream_and_atexit():
     assert wanted.shutdown_calls == 1
     assert wanted_stops.shutdown_calls == 1
     assert idle.shutdown_calls == 1
+
+
+def test_service_stream_bounded_queue_drops_oldest_items():
+    q = Queue(maxsize=2)
+
+    ServiceManager._enqueue_stream_item(q, "one")
+    ServiceManager._enqueue_stream_item(q, "two")
+    ServiceManager._enqueue_stream_item(q, "three")
+
+    assert q.get_nowait() == "two"
+    assert q.get_nowait() == "three"

--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -77,6 +77,7 @@ class FakeFD:
 def test_video_queue_worker_start_stop_and_handler(monkeypatch):
     queue = object.__new__(VideoQueue)
     queue.video_enabled = True
+    queue.wanted = True
     queue.handlers = []
     queue.state = RunState.Stopped
     queue.saved_light_state = True
@@ -90,6 +91,13 @@ def test_video_queue_worker_start_stop_and_handler(monkeypatch):
     queue._live_active = False
     queue.api_id = None
     queue._enable_generation = 0
+    queue._pppp_ref_held = False
+    queue._recycle_pppp_on_restart = False
+    queue._awaiting_pppp_recycle = False
+    queue._pending_disable = False
+    queue._in_place_recovery = False
+    queue._pppp_recycle_requested_at = None
+    queue._live_auth_data = lambda: {"encryptkey": "secret", "accountId": "user-123456"}
     notifications = []
     queue.notify = lambda msg: notifications.append(msg)
 
@@ -106,7 +114,7 @@ def test_video_queue_worker_start_stop_and_handler(monkeypatch):
     puts = []
     old_svc = app.svc
     app.svc = SimpleNamespace(
-        get=lambda name: fake_pppp,
+        get=lambda name, ready=True: fake_pppp,
         put=lambda name: puts.append(name),
     )
 
@@ -121,6 +129,7 @@ def test_video_queue_worker_start_stop_and_handler(monkeypatch):
         queue.worker_start()
         queue._handler((1, FakeXzyh(1)))
         queue._handler((1, FakeXzyh(P2PCmdType.APP_CMD_VIDEO_FRAME)))
+        queue.wanted = False
         queue.worker_stop()
     finally:
         app.svc = old_svc
@@ -130,25 +139,29 @@ def test_video_queue_worker_start_stop_and_handler(monkeypatch):
     assert puts == ["pppp"]
     assert len(commands) == 4
     assert queue.last_frame_at == 123.0
-    assert len(notifications) == 2
+    assert len(notifications) == 1
+    assert notifications[0].cmd == P2PCmdType.APP_CMD_VIDEO_FRAME
 
 
 def test_video_queue_worker_run_detects_disconnect_api_swap_and_stall(monkeypatch):
     queue = object.__new__(VideoQueue)
     queue.video_enabled = True
+    queue.wanted = True
     queue.handlers = [lambda _: None]
     queue.idle = lambda timeout=None: None
+    queue._in_place_recovery = False
     queue._live_started_at = 100.0
     queue.last_frame_at = None
     queue._last_live_refresh_at = 0.0
     queue._last_no_frame_log_at = 0.0
     queue._last_start_live_at = 0.0
     queue._live_active = False
+    queue._stall_retry_count = 0
     queue.api_id = 1
     queue.pppp = SimpleNamespace(connected=False, _api=object())
 
-    with pytest.raises(ServiceRestartSignal, match="No pppp connection"):
-        queue.worker_run(timeout=0.1)
+    monkeypatch.setattr("web.service.video.time.sleep", lambda seconds: None)
+    queue.worker_run(timeout=0.1)
 
     queue.pppp = SimpleNamespace(connected=True, _api=object())
     with pytest.raises(ServiceRestartSignal, match="New pppp connection"):
@@ -159,13 +172,59 @@ def test_video_queue_worker_run_detects_disconnect_api_swap_and_stall(monkeypatc
     queue.api_id = id(api)
     commands = []
     queue.pppp.api_command = lambda command, data=None: commands.append((command, data))
+    queue._live_auth_data = lambda: {"encryptkey": "secret", "accountId": "user-123456"}
     times = iter([100.0 + _STALL_TIMEOUT + 1, 100.0 + _STALL_TIMEOUT + 1, 100.0 + _STALL_TIMEOUT + 1])
     monkeypatch.setattr("web.service.video.time.monotonic", lambda: next(times))
-    monkeypatch.setattr("web.service.video.time.sleep", lambda seconds: None)
     queue.worker_run(timeout=0.1)
 
     assert commands[0][0] == P2PSubCmdType.CLOSE_LIVE
     assert commands[1][0] == P2PSubCmdType.START_LIVE
+
+
+def test_video_queue_disable_cancels_recovery_with_connected_viewer():
+    queue = object.__new__(VideoQueue)
+    queue.video_enabled = True
+    queue.wanted = True
+    queue.persistent = True
+    queue.state = RunState.Running
+    queue._viewer_count = 1
+    queue._pending_disable = False
+    queue._live_active = True
+    queue._live_started_at = 100.0
+    queue.last_frame_at = 100.0
+    queue._last_start_live_at = 100.0
+    queue._last_no_frame_log_at = 100.0
+    queue._last_live_refresh_at = 100.0
+    queue._stall_retry_count = 2
+    queue._awaiting_pppp_recycle = True
+    queue._pppp_recycle_requested_at = 100.0
+    stop_calls = []
+
+    def stop():
+        stop_calls.append(True)
+        queue.wanted = False
+
+    queue.stop = stop
+
+    assert queue.set_video_enabled(False) is True
+
+    assert stop_calls == [True]
+    assert queue.video_enabled is False
+    assert queue.wanted is False
+    assert queue._pending_disable is False
+    assert queue._awaiting_pppp_recycle is False
+    assert queue._pppp_recycle_requested_at is None
+    assert queue._stall_retry_count == 0
+
+    queue.video_enabled = True
+    queue.wanted = True
+    queue.state = RunState.Stopping
+    stop_calls.clear()
+
+    assert queue.set_video_enabled(False) is True
+
+    assert stop_calls == []
+    assert queue.wanted is False
 
 
 def test_video_queue_api_profile_and_mode_validation():
@@ -272,6 +331,17 @@ def test_pppp_service_worker_run_handles_reset_aabb_and_xzyh(monkeypatch):
     svc.worker_run(timeout=0.1)
 
     assert drained == [1, 0]
+
+    channel = FakeFD(
+        peeks=[b"abcd" + b"\x00" * 12, b"abcd"],
+        reads=[],
+    )
+    svc._drain_xzyh = PPPPService._drain_xzyh.__get__(svc, PPPPService)
+    svc._api = SimpleNamespace(
+        poll=lambda timeout=0: SimpleNamespace(type=208, chan=1),
+        chans=[FakeFD(peeks=[], reads=[]), channel],
+    )
+    svc.worker_run(timeout=0.1)
 
 
 def test_filetransfer_notify_upload_swallow_and_error_paths(monkeypatch):

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -4,7 +4,7 @@ import time
 from contextlib import contextmanager
 from types import SimpleNamespace
 
-from web.service.timelapse import TimelapseService, _IN_PROGRESS_SUBDIR
+from web.service.timelapse import TimelapseService, _IN_PROGRESS_SUBDIR, _resolve_ffmpeg_path
 
 
 class FakeConfigManager:
@@ -62,6 +62,15 @@ def test_timelapse_prunes_old_videos(tmp_path):
 
     remaining = sorted(p.name for p in tmp_path.glob("*.mp4"))
     assert remaining == ["mid.mp4", "new.mp4"]
+
+
+def test_timelapse_resolves_ffmpeg_through_web_fallback(monkeypatch):
+    import web
+
+    monkeypatch.setattr("web.service.timelapse.shutil.which", lambda name: None)
+    monkeypatch.setattr(web, "_ffmpeg_path", lambda: r"C:\ffmpeg\ffmpeg.exe")
+
+    assert _resolve_ffmpeg_path() == r"C:\ffmpeg\ffmpeg.exe"
 
 
 def test_timelapse_scan_recovers_or_resumes_in_progress(monkeypatch, tmp_path):
@@ -166,7 +175,7 @@ def test_timelapse_start_capture_resumes_pending_session(monkeypatch, tmp_path):
         def start(self):
             calls.append("thread-start")
 
-    monkeypatch.setattr("web.service.timelapse.shutil.which", lambda name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr("web.service.timelapse._resolve_ffmpeg_path", lambda: "/usr/bin/ffmpeg")
     monkeypatch.setattr(TimelapseService, "_stop_capture_thread", lambda self: calls.append("stop-thread"))
     monkeypatch.setattr(TimelapseService, "_cancel_finalize_timer", lambda self: calls.append("cancel-finalize"))
     monkeypatch.setattr(TimelapseService, "_cancel_pending_resume", lambda self: calls.append("cancel-pending"))
@@ -210,6 +219,7 @@ def test_timelapse_take_snapshot_retries_and_restores_light(monkeypatch, tmp_pat
         return SimpleNamespace(returncode=1)
 
     try:
+        monkeypatch.setattr("web.service.timelapse._resolve_ffmpeg_path", lambda: "resolved-ffmpeg")
         monkeypatch.setattr(TimelapseService, "_await_video_frame", lambda self: True)
         monkeypatch.setattr("web.service.timelapse.subprocess.run", fake_run)
         monkeypatch.setattr("web.service.timelapse.time.sleep", lambda seconds: None)
@@ -219,10 +229,36 @@ def test_timelapse_take_snapshot_retries_and_restores_light(monkeypatch, tmp_pat
         __import__("web").app.config["api_key"] = old_api_key
 
     assert len(runs) == 2
+    assert runs[0][0] == "resolved-ffmpeg"
+    assert runs[1][0] == "resolved-ffmpeg"
     assert any("apikey=secret-key" in part for part in runs[0] if isinstance(part, str))
     assert light_calls == [True, False]
     assert svc._frame_count == 1
     assert os.path.exists(os.path.join(svc._current_dir, "frame_00000.jpg"))
+
+
+def test_timelapse_assemble_uses_resolved_ffmpeg(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    (frames_dir / "frame_00000.jpg").write_bytes(b"jpg")
+    (frames_dir / "frame_00001.jpg").write_bytes(b"jpg")
+    runs = []
+
+    def fake_run(cmd, stdout=None, stderr=None, timeout=None):
+        runs.append(cmd)
+        with open(cmd[-1], "wb") as fh:
+            fh.write(b"mp4")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr("web.service.timelapse._resolve_ffmpeg_path", lambda: "resolved-ffmpeg")
+    monkeypatch.setattr("web.service.timelapse.subprocess.run", fake_run)
+
+    svc._assemble_video_from(str(frames_dir), "cube.gcode", 2)
+
+    assert runs[0][0] == "resolved-ffmpeg"
+    assert list(tmp_path.glob("*.mp4"))
 
 
 def test_capture_thread_crash_clears_ref(tmp_path):

--- a/tests/test_websockets_and_debug.py
+++ b/tests/test_websockets_and_debug.py
@@ -155,12 +155,15 @@ def test_mqtt_and_upload_websockets_forward_stream_messages():
 
 def test_video_websocket_toggles_streaming_and_ctrl_dispatches_commands():
     set_enabled = []
+    viewer_events = []
     light_calls = []
     profile_calls = []
     quality_calls = []
     videoqueue = SimpleNamespace(
         saved_video_profile_id="balanced",
         set_video_enabled=lambda enabled: set_enabled.append(enabled),
+        viewer_connected=lambda: viewer_events.append("connect"),
+        viewer_disconnected=lambda: viewer_events.append("disconnect"),
         api_light_state=lambda enabled: light_calls.append(enabled),
         api_video_profile=lambda profile: profile_calls.append(profile),
         api_video_mode=lambda quality: quality_calls.append(quality),
@@ -189,7 +192,8 @@ def test_video_websocket_toggles_streaming_and_ctrl_dispatches_commands():
         _restore_app_state(web_module, old_values, old_svc)
 
     assert video_sock.sent == [b"frame-1", b"frame-2"]
-    assert set_enabled == [True, False, False]
+    assert viewer_events == ["connect", "disconnect"]
+    assert set_enabled == [False]
     assert json.loads(ctrl_sock.sent[0]) == {"ankerctl": 1}
     assert json.loads(ctrl_sock.sent[1]) == {"video_profile": "balanced"}
     assert light_calls == [True]

--- a/tests/test_websockets_and_debug.py
+++ b/tests/test_websockets_and_debug.py
@@ -72,7 +72,7 @@ class FakeServices:
         self.svcs = svcs or {}
         self.refs = refs or {}
 
-    def stream(self, name):
+    def stream(self, name, **kwargs):
         yield from self._streams.get(name, [])
 
     @contextmanager

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -40,6 +40,18 @@ from contextlib import contextmanager
 log = logging.getLogger("web")
 
 
+class _StaticAssetAccessLogFilter(logging.Filter):
+    def filter(self, record):
+        message = record.getMessage()
+        return '"GET /static/' not in message and '"GET /favicon.ico' not in message
+
+
+def _configure_access_log_noise():
+    werkzeug_log = logging.getLogger("werkzeug")
+    if not any(isinstance(f, _StaticAssetAccessLogFilter) for f in werkzeug_log.filters):
+        werkzeug_log.addFilter(_StaticAssetAccessLogFilter())
+
+
 from secrets import token_urlsafe as token
 from flask import Flask, flash, request, render_template, Response, session, url_for, jsonify
 from flask_sock import Sock
@@ -716,9 +728,17 @@ def mqtt(sock):
     if not _validate_ws_auth(sock):
         return
 
-    for data in stream_mqtt():
-        log.debug(f"MQTT message: {data}")
-        sock.send(json.dumps(data))
+    try:
+        for data in stream_mqtt():
+            log.debug(f"MQTT message: {data}")
+            sock.send(json.dumps(data))
+    except ConnectionClosed:
+        log.debug("/ws/mqtt closed by client")
+    except OSError as exc:
+        log.debug(f"/ws/mqtt closed during send: {exc}")
+    except Exception as exc:
+        log.warning(f"/ws/mqtt error: {exc}")
+        log.info("Stack trace:", exc_info=True)
 
 
 @sock.route("/ws/video")
@@ -739,15 +759,30 @@ def video(sock):
     if not vq:
         return
 
-    vq.set_video_enabled(True)
+    vq.viewer_connected()
     try:
         for msg in app.svc.stream("videoqueue"):
-            sock.send(msg.data)
+            payload = getattr(msg, "data", None)
+            if not payload:
+                continue
+            sock.send(payload)
+    except ConnectionClosed:
+        log.debug("/ws/video closed by client")
+    except OSError as exc:
+        log.debug(f"/ws/video closed during send: {exc}")
+    except Exception as exc:
+        log.warning(f"/ws/video error: {exc}")
+        log.info("Stack trace:", exc_info=True)
     finally:
-        # Only disable video if no other clients are consuming the stream.
-        # refs > 0 means other /ws/video handlers are still inside stream() → borrow().
-        if app.svc.refs.get("videoqueue", 0) == 0:
-            vq.set_video_enabled(False)
+        # /ws/video is only a consumer of the shared video service.
+        # The explicit owner of video enable/disable is /ws/ctrl via
+        # {"video_enabled": true/false}.  Do not tear the service down here,
+        # because transient websocket disconnects or reconnects would otherwise
+        # stop live video for the whole app.
+        try:
+            vq.viewer_disconnected()
+        except Exception as exc:
+            log.debug(f"/ws/video cleanup failed: {exc}")
 
 
 def _maybe_start_pppp_probe(reason="scheduled"):
@@ -900,7 +935,7 @@ def pppp_state(sock):
 
             time.sleep(1.0)
     except ConnectionClosed:
-        log.info("WebSocket connection closed by client")
+        log.debug("WebSocket connection closed by client")
     except Exception as e:
         log.warning(f"Error in PPPP state websocket handler: {e}")
         log.info("Stack trace:", exc_info=True)
@@ -910,7 +945,7 @@ def pppp_state(sock):
                 app.pppp_probe["client_count"] -= 1
         except Exception as exc:
             log.debug(f"PPPP state cleanup failed: {exc}")
-        log.info("PPPP state websocket handler ending")
+        log.debug("PPPP state websocket handler ending")
 
 
 @sock.route("/ws/upload")
@@ -923,8 +958,16 @@ def upload(sock):
     if not _validate_ws_auth(sock):
         return
 
-    for data in app.svc.stream("filetransfer"):
-        sock.send(json.dumps(data))
+    try:
+        for data in app.svc.stream("filetransfer"):
+            sock.send(json.dumps(data))
+    except ConnectionClosed:
+        log.debug("/ws/upload closed by client")
+    except OSError as exc:
+        log.debug(f"/ws/upload closed during send: {exc}")
+    except Exception as exc:
+        log.warning(f"/ws/upload error: {exc}")
+        log.info("Stack trace:", exc_info=True)
 
 
 @sock.route("/ws/ctrl")
@@ -2708,6 +2751,7 @@ def webserver(config, printer_index, host, port, insecure=False, **kwargs):
     def inject_debug():
         return {"debug_mode": os.getenv("ANKERCTL_DEV_MODE", "false").lower() == "true"}
 
+    _configure_access_log_noise()
     app.run(host=host, port=port)
 
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -145,6 +145,25 @@ def _ffmpeg_available():
     return _ffmpeg_path() is not None
 
 
+SNAPSHOT_FRAME_WAIT_SEC = 3.0
+SNAPSHOT_FRAME_MAX_AGE_SEC = 2.0
+SNAPSHOT_FFMPEG_TIMEOUT_SEC = 30
+
+
+def _video_has_recent_frame(vq, wait_sec=SNAPSHOT_FRAME_WAIT_SEC, max_age_sec=SNAPSHOT_FRAME_MAX_AGE_SEC):
+    if not hasattr(vq, "last_frame_at"):
+        return True
+
+    deadline = time.monotonic() + wait_sec
+    while True:
+        last_frame_at = getattr(vq, "last_frame_at", None)
+        if last_frame_at is not None and time.monotonic() - last_frame_at <= max_age_sec:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.1)
+
+
 def _configure_request_limits(flask_app, env=None):
     # Keep large GCode uploads configurable, but bound multipart metadata more
     # tightly. These form limits apply to multipart parsing, not the file size.
@@ -2186,6 +2205,8 @@ def app_api_snapshot():
         return {"error": "Video service not available"}, 503
     if not getattr(vq, "video_enabled", False):
         return {"error": "Enable video before taking a snapshot"}, 409
+    if not _video_has_recent_frame(vq):
+        return {"error": "Video is enabled, but no live camera frames are available yet. Wait for live video to appear and try again."}, 409
 
     host = os.getenv("FLASK_HOST") or "127.0.0.1"
     if host in {"0.0.0.0", "::"}:
@@ -2207,16 +2228,19 @@ def app_api_snapshot():
         result = subprocess.run(
             [ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
              "-f", "h264", "-i", url, "-frames:v", "1", temp_path],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=SNAPSHOT_FFMPEG_TIMEOUT_SEC,
         )
         if result.returncode != 0:
             # Retry without -f h264
             result = subprocess.run(
                 [ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
                  "-i", url, "-frames:v", "1", temp_path],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=SNAPSHOT_FFMPEG_TIMEOUT_SEC,
             )
         if result.returncode != 0 or not os.path.exists(temp_path) or os.path.getsize(temp_path) == 0:
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            if stderr:
+                log.warning("Snapshot ffmpeg failed: %s", stderr)
             try:
                 os.remove(temp_path)
             except OSError:
@@ -2238,12 +2262,18 @@ def app_api_snapshot():
         return send_file(temp_path, mimetype="image/jpeg",
                          as_attachment=True,
                          download_name=f"ankerctl_snapshot_{timestamp}.jpg")
-    except (subprocess.TimeoutExpired, OSError) as err:
+    except subprocess.TimeoutExpired:
         try:
             os.remove(temp_path)
         except OSError:
             pass
-        return {"error": f"Snapshot failed: {err}"}, 500
+        return {"error": "Snapshot timed out waiting for a camera frame. Wait for live video to update and try again."}, 504
+    except OSError as err:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+        return {"error": f"Snapshot could not run ffmpeg: {err}"}, 500
 
 @app.get("/api/history")
 def app_api_history():

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -148,6 +148,7 @@ def _ffmpeg_available():
 SNAPSHOT_FRAME_WAIT_SEC = 3.0
 SNAPSHOT_FRAME_MAX_AGE_SEC = 2.0
 SNAPSHOT_FFMPEG_TIMEOUT_SEC = 30
+VIDEO_STREAM_QUEUE_MAX = 30
 
 
 def _video_has_recent_frame(vq, wait_sec=SNAPSHOT_FRAME_WAIT_SEC, max_age_sec=SNAPSHOT_FRAME_MAX_AGE_SEC):
@@ -802,7 +803,7 @@ def video(sock):
 
     vq.viewer_connected()
     try:
-        for msg in app.svc.stream("videoqueue"):
+        for msg in app.svc.stream("videoqueue", maxsize=VIDEO_STREAM_QUEUE_MAX):
             payload = getattr(msg, "data", None)
             if not payload:
                 continue
@@ -1107,7 +1108,7 @@ def video_download():
                     vq.await_ready()
                 except ServiceStoppedError:
                     return
-        for msg in app.svc.stream("videoqueue"):
+        for msg in app.svc.stream("videoqueue", maxsize=VIDEO_STREAM_QUEUE_MAX):
             yield msg.data
 
     return Response(generate(), mimetype="video/mp4")

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -119,8 +119,30 @@ def _env_int(name, default, min_value=1, env=None):
     return value
 
 
+def _ffmpeg_path():
+    found = shutil.which("ffmpeg")
+    if found:
+        return found
+
+    cached = getattr(_ffmpeg_path, "_cached", None)
+    if cached and os.path.isfile(cached):
+        return cached
+
+    local_app_data = os.getenv("LOCALAPPDATA")
+    if local_app_data:
+        packages_dir = os.path.join(local_app_data, "Microsoft", "WinGet", "Packages")
+        if os.path.isdir(packages_dir):
+            for root, _, files in os.walk(packages_dir):
+                if "ffmpeg.exe" in files:
+                    candidate = os.path.join(root, "ffmpeg.exe")
+                    _ffmpeg_path._cached = candidate
+                    return candidate
+
+    return None
+
+
 def _ffmpeg_available():
-    return shutil.which("ffmpeg") is not None
+    return _ffmpeg_path() is not None
 
 
 def _configure_request_limits(flask_app, env=None):
@@ -2149,19 +2171,21 @@ def app_api_printer_bed_leveling_last():
 @app.get("/api/snapshot")
 def app_api_snapshot():
     """Capture a JPEG snapshot from the camera and return it as a file download."""
-    import shutil
     import subprocess
     import tempfile
 
     if not app.config.get("video_supported"):
         return {"error": "Video not supported on this platform"}, 400
 
-    if not shutil.which("ffmpeg"):
+    ffmpeg_path = _ffmpeg_path()
+    if not ffmpeg_path:
         return {"error": "ffmpeg not installed"}, 500
 
     vq = app.svc.svcs.get("videoqueue")
     if not vq:
         return {"error": "Video service not available"}, 503
+    if not getattr(vq, "video_enabled", False):
+        return {"error": "Enable video before taking a snapshot"}, 409
 
     host = os.getenv("FLASK_HOST") or "127.0.0.1"
     if host in {"0.0.0.0", "::"}:
@@ -2181,14 +2205,14 @@ def app_api_snapshot():
 
     try:
         result = subprocess.run(
-            ["ffmpeg", "-loglevel", "error", "-nostdin", "-y",
+            [ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
              "-f", "h264", "-i", url, "-frames:v", "1", temp_path],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
         )
         if result.returncode != 0:
             # Retry without -f h264
             result = subprocess.run(
-                ["ffmpeg", "-loglevel", "error", "-nostdin", "-y",
+                [ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
                  "-i", url, "-frames:v", "1", temp_path],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10,
             )

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1681,6 +1681,21 @@ def app_api_printer_gcode():
     return {"status": "ok"}
 
 
+@app.post("/api/printer/home")
+def app_api_printer_home():
+    payload = request.get_json(silent=True) or {}
+    axis = str(payload.get("axis", "all")).lower()
+    if axis not in {"all", "xy", "z"}:
+        return {"error": "Invalid home axis"}, 400
+
+    with borrow_mqtt() as mqtt:
+        if mqtt.is_printing:
+            return {"error": "Motion commands blocked while printing"}, 409
+        mqtt.send_home(axis)
+
+    return {"status": "ok", "axis": axis}
+
+
 @app.post("/api/printer/control")
 def app_api_printer_control():
     payload = request.get_json(silent=True)

--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -68,11 +68,15 @@ class Service(Thread):
         return type(self).__name__
 
     def start(self):
+        if self.wanted or self.state in (RunState.Starting, RunState.Running):
+            return
         log.info(f"{self.name}: Requesting start")
         self.wanted = True
         self._event.set()
 
     def stop(self):
+        if (not self.wanted) or self.state in (RunState.Stopping, RunState.Stopped):
+            return
         log.info(f"{self.name}: Requesting stop")
         self.wanted = False
         self._event.set()
@@ -240,6 +244,7 @@ class ServiceManager:
     def __init__(self):
         self.svcs = {}
         self.refs = {}
+        self.shutting_down = False
         atexit.register(self.atexit)
 
     def __iter__(self):
@@ -249,21 +254,41 @@ class ServiceManager:
         return name in self.svcs
 
     def atexit(self):
+        self.shutting_down = True
         log.debug("ServiceManager: Shutting down threads..")
         self.dump()
-        for svc in self.svcs.values():
+
+        stop_order = [
+            "videoqueue",
+            "filetransfer",
+            *(name for name in self.svcs if name.startswith("mqttqueue")),
+            "pppp",
+        ]
+        seen = set()
+        ordered_names = []
+        for name in stop_order:
+            if name in self.svcs and name not in seen:
+                ordered_names.append(name)
+                seen.add(name)
+        for name in self.svcs:
+            if name not in seen:
+                ordered_names.append(name)
+                seen.add(name)
+
+        for name in ordered_names:
+            svc = self.svcs[name]
             if svc.state != RunState.Stopped:
                 svc.stop()
 
         log.debug("ServiceManager: Waiting for threads to stop..")
         self.dump()
-        for svc in self.svcs.values():
-            svc.await_stopped()
+        for name in ordered_names:
+            self.svcs[name].await_stopped()
 
         log.debug("ServiceManager: Cleaning up threads..")
         self.dump()
-        for svc in self.svcs.values():
-            svc.shutdown()
+        for name in ordered_names:
+            self.svcs[name].shutdown()
 
         log.info("ServiceManager: Shutdown complete")
 
@@ -290,6 +315,34 @@ class ServiceManager:
 
         del self.svcs[name]
         del self.refs[name]
+
+
+    def replace_service(self, name: str, svc: Service):
+        if name not in self:
+            raise KeyError(f"Trying to replace unknown service {name!r}")
+
+        old = self.svcs[name]
+        try:
+            old.wanted = False
+        except Exception:
+            pass
+        try:
+            if hasattr(old, "_event"):
+                old._event.set()
+        except Exception:
+            pass
+        try:
+            if hasattr(old, "_force_close_api"):
+                old._force_close_api()
+        except Exception:
+            pass
+        try:
+            old.running = False
+        except Exception:
+            pass
+
+        self.svcs[name] = svc
+        self.refs[name] = 0
 
     def restart_all(self, await_ready=True):
         wanted = {}
@@ -324,17 +377,32 @@ class ServiceManager:
         svc = self.svcs[name]
         self.refs[name] += 1
 
-        if self.refs[name] == 1:
-            svc.start()
+        try:
+            # Never request a fresh start while the old worker is still stopping.
+            # Let it finish that transition first, then start cleanly.
+            if svc.state == RunState.Stopping:
+                svc.await_stopped()
 
-        if ready:
-            try:
+            should_start = False
+
+            if self.refs[name] == 1:
+                should_start = True
+            elif not svc.wanted and svc.state == RunState.Stopped:
+                should_start = True
+            elif svc.state == RunState.Stopped:
+                should_start = True
+
+            if should_start:
+                svc.start()
+
+            if ready:
                 svc.await_ready()
-            except ServiceError:
-                self.put(name)
-                raise
 
-        return svc
+            return svc
+
+        except ServiceError:
+            self.put(name)
+            raise
 
     def put(self, name: str):
         if name not in self:

--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -427,12 +427,25 @@ class ServiceManager:
         finally:
             self.put(name)
 
-    def stream(self, name: str):
+    @staticmethod
+    def _enqueue_stream_item(q, data):
+        if q.maxsize and q.full():
+            try:
+                q.get_nowait()
+            except queue.Empty:
+                pass
+        try:
+            q.put_nowait(data)
+        except queue.Full:
+            # If another producer won the race, drop the stale realtime item.
+            pass
+
+    def stream(self, name: str, maxsize=0):
         try:
             with self.borrow(name) as svc:
-                q = Queue()
+                q = Queue(maxsize=max(0, int(maxsize or 0)))
 
-                with svc.tap(lambda data: q.put(data)):
+                with svc.tap(lambda data: self._enqueue_stream_item(q, data)):
                     while svc.state == RunState.Running:
                         try:
                             data = q.get(timeout=1.0)

--- a/web/service/filament.py
+++ b/web/service/filament.py
@@ -5,6 +5,7 @@ import re
 import sqlite3
 import threading
 import logging
+from contextlib import contextmanager
 
 log = logging.getLogger(__name__)
 
@@ -267,6 +268,15 @@ class FilamentStore:
         conn.row_factory = sqlite3.Row
         return conn
 
+    @contextmanager
+    def _connection(self):
+        conn = self._connect()
+        try:
+            yield conn
+        finally:
+            if os.fspath(self.db_path) != ":memory:":
+                conn.close()
+
     def _recreate_db_after_corruption(self, exc):
         db_path = os.fspath(self.db_path)
         if db_path == ":memory:":
@@ -280,7 +290,7 @@ class FilamentStore:
     def _init_db(self):
         with self._lock:
             try:
-                with self._connect() as conn:
+                with self._connection() as conn:
                     conn.executescript(_SCHEMA)
                     self._migrate(conn)
                     count = conn.execute("SELECT COUNT(*) FROM filaments").fetchone()[0]
@@ -289,7 +299,7 @@ class FilamentStore:
                     conn.commit()
             except sqlite3.DatabaseError as exc:
                 self._recreate_db_after_corruption(exc)
-                with self._connect() as conn:
+                with self._connection() as conn:
                     conn.executescript(_SCHEMA)
                     self._migrate(conn)
                     count = conn.execute("SELECT COUNT(*) FROM filaments").fetchone()[0]
@@ -355,7 +365,7 @@ class FilamentStore:
     def list_all(self):
         """Return all filament profiles as list of dicts, ordered by id."""
         with self._lock:
-            with self._connect() as conn:
+            with self._connection() as conn:
                 rows = conn.execute(
                     "SELECT * FROM filaments ORDER BY id ASC"
                 ).fetchall()
@@ -364,7 +374,7 @@ class FilamentStore:
     def get(self, profile_id):
         """Return a single profile dict or None."""
         with self._lock:
-            with self._connect() as conn:
+            with self._connection() as conn:
                 row = conn.execute(
                     "SELECT * FROM filaments WHERE id = ?", (profile_id,)
                 ).fetchone()
@@ -382,7 +392,7 @@ class FilamentStore:
         cols = ", ".join(safe.keys())
         placeholders = ", ".join("?" for _ in safe)
         with self._lock:
-            with self._connect() as conn:
+            with self._connection() as conn:
                 cur = conn.execute(
                     f"INSERT INTO filaments ({cols}) VALUES ({placeholders})",
                     list(safe.values()),
@@ -404,7 +414,7 @@ class FilamentStore:
             return self.get(profile_id)
         assignments = ", ".join(f"{k} = ?" for k in safe)
         with self._lock:
-            with self._connect() as conn:
+            with self._connection() as conn:
                 conn.execute(
                     f"UPDATE filaments SET {assignments} WHERE id = ?",
                     list(safe.values()) + [profile_id],
@@ -418,7 +428,7 @@ class FilamentStore:
     def delete(self, profile_id):
         """Delete a profile. Returns True if deleted, False if not found."""
         with self._lock:
-            with self._connect() as conn:
+            with self._connection() as conn:
                 cur = conn.execute(
                     "DELETE FROM filaments WHERE id = ?", (profile_id,)
                 )

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -53,14 +53,24 @@ class PrintHistory:
 
     def _init_db(self):
         try:
-            with self._connect() as conn:
+            conn = self._connect()
+            try:
                 conn.executescript(_SCHEMA)
                 self._migrate_schema(conn)
+                conn.commit()
+            finally:
+                if os.fspath(self._db_path) != ":memory:":
+                    conn.close()
         except sqlite3.DatabaseError as exc:
             self._recreate_db_after_corruption(exc)
-            with self._connect() as conn:
+            conn = self._connect()
+            try:
                 conn.executescript(_SCHEMA)
                 self._migrate_schema(conn)
+                conn.commit()
+            finally:
+                if os.fspath(self._db_path) != ":memory:":
+                    conn.close()
 
     def _migrate_schema(self, conn):
         """Ensure schema is up to date."""

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -1022,12 +1022,9 @@ class MqttQueue(Service):
     def send_home(self, axis="all"):
         axis = str(axis or "all").lower()
         if axis == "all":
-            # The official app has been observed sending value=0 for XY and value=2 for Z.
-            # Avoid guessing an undocumented "all" value; send the known native commands.
-            for known_axis in ("xy", "z"):
-                self.send_home(known_axis)
-                time.sleep(0.1)
-            return
+            # On the M5, the native Z home sequence also homes the XY axes.
+            # Route "Home All" through that same proven firmware path.
+            axis = "z"
         if axis not in HOME_MOVE_ZERO_VALUE_BY_AXIS:
             raise ValueError(f"Unsupported home axis: {axis}")
 

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -1073,7 +1073,7 @@ class MqttQueue(Service):
                 time.sleep(0.12)
                 self.client.command(flat_cmd)
                 time.sleep(0.18)
-        elif value in (2, 3):
+        elif value in (2, 3, 4):
             nested_data = {"value": value}
             if self._control_username:
                 nested_data["userName"] = self._control_username

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -190,15 +190,23 @@ class MqttQueue(Service):
             self._history.record_start(effective_filename, task_id=self._last_task_id)
             self._pending_history_start = False
             log.info(f"Print started, filename={effective_filename!r}")
+            self._timelapse.start_capture(effective_filename)
         else:
             self._pending_history_start = True
             log.info("Print started, history deferred (no filename yet)")
 
-        self._timelapse.start_capture(effective_filename or "unknown")
         self._ha.update_state(print_status="printing")
         self._send_event(EVENT_PRINT_STARTED, self._build_payload(payload, progress))
 
         return True
+
+    def _complete_deferred_print_start(self):
+        """Record and start helpers when filename arrives after print activation."""
+        if self._state == PrintState.PRINTING and self._pending_history_start and self._last_filename:
+            self._history.record_start(self._last_filename, task_id=self._last_task_id)
+            self._timelapse.start_capture(self._last_filename)
+            self._pending_history_start = False
+            log.info(f"Print start completed after filename arrived, filename={self._last_filename!r}")
 
     @property
     def is_printing(self):
@@ -630,9 +638,7 @@ class MqttQueue(Service):
                 self._last_filename = os.path.basename(file_path)
                 log.info(f"History: captured filename from ct 1044: {self._last_filename}")
             # If ct=1000 value=1 arrived before ct=1044, record the start now that we have the filename
-            if self._state == PrintState.PRINTING and self._pending_history_start and self._last_filename:
-                self._history.record_start(self._last_filename, task_id=self._last_task_id)
-                self._pending_history_start = False
+            self._complete_deferred_print_start()
             # Activate print early so Stop sends value=4 (not the prepare-cancel path)
             # during the G28/calibration window before ct=1000 value=1 arrives.
             # Only activate if a print was actually requested (PREPARING state),
@@ -755,6 +761,7 @@ class MqttQueue(Service):
                     filename = self._last_filename
             else:
                 self._last_filename = filename
+            self._complete_deferred_print_start()
 
         if self._last_progress is not None and progress < self._last_progress and progress <= 1:
             same_task = task_id and prev_task_id and task_id == prev_task_id

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -711,7 +711,7 @@ class MqttQueue(Service):
                     self._reset_print_state()
             elif value == 8:
                 self._state = PrintState.IDLE
-            log.info(
+            log.debug(
                 "Printer state trace: ct=1000 value=%r (%s) internal=%s->%s stop_requested=%s pending_start=%s preparing=%s",
                 value,
                 self._print_state_value_label(value),
@@ -994,14 +994,14 @@ class MqttQueue(Service):
         lines = cli.util.normalize_gcode_lines(gcode)
         for line in lines:
             if self._is_duplicate_g28(line):
-                log.info("Ignoring duplicate homing command: %s", line)
+                log.debug("Ignoring duplicate homing command: %s", line)
                 continue
             cmd = {
                 "commandType": MqttMsgType.ZZ_MQTT_CMD_GCODE_COMMAND.value,
                 "cmdData": line,
                 "cmdLen": len(line),
             }
-            log.info("Sending GCode command: %s", line)
+            log.debug("Sending GCode command: %s", line)
             self.client.command(cmd)
             time.sleep(0.1)
 
@@ -1026,7 +1026,7 @@ class MqttQueue(Service):
             raise ValueError(f"Unsupported home axis: {axis}")
 
         gcode = HOME_GCODE_BY_AXIS[axis]
-        log.info("Sending home GCode axis=%s gcode=%s", axis, gcode)
+        log.debug("Sending home GCode axis=%s gcode=%s", axis, gcode)
         self.send_gcode(gcode)
 
     def send_print_control(self, value):
@@ -1034,7 +1034,7 @@ class MqttQueue(Service):
 
         pre_start_window = self.is_preparing_print or self.has_pending_print_start
 
-        log.info(
+        log.debug(
             "send_print_control(value=%s, state=%s, preparing=%s, pending_start=%s)",
             value,
             self._state.value,
@@ -1062,7 +1062,7 @@ class MqttQueue(Service):
                     "commandType": MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL.value,
                     "value": candidate,
                 }
-                log.info("Pre-start cancel attempt value=%s (nested + flat)", candidate)
+                log.debug("Pre-start cancel attempt value=%s (nested + flat)", candidate)
                 self.client.command(nested_cmd)
                 time.sleep(0.12)
                 self.client.command(flat_cmd)
@@ -1079,7 +1079,7 @@ class MqttQueue(Service):
                 "commandType": MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL.value,
                 "value": value,
             }
-            log.info("Print control attempt value=%s (nested + flat)", value)
+            log.debug("Print control attempt value=%s (nested + flat)", value)
             self.client.command(nested_cmd)
             time.sleep(0.12)
             self.client.command(flat_cmd)

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -59,6 +59,10 @@ class MqttQueue(Service):
         self.persistent = True
         self._state_lock = threading.RLock()
 
+    @property
+    def name(self):
+        return f"MqttQueue[{self.printer_index}]"
+
     def worker_init(self):
         self._notifier = AppriseNotifier(app.config["config"])
         config_root = str(app.config["config"].config_root)
@@ -333,7 +337,7 @@ class MqttQueue(Service):
 
         for msg, body in self.client.fetch(timeout=timeout):
             self._last_message_time = time.time()
-            log.info(f"TOPIC [{msg.topic}]")
+            log.debug(f"TOPIC [{msg.topic}]")
             log.debug(enhex(msg.payload[:]))
             if body and getattr(self, "_debug_log_payloads", False):
                 import json

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -54,10 +54,9 @@ MQTT_PRINT_STATE_LABELS = {
 }
 
 G28_DEDUPE_WINDOW_SEC = 10.0
-HOME_GCODE_BY_AXIS = {
-    "all": "G28",
-    "xy": "G28 X0 Y0",
-    "z": "G28 Z0",
+HOME_MOVE_ZERO_VALUE_BY_AXIS = {
+    "xy": 0,
+    "z": 2,
 }
 
 
@@ -1022,12 +1021,22 @@ class MqttQueue(Service):
 
     def send_home(self, axis="all"):
         axis = str(axis or "all").lower()
-        if axis not in HOME_GCODE_BY_AXIS:
+        if axis == "all":
+            # The official app has been observed sending value=0 for XY and value=2 for Z.
+            # Avoid guessing an undocumented "all" value; send the known native commands.
+            for known_axis in ("xy", "z"):
+                self.send_home(known_axis)
+                time.sleep(0.1)
+            return
+        if axis not in HOME_MOVE_ZERO_VALUE_BY_AXIS:
             raise ValueError(f"Unsupported home axis: {axis}")
 
-        gcode = HOME_GCODE_BY_AXIS[axis]
-        log.debug("Sending home GCode axis=%s gcode=%s", axis, gcode)
-        self.send_gcode(gcode)
+        value = HOME_MOVE_ZERO_VALUE_BY_AXIS[axis]
+        log.debug("Sending native home command axis=%s value=%s", axis, value)
+        self.client.command({
+            "commandType": MqttMsgType.ZZ_MQTT_CMD_MOVE_ZERO.value,
+            "value": value,
+        })
 
     def send_print_control(self, value):
         value = int(value)

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -45,6 +45,22 @@ class PrintState(Enum):
     FAILED = "failed"
 
 
+MQTT_PRINT_STATE_LABELS = {
+    0: "idle",
+    1: "printing",
+    2: "paused",
+    3: "resume_ack",
+    8: "preparing_or_aborted",
+}
+
+G28_DEDUPE_WINDOW_SEC = 10.0
+HOME_GCODE_BY_AXIS = {
+    "all": "G28",
+    "xy": "G28 X0 Y0",
+    "z": "G28 Z0",
+}
+
+
 import cli.mqtt
 from ..notifications import AppriseNotifier, format_duration
 from .history import PrintHistory
@@ -94,6 +110,8 @@ class MqttQueue(Service):
         self._z_offset_updated_at = 0.0
         self._z_offset_seq = 0
         self._z_offset_cond = threading.Condition()
+        self._last_g28_command = None
+        self._last_g28_command_at = 0.0
 
     def set_gcode_layer_count(self, count: int):
         """Store the layer count extracted from a GCode header for UI display."""
@@ -137,6 +155,18 @@ class MqttQueue(Service):
         )
         self._failure_sent = True
         self._state = PrintState.FAILED
+
+    @staticmethod
+    def _print_state_value_label(value):
+        return MQTT_PRINT_STATE_LABELS.get(value, f"unknown_{value}")
+
+    def _transition_from_paused_to_printing(self):
+        if self._state != PrintState.PAUSED:
+            return False
+
+        self._state = PrintState.PRINTING
+        self._ha.update_state(print_status="printing")
+        return True
 
     def _transition_to_active(self, payload, progress, filename=None):
         """Activate print state.  Handles both fresh activation and upgrade
@@ -620,17 +650,21 @@ class MqttQueue(Service):
             # prepare(8) -> idle(0) can still be classified correctly.
             was_preparing_print = self.is_preparing_print
             was_pending_start = self._state == PrintState.PREPARING
+            stop_was_requested = self._stop_requested
+            previous_state = self._state
             self._last_state_value = value
-            if value == 1:
+            if value == 1 and self._state == PrintState.PAUSED:
+                if self._transition_from_paused_to_printing():
+                    log.info("Print resumed (ct 1000 value=1)")
+            elif value == 1:
                 self._transition_to_active(payload, progress=0)
             elif value == 2 and self._state == PrintState.PRINTING:
                 self._state = PrintState.PAUSED
                 self._ha.update_state(print_status="paused")
                 log.info("Print paused (ct 1000 value=2)")
             elif value == 3 and self._state == PrintState.PAUSED:
-                self._state = PrintState.PRINTING
-                self._ha.update_state(print_status="printing")
-                log.info("Print resumed (ct 1000 value=3)")
+                if self._transition_from_paused_to_printing():
+                    log.info("Print resumed (ct 1000 value=3)")
             elif value == 0 and (self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED) or was_preparing_print or was_pending_start):
                 if self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
                     if self._stop_requested:
@@ -671,6 +705,16 @@ class MqttQueue(Service):
                     self._reset_print_state()
             elif value == 8:
                 self._state = PrintState.IDLE
+            log.info(
+                "Printer state trace: ct=1000 value=%r (%s) internal=%s->%s stop_requested=%s pending_start=%s preparing=%s",
+                value,
+                self._print_state_value_label(value),
+                previous_state.value,
+                self._state.value,
+                stop_was_requested,
+                was_pending_start,
+                was_preparing_print,
+            )
             return
 
         if command_type not in (
@@ -832,6 +876,7 @@ class MqttQueue(Service):
                 "in_pre_print_window": self._state == PrintState.PRE_PRINT,
                 "pending_start": self._state == PrintState.PREPARING,
                 "state": self._last_state_value,
+                "state_label": self._print_state_value_label(self._last_state_value),
                 "preparing": self.is_preparing_print,
                 "started_at": self._print_started_at,
                 "last_progress": self._last_progress,
@@ -941,13 +986,41 @@ class MqttQueue(Service):
 
         lines = cli.util.normalize_gcode_lines(gcode)
         for line in lines:
+            if self._is_duplicate_g28(line):
+                log.info("Ignoring duplicate homing command: %s", line)
+                continue
             cmd = {
                 "commandType": MqttMsgType.ZZ_MQTT_CMD_GCODE_COMMAND.value,
                 "cmdData": line,
                 "cmdLen": len(line),
             }
+            log.info("Sending GCode command: %s", line)
             self.client.command(cmd)
             time.sleep(0.1)
+
+    def _is_duplicate_g28(self, line):
+        parts = line.split()
+        if not parts or parts[0].upper() != "G28":
+            return False
+
+        now = time.monotonic()
+        key = " ".join(part.upper() for part in parts)
+        last_key = getattr(self, "_last_g28_command", None)
+        last_at = getattr(self, "_last_g28_command_at", 0.0)
+        duplicate = key == last_key and now - last_at < G28_DEDUPE_WINDOW_SEC
+        if not duplicate:
+            self._last_g28_command = key
+            self._last_g28_command_at = now
+        return duplicate
+
+    def send_home(self, axis="all"):
+        axis = str(axis or "all").lower()
+        if axis not in HOME_GCODE_BY_AXIS:
+            raise ValueError(f"Unsupported home axis: {axis}")
+
+        gcode = HOME_GCODE_BY_AXIS[axis]
+        log.info("Sending home GCode axis=%s gcode=%s", axis, gcode)
+        self.send_gcode(gcode)
 
     def send_print_control(self, value):
         value = int(value)
@@ -987,6 +1060,22 @@ class MqttQueue(Service):
                 time.sleep(0.12)
                 self.client.command(flat_cmd)
                 time.sleep(0.18)
+        elif value in (2, 3):
+            nested_data = {"value": value}
+            if self._control_username:
+                nested_data["userName"] = self._control_username
+            nested_cmd = {
+                "commandType": MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL.value,
+                "data": nested_data,
+            }
+            flat_cmd = {
+                "commandType": MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL.value,
+                "value": value,
+            }
+            log.info("Print control attempt value=%s (nested + flat)", value)
+            self.client.command(nested_cmd)
+            time.sleep(0.12)
+            self.client.command(flat_cmd)
         else:
             cmd = {
                 "commandType": MqttMsgType.ZZ_MQTT_CMD_PRINT_CONTROL.value,

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -41,6 +41,42 @@ class PPPPService(Service):
         self._handler_lock = threading.Lock()
         super().__init__()
 
+    def _force_close_api(self):
+        if not hasattr(self, "_api"):
+            return
+        api = self._api
+        # Do not try to send a graceful close packet here. After a video freeze,
+        # that send path can block and leave PPPP half-stopped forever. Force the
+        # transport down locally so the service thread can complete its stop and
+        # be restarted cleanly.
+        try:
+            api.state = PPPPState.Disconnected
+        except Exception:
+            pass
+        try:
+            if getattr(api, "sock", None):
+                try:
+                    api.sock.shutdown(2)
+                except Exception:
+                    pass
+                api.sock.close()
+        except Exception:
+            pass
+        try:
+            del self._api
+        except Exception:
+            try:
+                self._api = None
+            except Exception:
+                pass
+
+    def stop(self):
+        was_wanted = self.wanted
+        super().stop()
+        if was_wanted:
+            log.info("PPPPService: forcing socket close to expedite stop")
+            self._force_close_api()
+
     def api_command(self, commandType, **kwargs):
         if not hasattr(self, "_api"):
             raise ConnectionError("No pppp connection")
@@ -112,6 +148,8 @@ class PPPPService(Service):
                 if not hdr:
                     return
                 if hdr[:4] != b"XZYH":
+                    if self._resync_xzyh(fd, chan):
+                        continue
                     return
 
                 xzyh = Xzyh.parse(hdr)[0]
@@ -128,6 +166,25 @@ class PPPPService(Service):
                 except Exception as e:
                     log.warning(f"Handler error: {e}")
 
+    def _resync_xzyh(self, fd, chan):
+        rx = getattr(fd, "rx", None)
+        buf = getattr(rx, "buf", None)
+        if not buf:
+            return False
+
+        data = bytes(buf)
+        pos = data.find(b"XZYH", 1)
+        if pos < 0:
+            if len(buf) > 3:
+                discarded = len(buf) - 3
+                del buf[:-3]
+                log.debug(f"PPPPService: discarded {discarded} unsynced channel {chan} byte(s) while looking for XZYH")
+            return False
+
+        del buf[:pos]
+        log.debug(f"PPPPService: resynced channel {chan} stream at next XZYH boundary")
+        return True
+
     def _recv_aabb(self, fd):
         data = fd.read(12)
         aabb = Aabb.parse(data)[0]
@@ -136,10 +193,40 @@ class PPPPService(Service):
         return aabb, data
 
     def worker_run(self, timeout):
+        if not hasattr(self, "_api"):
+            if getattr(self, "wanted", True):
+                raise ServiceRestartSignal("PPPP API missing while service is wanted")
+            return
+
+        # A stale/disconnected API object after video recovery is not a usable
+        # running PPPP session. Force an internal restart instead of idling
+        # forever in a wanted-but-disconnected state.
+        if getattr(self._api, "state", PPPPState.Connected) != PPPPState.Connected:
+            if getattr(self, "wanted", True):
+                raise ServiceRestartSignal("PPPP API exists but is not connected while service is wanted")
+            return
+
         try:
             msg = self._api.poll(timeout=timeout)
-        except ConnectionResetError:
+        except (ConnectionResetError, OSError):
+            if not getattr(self, "wanted", True):
+                return
             raise ServiceRestartSignal()
+
+        if not hasattr(self, "_api"):
+            if getattr(self, "wanted", True):
+                raise ServiceRestartSignal("PPPP API disappeared during worker loop")
+            return
+
+        if getattr(self._api, "state", PPPPState.Connected) != PPPPState.Connected:
+            if getattr(self, "wanted", True):
+                raise ServiceRestartSignal("PPPP API disconnected during worker loop")
+            return
+
+        chans = getattr(self._api, "chans", [])
+        if len(chans) > 1 and hasattr(chans[1], "skip_rx_gap"):
+            if chans[1].skip_rx_gap(max_queued=12):
+                self._drain_xzyh(chan=1)
 
         self._drain_xzyh(chan=1)
 
@@ -172,15 +259,19 @@ class PPPPService(Service):
                 aabb.data = data
                 self.notify((msg.chan, aabb))
             else:
-                raise ValueError(f"Unexpected data in stream: {header!r}")
+                if msg.chan == 1:
+                    if self._resync_xzyh(ch, msg.chan):
+                        drain_xzyh = True
+                    else:
+                        return
+                else:
+                    raise ValueError(f"Unexpected data in stream: {header!r}")
 
         if drain_xzyh:
             self._drain_xzyh(chan=msg.chan)
 
     def worker_stop(self):
-        if hasattr(self, "_api"):
-            self._api.send(PktClose())
-            del self._api
+        self._force_close_api()
 
     @property
     def connected(self):

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -22,6 +22,18 @@ _IN_PROGRESS_SUBDIR = "in_progress"
 _MAX_ORPHAN_AGE_SEC = 24 * 3600  # 24 hours
 
 
+def _resolve_ffmpeg_path():
+    """Find ffmpeg using the same fallback path as the web snapshot route."""
+    try:
+        from web import _ffmpeg_path as web_ffmpeg_path  # Lazy import avoids circular deps
+        ffmpeg_path = web_ffmpeg_path()
+        if ffmpeg_path:
+            return ffmpeg_path
+    except Exception as err:
+        log.debug(f"Timelapse: web ffmpeg lookup unavailable: {err}")
+    return shutil.which("ffmpeg")
+
+
 class TimelapseService:
     """Captures periodic snapshots during a print and assembles a timelapse video."""
 
@@ -252,7 +264,7 @@ class TimelapseService:
         if not filename or filename.strip().lower() in {"unknown", "unknown.gcode", ""}:
             log.debug(f"Timelapse: skipping placeholder filename {filename!r}")
             return
-        if not shutil.which("ffmpeg"):
+        if not _resolve_ffmpeg_path():
             log.warning("Timelapse: ffmpeg not available, skipping")
             return
 
@@ -413,6 +425,10 @@ class TimelapseService:
     def _take_snapshot(self):
         """Capture a single frame using ffmpeg."""
         from web import app  # Lazy import to avoid circular deps
+        ffmpeg_path = _resolve_ffmpeg_path()
+        if not ffmpeg_path:
+            log.warning("Timelapse: ffmpeg not available, skipping snapshot")
+            return
 
         host = os.getenv("FLASK_HOST") or "127.0.0.1"
         if host in {"0.0.0.0", "::"}:
@@ -436,13 +452,15 @@ class TimelapseService:
                 vq.api_light_state(True)
                 time.sleep(1.5)
 
-        self._await_video_frame()
-
         frame_path = os.path.join(self._current_dir, f"frame_{self._frame_count:05d}.jpg")
         try:
+            if not self._await_video_frame():
+                log.debug("Timelapse: no recent video frame, skipping snapshot")
+                return
+
             result = subprocess.run(
                 [
-                    "ffmpeg", "-loglevel", "error", "-nostdin", "-y",
+                    ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
                     "-f", "h264", "-i", url,
                     "-frames:v", "1",
                     frame_path,
@@ -455,7 +473,7 @@ class TimelapseService:
                 # Retry without format hint
                 result = subprocess.run(
                     [
-                        "ffmpeg", "-loglevel", "error", "-nostdin", "-y",
+                        ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
                         "-i", url,
                         "-frames:v", "1",
                         frame_path,
@@ -473,6 +491,23 @@ class TimelapseService:
                     os.remove(frame_path)
                 except OSError:
                     pass
+                stderr = getattr(result, "stderr", b"").decode(errors="ignore").strip()
+                if stderr:
+                    log.warning(f"Timelapse: snapshot failed: {stderr}")
+                else:
+                    log.warning("Timelapse: snapshot failed")
+        except subprocess.TimeoutExpired:
+            try:
+                os.remove(frame_path)
+            except OSError:
+                pass
+            log.warning("Timelapse: snapshot timed out waiting for a camera frame")
+        except OSError as err:
+            try:
+                os.remove(frame_path)
+            except OSError:
+                pass
+            log.warning(f"Timelapse: snapshot could not run ffmpeg: {err}")
         finally:
             # Always restore light even if ffmpeg timed out or raised an exception
             if vq and snap_original_light is not True:
@@ -581,11 +616,15 @@ class TimelapseService:
         fps = max(1, min(30, math.ceil(frame_count / 30)))
 
         input_pattern = os.path.join(dir_path, "frame_%05d.jpg")
+        ffmpeg_path = _resolve_ffmpeg_path()
+        if not ffmpeg_path:
+            log.warning("Timelapse: ffmpeg not available, skipping assembly")
+            return
 
         try:
             result = subprocess.run(
                 [
-                    "ffmpeg", "-loglevel", "error", "-nostdin", "-y",
+                    ffmpeg_path, "-loglevel", "error", "-nostdin", "-y",
                     "-framerate", str(fps),
                     "-i", input_pattern,
                     "-c:v", "libx264", "-pix_fmt", "yuv420p",

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -98,7 +98,11 @@ class TimelapseService:
             self._light_mode = "session"
         else:
             self._light_mode = None
-        log.info(f"Timelapse: config loaded — enabled={self._enabled}, interval={self._interval}s, light_mode={self._light_mode}")
+        config_message = f"Timelapse: config loaded — enabled={self._enabled}, interval={self._interval}s, light_mode={self._light_mode}"
+        if self._enabled:
+            log.info(config_message)
+        else:
+            log.debug(config_message)
 
     @property
     def enabled(self):
@@ -448,7 +452,7 @@ class TimelapseService:
         if vq:
             snap_original_light = getattr(vq, "saved_light_state", None)
             if snap_original_light is not True:
-                log.info("Timelapse: light on for snapshot, waiting 1.5s")
+                log.debug("Timelapse: light on for snapshot, waiting 1.5s")
                 vq.api_light_state(True)
                 time.sleep(1.5)
 
@@ -513,7 +517,7 @@ class TimelapseService:
             if vq and snap_original_light is not True:
                 time.sleep(1.0)
                 restore = snap_original_light if snap_original_light is not None else False
-                log.info(f"Timelapse: restoring light to {restore} after snapshot")
+                log.debug(f"Timelapse: restoring light to {restore} after snapshot")
                 vq.api_light_state(restore)
 
     def _in_progress_base(self):

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -99,10 +99,7 @@ class TimelapseService:
         else:
             self._light_mode = None
         config_message = f"Timelapse: config loaded — enabled={self._enabled}, interval={self._interval}s, light_mode={self._light_mode}"
-        if self._enabled:
-            log.info(config_message)
-        else:
-            log.debug(config_message)
+        log.debug(config_message)
 
     @property
     def enabled(self):
@@ -256,7 +253,8 @@ class TimelapseService:
         timer.daemon = True
         timer.start()
         self._finalize_timer = timer
-        log.info(
+        pause_log = log.info if frame_count >= 2 else log.debug
+        pause_log(
             f"Timelapse: capture paused for '{filename}' ({frame_count} frames), "
             f"resumable for {_RESUME_WINDOW_SEC // 60} min"
         )
@@ -584,7 +582,8 @@ class TimelapseService:
 
         # Handle the youngest candidate
         if youngest_age <= _MAX_ORPHAN_AGE_SEC:
-            log.info(
+            resume_log = log.info if youngest_frames >= 2 else log.debug
+            resume_log(
                 f"Timelapse: found persisted capture '{youngest_filename}' "
                 f"({youngest_frames} frames, {youngest_age / 3600:.1f}h ago) — "
                 f"resumable for {_RESUME_WINDOW_SEC // 60} min"

--- a/web/service/video.py
+++ b/web/service/video.py
@@ -335,15 +335,15 @@ class VideoQueue(Service):
 
         self.pppp = self._ensure_pppp_ready()
         if not self.pppp:
-            log.info("VideoQueue: PPPP not available yet in worker_start")
+            log.debug("VideoQueue: PPPP not available yet in worker_start")
             self.api_id = None
             return
         if not getattr(self.pppp, "connected", False):
-            log.info("VideoQueue: PPPP exists but is not connected yet in worker_start")
+            log.debug("VideoQueue: PPPP exists but is not connected yet in worker_start")
             self.api_id = None
             return
         if not hasattr(self.pppp, "_api"):
-            log.info("VideoQueue: PPPP connected but API not ready yet in worker_start")
+            log.debug("VideoQueue: PPPP connected but API not ready yet in worker_start")
             self.api_id = None
             return
 
@@ -378,7 +378,7 @@ class VideoQueue(Service):
         if not self.pppp:
             self.pppp = self._ensure_pppp_ready()
             if not self.pppp:
-                log.info("VideoQueue: PPPP not available yet")
+                log.debug("VideoQueue: PPPP not available yet")
                 time.sleep(0.5)
                 return
 
@@ -389,13 +389,13 @@ class VideoQueue(Service):
             raise ServiceRestartSignal("PPPP reference lost during video session")
 
         if not getattr(pppp, "connected", False):
-            log.info("VideoQueue: PPPP exists but is not connected yet")
+            log.debug("VideoQueue: PPPP exists but is not connected yet")
             time.sleep(0.5)
             return
 
         if getattr(self, "api_id", None) is None:
             if not hasattr(pppp, "_api"):
-                log.info("VideoQueue: PPPP connected but API not ready yet")
+                log.debug("VideoQueue: PPPP connected but API not ready yet")
                 time.sleep(0.5)
                 return
 

--- a/web/service/video.py
+++ b/web/service/video.py
@@ -4,14 +4,15 @@ import time
 
 from queue import Empty
 
-_STALL_TIMEOUT = 60.0  # seconds without a frame before soft restart; 3 failures → ServiceRestartSignal
+_STALL_TIMEOUT = 5.0  # seconds without a frame before soft restart; 3 failures → ServiceRestartSignal
 _STALL_MAX_RETRIES = 3  # escalate to hard restart after this many consecutive soft-reset failures
-_LIVE_REFRESH_COOLDOWN = 15.0
+_LIVE_REFRESH_COOLDOWN = 4.0
 
 log = logging.getLogger(__name__)
 
-from ..lib.service import Service, ServiceRestartSignal, RunState
+from ..lib.service import Service, ServiceRestartSignal, ServiceStoppedError, RunState
 from .. import app
+from .pppp import PPPPService
 
 from libflagship.pppp import P2PSubCmdType, P2PCmdType, Xzyh
 
@@ -60,16 +61,50 @@ class VideoQueue(Service):
         self.video_enabled = False
         self.last_frame_at = None
         self._enable_generation = 0  # increments each time video is enabled
+        self._viewer_count = 0
+        self._pppp_ref_held = False
+        self._recycle_pppp_on_restart = False
+        self._awaiting_pppp_recycle = False
+        self._pending_disable = False
+        self._in_place_recovery = False
+        self._pppp_recycle_requested_at = None
         super().__init__()
 
     def api_start_live(self):
         if not self.pppp or not getattr(self.pppp, "connected", False):
             return False
+        live_auth = self._live_auth_data()
+        if not live_auth:
+            log.warning("VideoQueue: cannot start live view because live auth data is missing")
+            return False
         self.pppp.api_command(P2PSubCmdType.START_LIVE, data={
-            "encryptkey": "x",
-            "accountId": "y",
+            "encryptkey": live_auth["encryptkey"],
+            "accountId": live_auth["accountId"],
         })
         return True
+
+    def _live_auth_data(self):
+        """Return the live-view auth payload without logging sensitive values."""
+        try:
+            with app.config["config"].open() as cfg:
+                if not cfg:
+                    return None
+                printer_index = app.config.get("printer_index", 0)
+                if printer_index < 0 or printer_index >= len(cfg.printers):
+                    return None
+                printer = cfg.printers[printer_index]
+                account = getattr(cfg, "account", None)
+                encryptkey = getattr(printer, "p2p_key", None)
+                account_id = getattr(account, "user_id", None)
+                if not encryptkey or not account_id:
+                    return None
+                return {
+                    "encryptkey": encryptkey,
+                    "accountId": account_id,
+                }
+        except Exception as exc:
+            log.warning(f"VideoQueue: failed to load live auth data: {exc}")
+            return None
 
     def api_stop_live(self):
         if not self.pppp or not getattr(self.pppp, "connected", False):
@@ -130,13 +165,18 @@ class VideoQueue(Service):
         if not isinstance(msg, Xzyh):
             return
 
-        if msg.cmd == P2PCmdType.APP_CMD_VIDEO_FRAME:
-            self.last_frame_at = time.monotonic()
-            self._live_active = True
+        if msg.cmd != P2PCmdType.APP_CMD_VIDEO_FRAME:
+            log.debug(f"VideoQueue: ignoring non-video XZYH command {msg.cmd!r}")
+            return
 
+        self.last_frame_at = time.monotonic()
+        self._live_active = True
+        self._stall_retry_count = 0
         self.notify(msg)
 
     def _start_live_if_needed(self, force=False):
+        if not self.video_enabled or not self.wanted:
+            return False
         if not self.pppp or not getattr(self.pppp, "connected", False):
             return False
 
@@ -159,6 +199,69 @@ class VideoQueue(Service):
         self._live_active = False
         return True
 
+    def _ensure_pppp_ready(self):
+        """Return a ready PPPP service while preserving the existing borrow across
+        internal VideoQueue restarts.
+
+        Reacquiring PPPP on every VideoQueue restart causes a ref drop to zero,
+        which stops PPPP and then races with the next video start. Keep the PPPP
+        borrow alive across ordinary internal video restarts and only release it
+        when video is actually being disabled, the app is shutting down, or a
+        hard recovery explicitly requests a full PPPP recycle.
+        """
+        if self._pppp_ref_held and self.pppp is not None:
+            try:
+                self.pppp.await_ready()
+            except ServiceStoppedError:
+                try:
+                    app.svc.put("pppp")
+                except Exception:
+                    pass
+                self._pppp_ref_held = False
+                self.pppp = None
+            else:
+                return self.pppp
+
+        pppp_svc = getattr(app.svc, "svcs", {}).get("pppp")
+        if self._awaiting_pppp_recycle and pppp_svc is not None:
+            effectively_stopped = (
+                not getattr(pppp_svc, "wanted", False)
+                and not getattr(pppp_svc, "connected", False)
+                and not hasattr(pppp_svc, "_api")
+            )
+
+            if pppp_svc.state != RunState.Stopped:
+                recycle_requested_at = getattr(self, "_pppp_recycle_requested_at", None)
+                stuck_after_forced_recycle = (
+                    not getattr(pppp_svc, "wanted", False)
+                    and recycle_requested_at is not None
+                    and (time.monotonic() - recycle_requested_at) >= 2.0
+                )
+                if not effectively_stopped and not stuck_after_forced_recycle:
+                    return None
+
+                if stuck_after_forced_recycle and not effectively_stopped:
+                    log.warning("VideoQueue: PPPP stop is stuck after forced recycle; marking service reusable")
+
+                log.info("VideoQueue: PPPP recycle is effectively complete; proceeding with fresh reacquire")
+                # The old PPPP worker can get wedged after a video freeze.
+                # Replace the managed PPPP service with a fresh instance so a
+                # new connection attempt is guaranteed to start from a clean
+                # thread/service object instead of reusing stale state.
+                app.svc.replace_service("pppp", PPPPService())
+                pppp_svc = app.svc.svcs.get("pppp")
+
+            self._awaiting_pppp_recycle = False
+            self._pppp_recycle_requested_at = None
+            log.info("VideoQueue: PPPP recycle completed; reacquiring fresh PPPP session")
+
+        # Important: during a recycle handoff, do not block waiting for PPPP to
+        # become ready. Borrow it in non-ready mode and let worker_start/
+        # worker_run observe the connection state naturally.
+        self.pppp = app.svc.get("pppp", ready=False)
+        self._pppp_ref_held = True
+        return self.pppp
+
     def worker_init(self):
         self.saved_light_state = None
         self.saved_video_mode = None
@@ -171,13 +274,66 @@ class VideoQueue(Service):
         self._live_active = False
         self.api_id = None
         self.pppp = None
+        self._pppp_ref_held = False
         self._stall_retry_count = 0
+        self._recycle_pppp_on_restart = False
+        self._awaiting_pppp_recycle = False
+        self._pending_disable = False
+        self._in_place_recovery = False
+        self._pppp_recycle_requested_at = None
+
+    def _recycle_pppp_in_place(self):
+        """Recycle the PPPP session without restarting the VideoQueue service.
+
+        Keeping /ws/video open avoids forcing the browser to rebuild the
+        websocket/JMuxer pipeline on every hard video recovery.
+        """
+        if not self.video_enabled or not self.wanted:
+            log.info("VideoQueue: PPPP recycle skipped because video was disabled")
+            return
+
+        self._in_place_recovery = True
+        try:
+            try:
+                self.api_stop_live()
+            except Exception:
+                pass
+
+            old_pppp = self.pppp
+            if old_pppp is not None:
+                try:
+                    with old_pppp._handler_lock:
+                        if self._handler in old_pppp.xzyh_handlers:
+                            old_pppp.xzyh_handlers.remove(self._handler)
+                except Exception as exc:
+                    log.debug(f"VideoQueue: failed detaching handler during in-place recovery: {exc}")
+
+            if self._pppp_ref_held:
+                log.info("VideoQueue: recycling PPPP in place for video recovery")
+                self._awaiting_pppp_recycle = True
+                self._pppp_recycle_requested_at = time.monotonic()
+                app.svc.put("pppp")
+                self._pppp_ref_held = False
+
+            self.pppp = None
+            self.api_id = None
+            self._live_active = False
+            self._last_start_live_at = 0.0
+            self._live_started_at = None
+            self.last_frame_at = None
+            self._last_no_frame_log_at = 0.0
+            self._last_live_refresh_at = 0.0
+            self._stall_retry_count = 0
+            log.info("VideoQueue: PPPP recycle requested in place; waiting for clean stop before reacquire")
+        finally:
+            self._in_place_recovery = False
 
     def worker_start(self):
         self._stall_retry_count = 0
         if not self.video_enabled:
             return
-        self.pppp = app.svc.get("pppp")
+
+        self.pppp = self._ensure_pppp_ready()
         if not self.pppp:
             log.info("VideoQueue: PPPP not available yet in worker_start")
             self.api_id = None
@@ -212,9 +368,15 @@ class VideoQueue(Service):
         if not self.video_enabled:
             return
         self.idle(timeout=timeout)
+        if not self.video_enabled or not self.wanted:
+            return
+
+        if self._in_place_recovery:
+            time.sleep(0.1)
+            return
 
         if not self.pppp:
-            self.pppp = app.svc.get("pppp")
+            self.pppp = self._ensure_pppp_ready()
             if not self.pppp:
                 log.info("VideoQueue: PPPP not available yet")
                 time.sleep(0.5)
@@ -227,7 +389,9 @@ class VideoQueue(Service):
             raise ServiceRestartSignal("PPPP reference lost during video session")
 
         if not getattr(pppp, "connected", False):
-            raise ServiceRestartSignal("No pppp connection")
+            log.info("VideoQueue: PPPP exists but is not connected yet")
+            time.sleep(0.5)
+            return
 
         if getattr(self, "api_id", None) is None:
             if not hasattr(pppp, "_api"):
@@ -298,28 +462,33 @@ class VideoQueue(Service):
     def _attempt_stall_recovery(self, pppp, warn_msg, retry_fail_msg, exhaust_msg):
         """Stop and restart the live stream after a stall.
 
-        Updates self._last_live_refresh_at, increments self._stall_retry_count on
-        failure, resets it on success.  Raises ServiceRestartSignal when max retries
-        are exceeded.  All other exceptions are logged and swallowed so the caller
-        can continue the polling loop.
+        Each invocation counts as one consecutive no-frame recovery attempt.
+        The counter is only reset when an actual frame arrives in _handler().
+        After enough consecutive no-frame recoveries, escalate to a full
+        VideoQueue/PPPP restart instead of looping forever on START_LIVE.
         """
         self._last_live_refresh_at = time.monotonic()
-        log.warning(warn_msg)
+        self._stall_retry_count += 1
+        attempt = self._stall_retry_count
+        log.warning(f"{warn_msg} (attempt {attempt}/{_STALL_MAX_RETRIES})")
         try:
             self._live_active = False
             self.api_stop_live()
             time.sleep(0.5)
+            if not self.video_enabled or not self.wanted:
+                log.info("VideoQueue: live refresh cancelled because video was disabled")
+                return
             if not pppp or not getattr(pppp, "connected", False):
                 log.warning("VideoQueue: PPPP unavailable during live refresh")
+                if attempt >= _STALL_MAX_RETRIES:
+                    raise ServiceRestartSignal(exhaust_msg)
                 time.sleep(0.5)
                 return
             if not self._start_live_if_needed(force=True):
-                self._stall_retry_count += 1
-                log.warning(f"{retry_fail_msg} (attempt {self._stall_retry_count}/{_STALL_MAX_RETRIES})")
-                if self._stall_retry_count >= _STALL_MAX_RETRIES:
-                    raise ServiceRestartSignal(exhaust_msg)
-            else:
-                self._stall_retry_count = 0
+                log.warning(f"{retry_fail_msg} (attempt {attempt}/{_STALL_MAX_RETRIES})")
+            if attempt >= _STALL_MAX_RETRIES:
+                log.warning(f"{exhaust_msg}; recycling PPPP in place")
+                self._recycle_pppp_in_place()
         except ServiceRestartSignal:
             raise
         except Exception as exc:
@@ -336,27 +505,72 @@ class VideoQueue(Service):
                 if self._handler in self.pppp.xzyh_handlers:
                     self.pppp.xzyh_handlers.remove(self._handler)
 
-        if self.pppp:
+        release_pppp = (not self.wanted) or (not self.video_enabled) or getattr(app.svc, "shutting_down", False) or self._recycle_pppp_on_restart
+        if self.pppp and self._pppp_ref_held and release_pppp:
+            if self._recycle_pppp_on_restart:
+                log.info("VideoQueue: releasing PPPP so it can be recycled for video recovery")
+                self._awaiting_pppp_recycle = True
             app.svc.put("pppp")
+            self._pppp_ref_held = False
             self.pppp = None
+        elif self.pppp and self._pppp_ref_held:
+            log.info("VideoQueue: keeping PPPP borrowed across video worker restart")
+
         self._live_active = False
         self._last_start_live_at = 0.0
         self.api_id = None
         self._live_started_at = None
+        if self._recycle_pppp_on_restart and self.wanted and self.video_enabled:
+            log.info("VideoQueue: PPPP will be reacquired on the next worker start")
+        self._recycle_pppp_on_restart = False
+
+
+    def viewer_connected(self):
+        self._viewer_count += 1
+        return self._viewer_count
+
+    def viewer_disconnected(self):
+        if self._viewer_count > 0:
+            self._viewer_count -= 1
+        if self._viewer_count == 0 and self._pending_disable:
+            log.info("VideoQueue: last viewer disconnected; clearing stale deferred disable")
+            self._pending_disable = False
+        elif self._viewer_count == 0 and not self.video_enabled and self.state == RunState.Running:
+            log.info("VideoQueue: last viewer disconnected; stopping disabled video service")
+            self.stop()
+        return self._viewer_count
 
     def set_video_enabled(self, enabled):
-        self.persistent = enabled
-        if enabled == self.video_enabled:
-            return True
-
-        self.video_enabled = enabled
-        if not enabled:
-            self.last_frame_at = None
         if enabled:
+            self._pending_disable = False
+            self.persistent = True
+            if self.video_enabled:
+                return True
+            self.video_enabled = True
             self._enable_generation += 1
             if self.state == RunState.Stopped:
                 self.start()
-        else:
-            if self.state == RunState.Running:
-                self.stop()
+            return True
+
+        self.persistent = False
+        if not self.video_enabled and not self._pending_disable:
+            return True
+
+        self._pending_disable = False
+        self.video_enabled = False
+        self._live_active = False
+        self._live_started_at = None
+        self.last_frame_at = None
+        self._last_start_live_at = 0.0
+        self._last_no_frame_log_at = 0.0
+        self._last_live_refresh_at = 0.0
+        self._stall_retry_count = 0
+        self._awaiting_pppp_recycle = False
+        self._pppp_recycle_requested_at = None
+        if self._viewer_count > 0:
+            log.info(f"VideoQueue: disabling video; stopping service with {self._viewer_count} video client(s) connected")
+        if self.state in (RunState.Starting, RunState.Running):
+            self.stop()
+        elif self.state in (RunState.Stopping, RunState.Stopped):
+            self.wanted = False
         return True


### PR DESCRIPTION
Fixed Stop, Pause, and Resume handling so the web UI stays in sync with printer firmware, including resume variants and more compatible active-print stop payloads.
Fixed the Stop button freeze by removing the fake UI STOPPING lock and removing extra cooldown GCode from the same click.
Added printer state tracing to map firmware behavior, then cleaned up the noisy logs afterward.
Fixed double homing by matching the official app’s native MQTT homing command instead of raw G28.
Updated Home All to use the same proven homing path as Home Z.
Improved MQTT monitor/debug capture so it can watch more topics and label traffic direction.
Fixed Snapshot handling with non-blocking error banners, FFmpeg detection, install support, and cleaner timeout messages.
Fixed Timelapse so it finds FFmpeg correctly, starts reliably when the filename arrives late, and resumes saved captures more safely.
Reduced unnecessary backend and frontend log noise, especially PPPP/video recovery spam.
Fixed a video-stream memory growth risk by bounding per-client realtime stream queues.
Installed and validated Node.js and FFmpeg for JS checks and snapshot/timelapse support.
Added and updated regression tests around printer control, homing, timelapse, video streaming, and service behavior.