### PR TITLE
History Duplicate Fix

### DIFF
--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -495,6 +495,10 @@ $(function () {
         capturing: false,
         recovering: false,
         detail: null,
+        promptStart: false,
+        promptFilename: null,
+        resumeAvailable: false,
+        resumeFrameCount: 0,
     };
 
     function setFilamentState(label, detail = null, detailTone = null) {
@@ -586,6 +590,46 @@ $(function () {
         }
     }
 
+    function renderTimelapseActionCard() {
+        const card = document.getElementById("timelapse-action-card");
+        const title = document.getElementById("timelapse-action-title");
+        const detail = document.getElementById("timelapse-action-detail");
+        const startBtn = document.getElementById("timelapse-action-start");
+        const dismissBtn = document.getElementById("timelapse-action-dismiss");
+        if (!card || !title || !detail || !startBtn || !dismissBtn) {
+            return;
+        }
+
+        if (!_timelapseRuntime.promptStart || _timelapseRuntime.capturing) {
+            card.style.display = "none";
+            return;
+        }
+
+        const fileName = String(_timelapseRuntime.promptFilename || "this print").trim() || "this print";
+        const frameCount = Number(_timelapseRuntime.resumeFrameCount || 0);
+        const canResume = !!_timelapseRuntime.resumeAvailable && frameCount > 0;
+        title.textContent = canResume
+            ? "Resume timelapse for active print"
+            : "Start timelapse for active print";
+        detail.textContent = canResume
+            ? `${fileName} already has ${frameCount} saved frame${frameCount === 1 ? "" : "s"}. Continue or dismiss this pending capture.`
+            : `${fileName} is already printing. Continue or dismiss timelapse capture for this print.`;
+        startBtn.textContent = canResume ? "Continue Timelapse" : "Start Timelapse";
+        card.style.display = "";
+    }
+
+    async function sendTimelapseCurrentAction(endpoint, successMessage) {
+        const resp = await fetch(endpoint, { method: "POST" });
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+            throw new Error(data.error || `HTTP ${resp.status}`);
+        }
+        applyRuntimeState(data);
+        if (successMessage) {
+            flash_message(successMessage, "success", 4000);
+        }
+    }
+
     function applyRuntimeState(data) {
         if (!data || typeof data !== "object") {
             return;
@@ -601,16 +645,21 @@ $(function () {
         _timelapseRuntime.capturing = !!timelapse.capturing;
         _timelapseRuntime.recovering = !!timelapse.recovering;
         _timelapseRuntime.detail = timelapse.detail || null;
+        _timelapseRuntime.promptStart = !!timelapse.prompt_start;
+        _timelapseRuntime.promptFilename = timelapse.prompt_filename || null;
+        _timelapseRuntime.resumeAvailable = !!timelapse.resume_available;
+        _timelapseRuntime.resumeFrameCount = Number(timelapse.resume_frame_count || 0);
 
         if (data.print && data.print.state !== undefined) {
             _updatePrintControlButtons(_normalizePrintStateValue(data.print.state));
         }
         renderFilamentStatus();
         renderTimelapseRuntimeStatus();
+        renderTimelapseActionCard();
     }
 
     async function loadPrinterRuntimeState() {
-        if (!document.getElementById("filament-state") || _printerRuntimeLoading) {
+        if (_printerRuntimeLoading) {
             return;
         }
         _printerRuntimeLoading = true;
@@ -627,9 +676,6 @@ $(function () {
     }
 
     function startPrinterRuntimePolling() {
-        if (!document.getElementById("filament-state")) {
-            return;
-        }
         loadPrinterRuntimeState().catch(function (err) {
             console.warn("Failed to load printer runtime state", err);
         });
@@ -3551,6 +3597,9 @@ $(function () {
     let _timelapseInterval = null;
     if (timelapseTabBtn) {
         timelapseTabBtn.addEventListener("shown.bs.tab", function () {
+            loadPrinterRuntimeState().catch(function (err) {
+                console.warn("Failed to refresh timelapse runtime state", err);
+            });
             loadTimelapses();
             if (!_timelapseInterval) {
                 _timelapseInterval = setInterval(loadTimelapses, 15000);
@@ -3563,6 +3612,31 @@ $(function () {
             }
         });
     }
+
+    $("#timelapse-action-start").on("click", async function () {
+        const btn = $(this);
+        const fileName = String(_timelapseRuntime.promptFilename || "this print").trim() || "this print";
+        btn.prop("disabled", true);
+        try {
+            await sendTimelapseCurrentAction("/api/timelapse/current/start", `Timelapse started for ${fileName}.`);
+        } catch (err) {
+            flash_message(`Timelapse start failed: ${err.message || err}`, "danger", 6000);
+        } finally {
+            btn.prop("disabled", false);
+        }
+    });
+
+    $("#timelapse-action-dismiss").on("click", async function () {
+        const btn = $(this);
+        btn.prop("disabled", true);
+        try {
+            await sendTimelapseCurrentAction("/api/timelapse/current/dismiss", "Pending timelapse capture dismissed.");
+        } catch (err) {
+            flash_message(`Dismiss failed: ${err.message || err}`, "danger", 6000);
+        } finally {
+            btn.prop("disabled", false);
+        }
+    });
 
     // Delete timelapse (list button or player delete button)
     $(document).on("click", ".timelapse-delete", function () {

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1707,6 +1707,10 @@ $(function () {
         $("#print-pause").prop("disabled", stopping);
         $("#print-resume").prop("disabled", stopping);
         $("#print-stop").prop("disabled", stopping);
+        updateGCodeStorageControls();
+        if (!isGCodeStorageLocked()) {
+            maybeRefreshGCodeStorageAfterUnlock();
+        }
     }
 
     const getStepDist = () => $('input[name="step-dist"]:checked').val() || "1";
@@ -2398,6 +2402,22 @@ $(function () {
     }
 
     let _selectedGCodeStorageFile = null;
+    let _gcodeStorageLoading = false;
+    let _gcodeStorageRefreshDeferred = false;
+
+    function isGCodeStorageLocked() {
+        const normalizedState = _normalizePrintStateValue(_currentPrintState);
+        return normalizedState === PRINT_STATE.PRINTING
+            || normalizedState === PRINT_STATE.PAUSED
+            || normalizedState === PRINT_STATE.CALIBRATING
+            || normalizedState === PRINT_STATE.STOPPING
+            || normalizedState === PRINT_STATE.PENDING_START;
+    }
+
+    function isGCodeTabVisible() {
+        const pane = document.getElementById("gcode");
+        return !!(pane && pane.classList.contains("show"));
+    }
 
     function buildGCodeThumbnail(url, altText) {
         const safeAlt = escapeHtml(altText || "GCode thumbnail");
@@ -2422,13 +2442,37 @@ $(function () {
     }
 
     function setGCodeStoragePrintEnabled(enabled) {
-        $("#gcode-storage-print").prop("disabled", !enabled);
+        $("#gcode-storage-print").prop("disabled", !enabled || _gcodeStorageLoading || isGCodeStorageLocked());
     }
 
     function setGCodeStorageBusy(busy) {
-        $("#gcode-storage-refresh").prop("disabled", busy);
-        $("#gcode-storage-source").prop("disabled", busy);
-        $("#gcode-storage-print").prop("disabled", busy || !_selectedGCodeStorageFile);
+        _gcodeStorageLoading = busy;
+        updateGCodeStorageControls();
+    }
+
+    function updateGCodeStorageControls() {
+        const busy = _gcodeStorageLoading;
+        const locked = isGCodeStorageLocked();
+        $("#gcode-storage-refresh").prop("disabled", busy || locked);
+        $("#gcode-storage-source").prop("disabled", busy || locked);
+        $("#gcode-storage-print").prop("disabled", busy || locked || !_selectedGCodeStorageFile);
+        $("#gcode-storage-lock-note").toggleClass("d-none", !locked);
+    }
+
+    function deferGCodeStorageRefresh(message) {
+        _gcodeStorageRefreshDeferred = true;
+        updateGCodeStorageControls();
+        if (message) {
+            $("#gcode-storage-status").text(message);
+        }
+    }
+
+    function maybeRefreshGCodeStorageAfterUnlock() {
+        if (!_gcodeStorageRefreshDeferred || _gcodeStorageLoading || isGCodeStorageLocked() || !isGCodeTabVisible()) {
+            return;
+        }
+        _gcodeStorageRefreshDeferred = false;
+        loadGCodeStorageFiles();
     }
 
     function renderGCodeStorageSelection(file) {
@@ -2518,8 +2562,15 @@ $(function () {
     async function loadGCodeStorageFiles() {
         const source = $("#gcode-storage-source").val() || "onboard";
         const status = $("#gcode-storage-status");
+        const lockedMessage = `File list is paused while the printer is busy. It will refresh after the print stops.`;
+
+        if (isGCodeStorageLocked()) {
+            deferGCodeStorageRefresh(lockedMessage);
+            return;
+        }
 
         setGCodeStorageBusy(true);
+        _gcodeStorageRefreshDeferred = false;
         status.text(`Loading ${gcodeStorageSourceLabel(source)} files...`);
         try {
             const resp = await fetch(`/api/files/printer?source=${encodeURIComponent(source)}`);
@@ -2527,8 +2578,16 @@ $(function () {
             if (!resp.ok) {
                 throw new Error(data.error || `HTTP ${resp.status}`);
             }
+            if (isGCodeStorageLocked()) {
+                deferGCodeStorageRefresh(lockedMessage);
+                return;
+            }
             renderGCodeStorageFiles(source, data.files || []);
         } catch (err) {
+            if (isGCodeStorageLocked()) {
+                deferGCodeStorageRefresh(lockedMessage);
+                return;
+            }
             $("#gcode-storage-list").html(
                 `<div class="list-group-item text-danger small">Failed to load ${escapeHtml(gcodeStorageSourceLabel(source))}: ${escapeHtml(err.message)}</div>`
             );
@@ -2679,6 +2738,12 @@ $(function () {
             flash_message("Select a stored file before printing.", "warning");
             return;
         }
+        if (isGCodeStorageLocked()) {
+            gcodeLog("Stored file actions are paused while the printer is busy");
+            flash_message("The printer is busy right now. Wait for it to return to idle before browsing or starting another stored file.", "warning");
+            deferGCodeStorageRefresh("File list is paused while the printer is busy. It will refresh after the print stops.");
+            return;
+        }
 
         const source = _selectedGCodeStorageFile.source || $("#gcode-storage-source").val() || "onboard";
         const fileName = _selectedGCodeStorageFile.name || "stored file";
@@ -2729,6 +2794,8 @@ $(function () {
             loadGCodeStorageFiles();
         });
     }
+
+    updateGCodeStorageControls();
 
     $("#print-pause").on("click", function () {
         sendPrintControl(PRINT_CONTROL.PAUSE);

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -118,31 +118,65 @@ $(function () {
         return `${size.toFixed(precision)} ${units[unit]}`;
     }
 
-    function flash_message(message, category = "info", timeout = 7500) {
+    function flash_message(message, category = "info", timeout = 7500, options = {}) {
         const messages = $("#messages");
         if (!messages.length) {
             console.log(`[${category}] ${message}`);
             return;
         }
+        const sticky = timeout === 0 || options.sticky === true;
+        const stickyKey = sticky ? String(options.key || "") : "";
+        if (stickyKey && _activeStickyAlerts.has(stickyKey)) {
+            return;
+        }
         const alert = $("<div>");
         alert.addClass(`alert alert-${category} alert-dismissible fade show`);
-        alert.attr("data-timeout", timeout);
         alert.attr("role", "alert");
+        if (!sticky) {
+            alert.attr("data-timeout", timeout);
+        } else if (stickyKey) {
+            _activeStickyAlerts.add(stickyKey);
+            alert.attr("data-sticky-key", stickyKey);
+        }
 
-        const closeBtn = $("<button>");
-        closeBtn.attr("type", "button");
-        closeBtn.addClass("btn-close btn-sm btn-close-white");
-        closeBtn.attr("data-bs-dismiss", "alert");
-        closeBtn.attr("aria-label", "Close");
+        const body = $("<div>");
+        body.addClass("d-flex align-items-center justify-content-between gap-3");
 
-        alert.append(closeBtn);
-        alert.append(document.createTextNode(message));
+        const messageText = $("<div>");
+        messageText.addClass("flex-grow-1");
+        messageText.text(String(message || ""));
+        body.append(messageText);
+
+        if (sticky) {
+            const ackBtn = $("<button>");
+            ackBtn.attr("type", "button");
+            ackBtn.addClass("btn btn-sm btn-light flex-shrink-0");
+            ackBtn.attr("data-bs-dismiss", "alert");
+            ackBtn.text("OK");
+            body.append(ackBtn);
+        } else {
+            const closeBtn = $("<button>");
+            closeBtn.attr("type", "button");
+            closeBtn.addClass("btn-close btn-sm btn-close-white flex-shrink-0");
+            closeBtn.attr("data-bs-dismiss", "alert");
+            closeBtn.attr("aria-label", "Close");
+            body.append(closeBtn);
+        }
+
+        alert.append(body);
         messages.append(alert);
 
         const bsalert = new bootstrap.Alert(alert[0]);
-        setTimeout(() => {
-            bsalert.close();
-        }, timeout);
+        if (stickyKey) {
+            alert.on("closed.bs.alert", function () {
+                _activeStickyAlerts.delete(stickyKey);
+            });
+        }
+        if (!sticky && timeout > 0) {
+            setTimeout(() => {
+                bsalert.close();
+            }, timeout);
+        }
     }
 
     /**
@@ -160,6 +194,8 @@ $(function () {
     const HOME_CONSOLE_INITIAL_LIMIT = 200;
     const HOME_CONSOLE_MAX_LINES = 400;
     const HOME_CONSOLE_POLL_MS = 2000;
+    const PRINTER_ALERT_POLL_MS = 4000;
+    const PRINTER_RUNTIME_POLL_MS = 5000;
 
     let _homeConsoleEntries = [];
     let _homeConsoleLastId = 0;
@@ -169,6 +205,11 @@ $(function () {
     let _homeConsoleAutoScrollPaused = false;
     let _homeConsoleClearedBeforeId = 0;
     let _homeConsoleWasCleared = false;
+    let _printerAlertLastId = 0;
+    let _printerAlertPollStarted = false;
+    let _printerRuntimeLoading = false;
+    let _printerRuntimePollInterval = null;
+    const _activeStickyAlerts = new Set();
 
     function setHomeConsoleStatus(message) {
         const status = $("#home-console-status");
@@ -448,25 +489,15 @@ $(function () {
         detail: null,
         issue: null,
         pauseReason: null,
+        pendingRunout: false,
+    };
+    const _timelapseRuntime = {
+        capturing: false,
+        recovering: false,
+        detail: null,
     };
 
-    function setPrintStatusDetail(message, tone = "warning") {
-        const el = $("#print-status-detail");
-        if (!el.length) {
-            return;
-        }
-        const value = String(message || "").trim();
-        el.removeClass("d-none text-warning text-danger text-muted text-success");
-        if (!value) {
-            el.text("");
-            el.addClass("d-none");
-            return;
-        }
-        el.text(value);
-        el.addClass(`text-${tone}`);
-    }
-
-    function setFilamentState(label, detail = null) {
+    function setFilamentState(label, detail = null, detailTone = null) {
         const el = $("#filament-state");
         const detailEl = $("#filament-state-detail");
         if (!el.length) {
@@ -488,24 +519,70 @@ $(function () {
 
         if (detailEl.length) {
             const detailText = String(detail || "").trim();
+            detailEl.removeClass("d-none text-danger text-warning text-muted text-success");
             detailEl.text(detailText);
             detailEl.toggleClass("d-none", !detailText);
+            if (detailText) {
+                detailEl.addClass(`text-${detailTone || "muted"}`);
+            }
         }
     }
 
     function renderFilamentStatus() {
         const pausedForFilament = _currentPrintState === PRINT_STATE.PAUSED && !!_filamentStatus.pauseReason;
+        const unverifiedFilamentState = _currentPrintState !== PRINT_STATE.PRINTING
+            && _currentPrintState !== PRINT_STATE.PAUSED
+            && _filamentStatus.label === "Loaded"
+            && !_filamentStatus.issue;
+        let label = _filamentStatus.label || "Unknown";
         let detail = _filamentStatus.detail || null;
+        let detailTone = "muted";
 
+        if (unverifiedFilamentState) {
+            label = "Unknown";
+            detail = detail || "Filament presence cannot be confirmed until the printer starts printing.";
+            detailTone = "muted";
+        }
         if (!detail && pausedForFilament && _filamentStatus.label === "Loaded") {
             detail = "Filament loaded. Resume the print when ready.";
+            detailTone = "success";
+        }
+        if (!detail && pausedForFilament) {
+            detail = `Paused: ${_filamentStatus.pauseReason}`;
+            detailTone = "warning";
+        }
+        if (_filamentStatus.issue === "runout") {
+            detailTone = pausedForFilament ? "warning" : "danger";
+        } else if (label === "Changing") {
+            detailTone = "warning";
+        } else if (label === "Loaded" && detail) {
+            detailTone = "success";
         }
 
-        setFilamentState(_filamentStatus.label || "Unknown", detail);
-        if (pausedForFilament) {
-            setPrintStatusDetail(`Paused: ${_filamentStatus.pauseReason}`, "warning");
+        setFilamentState(label, detail, detailTone);
+    }
+
+    function renderTimelapseRuntimeStatus() {
+        const el = $("#timelapse-runtime-detail");
+        if (!el.length) {
+            return;
+        }
+
+        const detailText = String(_timelapseRuntime.detail || "").trim();
+        el.removeClass("d-none text-warning text-muted text-success");
+        el.text(detailText);
+
+        if (!detailText) {
+            el.addClass("d-none");
+            return;
+        }
+
+        if (_timelapseRuntime.recovering) {
+            el.addClass("text-warning");
+        } else if (_timelapseRuntime.capturing) {
+            el.addClass("text-success");
         } else {
-            setPrintStatusDetail(null);
+            el.addClass("text-muted");
         }
     }
 
@@ -519,24 +596,110 @@ $(function () {
         _filamentStatus.detail = filament.detail || null;
         _filamentStatus.issue = filament.issue || null;
         _filamentStatus.pauseReason = filament.pause_reason_label || null;
+        _filamentStatus.pendingRunout = false;
+        const timelapse = data.timelapse || {};
+        _timelapseRuntime.capturing = !!timelapse.capturing;
+        _timelapseRuntime.recovering = !!timelapse.recovering;
+        _timelapseRuntime.detail = timelapse.detail || null;
 
         if (data.print && data.print.state !== undefined) {
             _updatePrintControlButtons(_normalizePrintStateValue(data.print.state));
-            return;
         }
         renderFilamentStatus();
+        renderTimelapseRuntimeStatus();
     }
 
     async function loadPrinterRuntimeState() {
+        if (!document.getElementById("filament-state") || _printerRuntimeLoading) {
+            return;
+        }
+        _printerRuntimeLoading = true;
+        try {
+            const resp = await fetch("/api/printer/runtime-state");
+            const data = await resp.json().catch(() => ({}));
+            if (!resp.ok) {
+                throw new Error(data.error || `HTTP ${resp.status}`);
+            }
+            applyRuntimeState(data);
+        } finally {
+            _printerRuntimeLoading = false;
+        }
+    }
+
+    function startPrinterRuntimePolling() {
         if (!document.getElementById("filament-state")) {
             return;
         }
-        const resp = await fetch("/api/printer/runtime-state");
+        loadPrinterRuntimeState().catch(function (err) {
+            console.warn("Failed to load printer runtime state", err);
+        });
+        if (_printerRuntimePollInterval) {
+            return;
+        }
+        _printerRuntimePollInterval = setInterval(function () {
+            loadPrinterRuntimeState().catch(function (err) {
+                console.warn("Failed to load printer runtime state", err);
+            });
+        }, PRINTER_RUNTIME_POLL_MS);
+    }
+
+    function getActivePrinterIndex() {
+        const raw = document.body ? document.body.dataset.activePrinterIndex : null;
+        const parsed = Number(raw);
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+        return 0;
+    }
+
+    function processPrinterAlertEntries(entries, notifyUser) {
+        if (!Array.isArray(entries) || !entries.length) {
+            return;
+        }
+        const activePrinterIndex = getActivePrinterIndex();
+        entries.forEach(function (entry) {
+            if (!notifyUser || !entry || Number(entry.printer_index) === activePrinterIndex) {
+                return;
+            }
+            const printerName = String(entry.printer_name || `Printer ${Number(entry.printer_index || 0) + 1}`);
+            const title = String(entry.title || "Printer alert");
+            const message = String(entry.message || title);
+            flash_message(`${printerName}: ${message}`, entry.level || "warning", 0, {
+                sticky: true,
+                key: `printer-alert:${Number(entry.printer_index || 0)}:${String(entry.type || title)}`,
+            });
+        });
+    }
+
+    async function pollPrinterAlerts() {
+        const params = new URLSearchParams({ limit: "20" });
+        if (_printerAlertLastId > 0) {
+            params.set("after", String(_printerAlertLastId));
+        }
+        const resp = await fetch(`/api/printer/alerts?${params.toString()}`);
         const data = await resp.json().catch(() => ({}));
         if (!resp.ok) {
             throw new Error(data.error || `HTTP ${resp.status}`);
         }
-        applyRuntimeState(data);
+
+        const notifyUser = _printerAlertPollStarted;
+        processPrinterAlertEntries(data.entries || [], notifyUser);
+        _printerAlertLastId = data.last_id || _printerAlertLastId;
+        _printerAlertPollStarted = true;
+    }
+
+    function startPrinterAlertPolling() {
+        if (!document.getElementById("messages")) {
+            return;
+        }
+        pollPrinterAlerts().catch(function (err) {
+            console.warn("Failed to poll printer alerts", err);
+        });
+        setInterval(function () {
+            pollPrinterAlerts().catch(function (err) {
+                console.warn("Failed to poll printer alerts", err);
+            });
+        }, PRINTER_ALERT_POLL_MS);
     }
 
     /**
@@ -818,10 +981,39 @@ $(function () {
                 return;
             }
             if (data.commandType == 1000) {
+                if (Number(data.subType) === 2 && Number(data.value) === 6) {
+                    _filamentStatus.pendingRunout = false;
+                    _filamentStatus.label = "Not Loaded";
+                    _filamentStatus.detail = _currentPrintState === PRINT_STATE.PAUSED
+                        ? "Paused: Filament runout. Reload filament to continue."
+                        : "Filament runout or break detected.";
+                    _filamentStatus.issue = "runout";
+                    _filamentStatus.pauseReason = "Filament runout";
+                    renderFilamentStatus();
+                    return;
+                }
                 // Printer state machine: normalize firmware resume acknowledgements for UI controls.
                 const normalizedState = _normalizePrintStateValue(data.value);
+                const wasPausedForFilament = _currentPrintState === PRINT_STATE.PAUSED
+                    && !!_filamentStatus.pauseReason
+                    && _filamentStatus.issue === "runout";
+                if (normalizedState === PRINT_STATE.PAUSED && _filamentStatus.pendingRunout && _filamentStatus.issue !== "runout") {
+                    _filamentStatus.pendingRunout = false;
+                    _filamentStatus.label = "Not Loaded";
+                    _filamentStatus.detail = "Paused: Filament runout. Reload filament to continue.";
+                    _filamentStatus.issue = "runout";
+                    _filamentStatus.pauseReason = "Filament runout";
+                }
+                if (normalizedState === PRINT_STATE.PRINTING && wasPausedForFilament) {
+                    _filamentStatus.label = "Loaded";
+                    _filamentStatus.detail = null;
+                    _filamentStatus.issue = null;
+                }
                 if (normalizedState !== PRINT_STATE.PAUSED) {
                     _filamentStatus.pauseReason = null;
+                    if (_filamentStatus.issue !== "runout") {
+                        _filamentStatus.pendingRunout = false;
+                    }
                 }
                 _updatePrintControlButtons(normalizedState);
                 if (typeof _onMqttStateChange === "function") {
@@ -886,20 +1078,36 @@ $(function () {
                 }
             } else if (data.commandType == 1021) {
                 applyZOffsetState(data, { populateTarget: false });
+            } else if (data.commandType == 1085 && String(data.errorCode || "") === "0xFF01030001") {
+                _filamentStatus.pendingRunout = true;
+            } else if (data.commandType == 1086 && String(data.errorCode || "") === "0xFF01030001") {
+                if (_filamentStatus.issue !== "runout") {
+                    _filamentStatus.pendingRunout = false;
+                }
             } else if (isFilamentRunoutEvent(data)) {
+                _filamentStatus.pendingRunout = false;
                 _filamentStatus.label = "Not Loaded";
                 _filamentStatus.detail = _currentPrintState === PRINT_STATE.PAUSED
-                    ? "Printer paused for filament reload."
+                    ? "Paused: Filament runout. Reload filament to continue."
                     : "Filament runout or break detected.";
                 _filamentStatus.issue = "runout";
                 _filamentStatus.pauseReason = "Filament runout";
                 renderFilamentStatus();
             } else if (data.commandType == 1023) {
                 const label = getFilamentStateLabel(data.value, data.progress, data.stepLen);
-                _filamentStatus.label = label;
-                _filamentStatus.detail = getFilamentStateDetail(label, data.progress);
-                if (label === "Changing" || label === "Loaded") {
+                const inFilamentRunoutPause = _currentPrintState === PRINT_STATE.PAUSED
+                    && !!_filamentStatus.pauseReason
+                    && _filamentStatus.issue === "runout";
+                if (inFilamentRunoutPause && label === "Loaded") {
+                    _filamentStatus.label = "Not Loaded";
+                    _filamentStatus.detail = null;
+                } else {
+                    _filamentStatus.label = label;
+                    _filamentStatus.detail = getFilamentStateDetail(label, data.progress);
+                }
+                if (!inFilamentRunoutPause && (label === "Changing" || label === "Loaded")) {
                     _filamentStatus.issue = null;
+                    _filamentStatus.pendingRunout = false;
                 }
                 renderFilamentStatus();
             } else if (data.commandType == 1044) {
@@ -933,6 +1141,7 @@ $(function () {
             _filamentStatus.detail = null;
             _filamentStatus.issue = null;
             _filamentStatus.pauseReason = null;
+            _filamentStatus.pendingRunout = false;
             renderFilamentStatus();
             document.title = "ankerctl";
             _updatePrintControlButtons(PRINT_STATE.IDLE);
@@ -1213,11 +1422,7 @@ $(function () {
     if ($("#upload-progressbar").length) {
         sockets.upload.connect();
     }
-    if (document.getElementById("filament-state")) {
-        loadPrinterRuntimeState().catch(function (err) {
-            console.warn("Failed to load printer runtime state", err);
-        });
-    }
+    startPrinterRuntimePolling();
 
     sockets.video.autoReconnect = false;
 
@@ -2909,6 +3114,7 @@ $(function () {
     }
 
     updateGCodeStorageControls();
+    startPrinterAlertPolling();
 
     $("#print-pause").on("click", function () {
         sendPrintControl(PRINT_CONTROL.PAUSE);

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -420,6 +420,17 @@ $(function () {
         return "Changing";
     }
 
+    function getFilamentStateDetail(label, progress) {
+        if (label !== "Changing") {
+            return null;
+        }
+        const parsedProgress = Number(progress);
+        if (Number.isFinite(parsedProgress) && parsedProgress > 0 && parsedProgress < 100) {
+            return `Filament swap in progress (${Math.round(parsedProgress)}%)`;
+        }
+        return "Filament swap in progress";
+    }
+
     function isFilamentRunoutEvent(data) {
         if (!data || typeof data !== "object") {
             return false;
@@ -432,8 +443,32 @@ $(function () {
             && Number(data.value) === 6;
     }
 
-    function setFilamentState(label) {
+    const _filamentStatus = {
+        label: "Unknown",
+        detail: null,
+        issue: null,
+        pauseReason: null,
+    };
+
+    function setPrintStatusDetail(message, tone = "warning") {
+        const el = $("#print-status-detail");
+        if (!el.length) {
+            return;
+        }
+        const value = String(message || "").trim();
+        el.removeClass("d-none text-warning text-danger text-muted text-success");
+        if (!value) {
+            el.text("");
+            el.addClass("d-none");
+            return;
+        }
+        el.text(value);
+        el.addClass(`text-${tone}`);
+    }
+
+    function setFilamentState(label, detail = null) {
         const el = $("#filament-state");
+        const detailEl = $("#filament-state-detail");
         if (!el.length) {
             return;
         }
@@ -450,6 +485,58 @@ $(function () {
         } else {
             el.addClass("text-muted");
         }
+
+        if (detailEl.length) {
+            const detailText = String(detail || "").trim();
+            detailEl.text(detailText);
+            detailEl.toggleClass("d-none", !detailText);
+        }
+    }
+
+    function renderFilamentStatus() {
+        const pausedForFilament = _currentPrintState === PRINT_STATE.PAUSED && !!_filamentStatus.pauseReason;
+        let detail = _filamentStatus.detail || null;
+
+        if (!detail && pausedForFilament && _filamentStatus.label === "Loaded") {
+            detail = "Filament loaded. Resume the print when ready.";
+        }
+
+        setFilamentState(_filamentStatus.label || "Unknown", detail);
+        if (pausedForFilament) {
+            setPrintStatusDetail(`Paused: ${_filamentStatus.pauseReason}`, "warning");
+        } else {
+            setPrintStatusDetail(null);
+        }
+    }
+
+    function applyRuntimeState(data) {
+        if (!data || typeof data !== "object") {
+            return;
+        }
+
+        const filament = data.filament || {};
+        _filamentStatus.label = String(filament.label || "Unknown");
+        _filamentStatus.detail = filament.detail || null;
+        _filamentStatus.issue = filament.issue || null;
+        _filamentStatus.pauseReason = filament.pause_reason_label || null;
+
+        if (data.print && data.print.state !== undefined) {
+            _updatePrintControlButtons(_normalizePrintStateValue(data.print.state));
+            return;
+        }
+        renderFilamentStatus();
+    }
+
+    async function loadPrinterRuntimeState() {
+        if (!document.getElementById("filament-state")) {
+            return;
+        }
+        const resp = await fetch("/api/printer/runtime-state");
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+            throw new Error(data.error || `HTTP ${resp.status}`);
+        }
+        applyRuntimeState(data);
     }
 
     /**
@@ -732,7 +819,11 @@ $(function () {
             }
             if (data.commandType == 1000) {
                 // Printer state machine: normalize firmware resume acknowledgements for UI controls.
-                _updatePrintControlButtons(_normalizePrintStateValue(data.value));
+                const normalizedState = _normalizePrintStateValue(data.value);
+                if (normalizedState !== PRINT_STATE.PAUSED) {
+                    _filamentStatus.pauseReason = null;
+                }
+                _updatePrintControlButtons(normalizedState);
                 if (typeof _onMqttStateChange === "function") {
                     _onMqttStateChange(data.value);
                 }
@@ -796,9 +887,21 @@ $(function () {
             } else if (data.commandType == 1021) {
                 applyZOffsetState(data, { populateTarget: false });
             } else if (isFilamentRunoutEvent(data)) {
-                setFilamentState("Not Loaded");
+                _filamentStatus.label = "Not Loaded";
+                _filamentStatus.detail = _currentPrintState === PRINT_STATE.PAUSED
+                    ? "Printer paused for filament reload."
+                    : "Filament runout or break detected.";
+                _filamentStatus.issue = "runout";
+                _filamentStatus.pauseReason = "Filament runout";
+                renderFilamentStatus();
             } else if (data.commandType == 1023) {
-                setFilamentState(getFilamentStateLabel(data.value, data.progress, data.stepLen));
+                const label = getFilamentStateLabel(data.value, data.progress, data.stepLen);
+                _filamentStatus.label = label;
+                _filamentStatus.detail = getFilamentStateDetail(label, data.progress);
+                if (label === "Changing" || label === "Loaded") {
+                    _filamentStatus.issue = null;
+                }
+                renderFilamentStatus();
             } else if (data.commandType == 1044) {
                 // Print start notification — extract basename from filePath
                 const filePath = data.filePath || "";
@@ -826,7 +929,11 @@ $(function () {
             $("#set-bed-temp").val(0);
             $("#print-speed").text("0mm/s");
             $("#print-layer").text("0 / 0");
-            setFilamentState("Unknown");
+            _filamentStatus.label = "Unknown";
+            _filamentStatus.detail = null;
+            _filamentStatus.issue = null;
+            _filamentStatus.pauseReason = null;
+            renderFilamentStatus();
             document.title = "ankerctl";
             _updatePrintControlButtons(PRINT_STATE.IDLE);
             _zOffsetCurrentMm = null;
@@ -1105,6 +1212,11 @@ $(function () {
     }
     if ($("#upload-progressbar").length) {
         sockets.upload.connect();
+    }
+    if (document.getElementById("filament-state")) {
+        loadPrinterRuntimeState().catch(function (err) {
+            console.warn("Failed to load printer runtime state", err);
+        });
     }
 
     sockets.video.autoReconnect = false;
@@ -1711,6 +1823,7 @@ $(function () {
         if (!isGCodeStorageLocked()) {
             maybeRefreshGCodeStorageAfterUnlock();
         }
+        renderFilamentStatus();
     }
 
     const getStepDist = () => $('input[name="step-dist"]:checked').val() || "1";

--- a/static/base.html
+++ b/static/base.html
@@ -13,7 +13,7 @@
     {%- block head %}{% endblock head %}
 </head>
 
-<body>
+<body data-active-printer-index="{{ active_printer_index|default(0) }}">
     <!-- Header -->
     <div class="bg-dark bg-gradient mb-3">
         <header class="container d-flex align-items-center py-2">

--- a/static/tabs/gcode.html
+++ b/static/tabs/gcode.html
@@ -81,6 +81,9 @@
                             Browse GCode files already stored on printer storage or an attached thumb drive.
                             The first file is selected automatically after a refresh, and you can click any other file before starting it.
                         </div>
+                        <div class="small text-warning mb-2 d-none" id="gcode-storage-lock-note">
+                            File browsing is paused while the printer is busy. The list will refresh after the print stops.
+                        </div>
                         <div class="small text-muted mb-2" id="gcode-storage-status">Choose a source and refresh to browse files.</div>
                         <div id="gcode-storage-selected" class="alert alert-secondary py-2 small mb-3" style="display:none;"></div>
                         <div class="d-grid mb-3">

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -364,6 +364,9 @@
                                     </button>
                                 </div>
                             </div>
+                            <div class="col-12 text-center">
+                                <div id="print-status-detail" class="small text-warning d-none"></div>
+                            </div>
                         </div>
                         <div class="row g-3">
                             <div class="col-md-6">
@@ -398,6 +401,7 @@
                                         Unknown
                                     </span>
                                 </div>
+                                <div id="filament-state-detail" class="form-text text-center small d-none"></div>
                             </div>
                         </div>
                     </div>

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -409,41 +409,48 @@
         <div class="row g-3 mt-1">
             <div class="col-12">
                 <div class="card">
-                    <div class="card-header">
-                        <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-2">
-                            <div class="d-flex flex-column">
-                                <span class="fs-6">Live Console</span>
-                                <span class="small text-muted" id="home-console-status">Loading recent output...</span>
-                            </div>
-                            <div class="d-flex flex-wrap gap-2">
-                                <button type="button" class="btn btn-sm btn-outline-secondary" id="home-console-clear">
-                                    {{ macro.bi_icon("eraser") }} Clear
-                                </button>
-                                <button type="button" class="btn btn-sm btn-outline-secondary" id="home-console-autoscroll-toggle"
-                                    aria-pressed="false">
-                                    {{ macro.bi_icon("pause-circle") }} Pause Auto-Scroll
-                                </button>
-                            </div>
+                    <div class="card-header d-flex align-items-center justify-content-between gap-2">
+                        <div class="d-flex flex-column">
+                            <span class="fs-6">Live Console</span>
+                            <span class="small text-muted" id="home-console-status">Loading recent output...</span>
                         </div>
-                        <div class="d-flex flex-wrap align-items-center gap-1 mt-2">
-                            <span class="small text-muted me-1">Filter:</span>
-                            <button type="button" class="btn btn-sm btn-outline-secondary active" data-home-console-filter="all"
-                                aria-pressed="true">All</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="mqtt"
-                                aria-pressed="false">MQTT</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="pppp"
-                                aria-pressed="false">PPPP</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="video"
-                                aria-pressed="false">Video</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="upload"
-                                aria-pressed="false">Upload</button>
-                            <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="error"
-                                aria-pressed="false">Error</button>
-                        </div>
+                        <button class="btn btn-sm btn-outline-secondary collapse-toggle" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#home-console-section" aria-expanded="true"
+                            aria-controls="home-console-section">
+                            {{ macro.bi_icon("chevron-down") }}
+                        </button>
                     </div>
-                    <div class="card-body p-0">
-                        <pre id="home-console-pre" class="bg-dark text-light p-3 m-0 border-0 small font-monospace"
-                            style="height: 260px; overflow-y: auto; white-space: pre-wrap;"><code id="home-console-content">Loading console output...</code></pre>
+                    <div class="collapse show" id="home-console-section">
+                        <div class="card-body p-0">
+                            <div class="d-flex flex-column gap-2 p-3 pb-0">
+                                <div class="d-flex flex-wrap gap-2">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="home-console-clear">
+                                        {{ macro.bi_icon("eraser") }} Clear
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="home-console-autoscroll-toggle"
+                                        aria-pressed="false">
+                                        {{ macro.bi_icon("pause-circle") }} Pause Auto-Scroll
+                                    </button>
+                                </div>
+                                <div class="d-flex flex-wrap align-items-center gap-1">
+                                    <span class="small text-muted me-1">Filter:</span>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary active" data-home-console-filter="all"
+                                        aria-pressed="true">All</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="mqtt"
+                                        aria-pressed="false">MQTT</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="pppp"
+                                        aria-pressed="false">PPPP</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="video"
+                                        aria-pressed="false">Video</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="upload"
+                                        aria-pressed="false">Upload</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" data-home-console-filter="error"
+                                        aria-pressed="false">Error</button>
+                                </div>
+                            </div>
+                            <pre id="home-console-pre" class="bg-dark text-light p-3 mt-3 mb-0 border-0 small font-monospace"
+                                style="height: 260px; overflow-y: auto; white-space: pre-wrap;"><code id="home-console-content">Loading console output...</code></pre>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -364,9 +364,6 @@
                                     </button>
                                 </div>
                             </div>
-                            <div class="col-12 text-center">
-                                <div id="print-status-detail" class="small text-warning d-none"></div>
-                            </div>
                         </div>
                         <div class="row g-3">
                             <div class="col-md-6">
@@ -402,6 +399,7 @@
                                     </span>
                                 </div>
                                 <div id="filament-state-detail" class="form-text text-center small d-none"></div>
+                                <div id="timelapse-runtime-detail" class="form-text text-center small d-none"></div>
                             </div>
                         </div>
                     </div>

--- a/static/tabs/timelapse.html
+++ b/static/tabs/timelapse.html
@@ -4,6 +4,24 @@
             {{ macro.bi_icon("exclamation-triangle") }}
             Timelapse is disabled. Enable it in <strong>Setup → Timelapse</strong>.
         </div>
+        <div id="timelapse-action-card" class="card border-warning mb-3" style="display:none;">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+                    <div>
+                        <div class="fw-semibold" id="timelapse-action-title">Active print detected</div>
+                        <div class="text-muted small" id="timelapse-action-detail"></div>
+                    </div>
+                    <div class="d-flex gap-2 flex-shrink-0">
+                        <button type="button" class="btn btn-success" id="timelapse-action-start">
+                            {{ macro.bi_icon("play-fill") }} Continue Timelapse
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" id="timelapse-action-dismiss">
+                            Dismiss
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="row g-3">
             <!-- Left: Video player -->
             <div class="col-lg-8">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+
+# Ensure plain `pytest` can import the repo's top-level modules on Windows
+# without requiring a manual PYTHONPATH override.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+repo_root_str = str(REPO_ROOT)
+if repo_root_str not in sys.path:
+    sys.path.insert(0, repo_root_str)

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -243,6 +243,48 @@ def test_handle_notification_records_cross_printer_runout_alert(monkeypatch):
     assert alerts[0]["alert_type"] == "filament_runout"
 
 
+def test_handle_notification_records_cross_printer_print_complete_alert(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    queue.printer_index = 1
+    queue._printer_name = "Thing 2"
+    alerts = []
+    del queue._record_printer_alert
+    monkeypatch.setattr(
+        "web.service.mqtt.app.record_printer_alert",
+        lambda **kwargs: alerts.append(kwargs),
+        raising=False,
+    )
+
+    queue._handle_notification({"commandType": 1044, "filePath": "/tmp/completed.gcode"})
+    queue._handle_notification({"commandType": 1000, "value": 1})
+    queue._handle_notification({"commandType": 1000, "value": 0})
+
+    assert len(alerts) == 1
+    assert alerts[0]["printer_index"] == 1
+    assert alerts[0]["printer_name"] == "Thing 2"
+    assert alerts[0]["alert_type"] == "print_complete"
+    assert alerts[0]["title"] == "Print complete"
+    assert alerts[0]["message"] == "completed.gcode finished printing."
+    assert alerts[0]["level"] == "success"
+
+
+def test_cancelled_print_does_not_record_print_complete_alert():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    alerts = []
+    queue._record_printer_alert = lambda **kwargs: alerts.append(kwargs)
+
+    queue._handle_notification({"commandType": 1044, "filePath": "/tmp/cancelled.gcode"})
+    queue._handle_notification({"commandType": 1000, "value": 1})
+    queue._stop_requested = True
+    queue._handle_notification({"commandType": 1000, "value": 0})
+
+    assert alerts == []
+
+
 def test_filament_runout_alarm_clears_if_printer_sends_clear_without_pause():
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -877,6 +877,102 @@ def test_early_stop_during_pre_print_window_sends_value4_and_cancels():
     assert queue.get_state()["print"]["in_pre_print_window"] is False
 
 
+def test_stop_confirmation_reply_cancels_active_print_without_value_zero():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue._handle_notification({"commandType": 1044, "filePath": "/tmp/cube.gcode"})
+    queue._handle_notification({"commandType": 1000, "value": 1})
+
+    history_calls.clear()
+    timelapse_calls.clear()
+    events.clear()
+
+    queue._stop_requested = True
+    queue._handle_notification({"commandType": 1057, "reply": 0})
+
+    assert queue._state == PrintState.IDLE
+    assert history_calls == [("fail", (), {"filename": "cube.gcode", "reason": "cancelled", "task_id": None})]
+    assert timelapse_calls == [("fail",)]
+    assert len(events) == 1
+    assert events[0][0] == "print_failed"
+    assert events[0][2] is False
+    assert events[0][1]["filename"] == "cube.gcode"
+    assert events[0][1]["reason"] == "cancelled"
+    assert queue.get_state()["timelapse"]["prompt_start"] is False
+
+
+def test_startup_attached_print_prompts_before_starting_timelapse(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    now = [100.0]
+    monkeypatch.setattr("web.service.mqtt.time.monotonic", lambda: now[0])
+    queue = _queue()
+    queue._timelapse_start_prompt_window_until = now[0] + 20.0
+
+    queue._handle_notification({
+        "commandType": 1001,
+        "progress": 2500,
+        "name": "startup.gcode",
+    })
+
+    assert queue._state == PrintState.PRINTING
+    assert history_calls == [("start", ("startup.gcode",), {"task_id": None})]
+    assert timelapse_calls == []
+    state = queue.get_state()
+    assert state["timelapse"]["prompt_start"] is True
+    assert state["timelapse"]["prompt_filename"] == "startup.gcode"
+    assert state["timelapse"]["detail"] == "Open Timelapse to continue or dismiss capture for this print."
+
+    filename = queue.start_timelapse_for_current_print()
+
+    assert filename == "startup.gcode"
+    assert timelapse_calls == [("start", "startup.gcode")]
+    assert queue.get_state()["timelapse"]["prompt_start"] is False
+
+
+def test_active_print_after_startup_window_auto_starts_timelapse(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    now = [100.0]
+    monkeypatch.setattr("web.service.mqtt.time.monotonic", lambda: now[0])
+    queue = _queue()
+    queue._timelapse_start_prompt_window_until = now[0] - 1.0
+
+    queue._handle_notification({
+        "commandType": 1001,
+        "progress": 2500,
+        "name": "auto-start.gcode",
+    })
+
+    assert queue._state == PrintState.PRINTING
+    assert timelapse_calls == [("start", "auto-start.gcode")]
+    assert queue.get_state()["timelapse"]["prompt_start"] is False
+
+
+def test_dismiss_timelapse_offer_discards_pending_resume():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    discarded = []
+    queue._timelapse = SimpleNamespace(
+        enabled=True,
+        _capture_thread=None,
+        discard_pending_resume=lambda filename=None: discarded.append(filename) or True,
+        get_runtime_state=lambda: {"enabled": True, "capturing": False},
+    )
+    queue._state = PrintState.PRINTING
+    queue._last_filename = "active.gcode"
+    queue._timelapse_start_prompt_pending = True
+    queue._timelapse_start_prompt_filename = "active.gcode"
+
+    queue.dismiss_timelapse_start_offer()
+
+    assert discarded == ["active.gcode"]
+    assert queue.get_state()["timelapse"]["prompt_start"] is False
+
+
 def test_build_payload_get_state_and_simulate_event(monkeypatch):
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -6,6 +6,9 @@ from web.service.mqtt import MqttQueue, PrintState
 
 def _queue():
     queue = object.__new__(MqttQueue)
+    queue.printer_index = 0
+    queue._printer_name = "Thing 1"
+    queue._printer_sn = "TEST-SN"
     queue._ha = SimpleNamespace(enabled=True, update_state=lambda **kwargs: ha_updates.append(kwargs))
     queue._notifier = SimpleNamespace(
         is_event_enabled=lambda event: True,
@@ -22,6 +25,7 @@ def _queue():
         start_capture=lambda filename="unknown": timelapse_calls.append(("start", filename)),
         finish_capture=lambda final=False: timelapse_calls.append(("finish", final)),
         fail_capture=lambda: timelapse_calls.append(("fail",)),
+        set_capture_paused=lambda paused, reason=None: None,
         enabled=True,
         _capture_thread=None,
     )
@@ -44,6 +48,7 @@ def _queue():
     queue._control_username = "tester@example.com"
     queue._control_user_id = "user-123"
     queue._debug_log_payloads = False
+    queue._record_printer_alert = lambda **kwargs: None
     queue._reset_print_state()
     return queue
 
@@ -117,7 +122,7 @@ def test_handle_notification_tracks_filament_changing_state():
     assert state["step_len"] == 40
 
 
-def test_handle_notification_tracks_filament_runout_alarm_state():
+def test_handle_notification_does_not_confirm_filament_runout_on_alarm_alone():
     global ha_updates, history_calls, timelapse_calls, events
     ha_updates, history_calls, timelapse_calls, events = [], [], [], []
     queue = _queue()
@@ -129,12 +134,12 @@ def test_handle_notification_tracks_filament_runout_alarm_state():
     })
     state = queue.get_state()["filament"]
 
-    assert state["state"] == "not_loaded"
-    assert state["label"] == "Not Loaded"
+    assert state["state"] == "unknown"
+    assert state["label"] == "Unknown"
     assert state["loaded"] is None
-    assert state["issue"] == "runout"
-    assert state["issue_label"] == "Filament runout"
-    assert state["detail"] == "Filament runout or break detected."
+    assert state["issue"] is None
+    assert state["issue_label"] is None
+    assert state["detail"] is None
 
 
 def test_handle_notification_exposes_filament_pause_reason_when_print_pauses():
@@ -155,7 +160,123 @@ def test_handle_notification_exposes_filament_pause_reason_when_print_pauses():
     assert state["print"]["pause_reason_label"] == "Filament runout"
     assert state["filament"]["pause_reason"] == "filament_runout"
     assert state["filament"]["pause_reason_label"] == "Filament runout"
-    assert state["filament"]["detail"] == "Printer paused for filament reload."
+    assert state["filament"]["detail"] == "Paused: Filament runout. Reload filament to continue."
+
+
+def test_filament_runout_pause_keeps_not_loaded_until_resume():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    queue._state = PrintState.PRINTING
+
+    queue._handle_notification({
+        "commandType": 1085,
+        "errorCode": "0xFF01030001",
+        "errorLevel": "P1",
+    })
+    queue._handle_notification({"commandType": 1000, "value": 2})
+    queue._handle_notification({"commandType": 1023, "value": 0, "progress": 100, "stepLen": 20})
+
+    paused_state = queue.get_state()["filament"]
+    assert paused_state["state"] == "not_loaded"
+    assert paused_state["issue"] == "runout"
+    assert paused_state["detail"] == "Paused: Filament runout. Reload filament to continue."
+
+    queue._handle_notification({"commandType": 1000, "value": 3})
+
+    resumed_state = queue.get_state()["filament"]
+    assert resumed_state["state"] == "loaded"
+    assert resumed_state["issue"] is None
+    assert resumed_state["pause_reason"] is None
+
+
+def test_filament_change_and_runout_pause_timelapse_snapshots():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    queue._state = PrintState.PRINTING
+    pause_calls = []
+    queue._timelapse.set_capture_paused = lambda paused, reason=None: pause_calls.append((paused, reason))
+
+    queue._handle_notification({"commandType": 1023, "value": 2, "progress": 25, "stepLen": 20})
+    queue._handle_notification({
+        "commandType": 1085,
+        "errorCode": "0xFF01030001",
+        "errorLevel": "P1",
+    })
+    queue._handle_notification({"commandType": 1000, "value": 2})
+    queue._handle_notification({"commandType": 1000, "value": 3})
+
+    assert pause_calls[0] == (True, "filament_change")
+    assert (True, "filament_runout") in pause_calls
+    assert pause_calls[-1] == (False, None)
+
+
+def test_handle_notification_records_cross_printer_runout_alert(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    queue.printer_index = 1
+    queue._printer_name = "Thing 2"
+    alerts = []
+    del queue._record_printer_alert
+    monkeypatch.setattr(
+        "web.service.mqtt.app.record_printer_alert",
+        lambda **kwargs: alerts.append(kwargs),
+        raising=False,
+    )
+
+    queue._handle_notification({
+        "commandType": 1085,
+        "errorCode": "0xFF01030001",
+        "errorLevel": "P1",
+    })
+    queue._handle_notification({
+        "commandType": 1000,
+        "subType": 2,
+        "value": 6,
+    })
+
+    assert len(alerts) == 1
+    assert alerts[0]["printer_index"] == 1
+    assert alerts[0]["printer_name"] == "Thing 2"
+    assert alerts[0]["alert_type"] == "filament_runout"
+
+
+def test_filament_runout_alarm_clears_if_printer_sends_clear_without_pause():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue._handle_notification({
+        "commandType": 1085,
+        "errorCode": "0xFF01030001",
+        "errorLevel": "P1",
+    })
+    queue._handle_notification({
+        "commandType": 1086,
+        "errorCode": "0xFF01030001",
+        "errorLevel": "P1",
+    })
+    queue._handle_notification({"commandType": 1000, "value": 2})
+
+    state = queue.get_state()
+    assert state["filament"]["issue"] is None
+    assert state["print"]["pause_reason"] is None
+
+
+def test_get_state_reports_timelapse_not_capturing_for_dead_thread():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    class DeadThread:
+        def is_alive(self):
+            return False
+
+    queue._timelapse._capture_thread = DeadThread()
+
+    assert queue.get_state()["timelapse"]["capturing"] is False
 
 
 def test_event_notify_filament_break_sets_not_loaded_until_change_cycle_completes():

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -132,6 +132,30 @@ def test_handle_notification_tracks_filament_runout_alarm_state():
     assert state["state"] == "not_loaded"
     assert state["label"] == "Not Loaded"
     assert state["loaded"] is None
+    assert state["issue"] == "runout"
+    assert state["issue_label"] == "Filament runout"
+    assert state["detail"] == "Filament runout or break detected."
+
+
+def test_handle_notification_exposes_filament_pause_reason_when_print_pauses():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    queue._state = PrintState.PRINTING
+
+    queue._handle_notification({
+        "commandType": 1085,
+        "errorCode": "0xFF01030001",
+        "errorLevel": "P1",
+    })
+    queue._handle_notification({"commandType": 1000, "value": 2})
+
+    state = queue.get_state()
+    assert state["print"]["pause_reason"] == "filament_runout"
+    assert state["print"]["pause_reason_label"] == "Filament runout"
+    assert state["filament"]["pause_reason"] == "filament_runout"
+    assert state["filament"]["pause_reason_label"] == "Filament runout"
+    assert state["filament"]["detail"] == "Printer paused for filament reload."
 
 
 def test_event_notify_filament_break_sets_not_loaded_until_change_cycle_completes():
@@ -153,6 +177,7 @@ def test_event_notify_filament_break_sets_not_loaded_until_change_cycle_complete
     state = queue.get_state()["filament"]
     assert state["state"] == "loaded"
     assert state["label"] == "Loaded"
+    assert state["issue"] is None
 
 
 def test_emit_progress_respects_bucket_interval():

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -809,6 +809,74 @@ def test_pre_print_window_upgrades_to_full_print():
     assert len(timelapse_calls) > 0, "Pre-print upgrade should start timelapse"
 
 
+def test_stale_post_completion_updates_for_same_task_are_ignored(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    now = [100.0]
+    monkeypatch.setattr("web.service.mqtt.time.monotonic", lambda: now[0])
+
+    queue._handle_notification({
+        "commandType": 1001,
+        "progress": 2500,
+        "name": "cube.gcode",
+        "task_id": "task-dup",
+    })
+    queue._handle_notification({"commandType": 1000, "value": 0})
+
+    history_calls.clear()
+    timelapse_calls.clear()
+    events.clear()
+
+    now[0] += 5.0
+    queue._handle_notification({
+        "commandType": 1001,
+        "progress": 9900,
+        "name": "cube.gcode",
+        "task_id": "task-dup",
+    })
+    queue._handle_notification({
+        "commandType": 1001,
+        "progress": 10000,
+        "name": "cube.gcode",
+        "task_id": "task-dup",
+    })
+
+    assert queue._state == PrintState.IDLE
+    assert history_calls == []
+    assert timelapse_calls == []
+    assert events == []
+
+
+def test_bare_ct1000_start_is_ignored_immediately_after_completion(monkeypatch):
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+    now = [100.0]
+    monkeypatch.setattr("web.service.mqtt.time.monotonic", lambda: now[0])
+
+    queue._handle_notification({
+        "commandType": 1001,
+        "progress": 2500,
+        "name": "cube.gcode",
+        "task_id": "task-bare",
+    })
+    queue._handle_notification({"commandType": 1000, "value": 0})
+
+    history_calls.clear()
+    timelapse_calls.clear()
+    events.clear()
+
+    now[0] += 2.0
+    queue._handle_notification({"commandType": 1000, "value": 1})
+
+    assert queue._state == PrintState.IDLE
+    assert queue._pending_history_start is False
+    assert history_calls == []
+    assert timelapse_calls == []
+    assert events == []
+
+
 def test_ct1001_blocked_during_pre_print_window():
     """Progress messages (ct=1001) during the pre-print window should NOT
     upgrade to full print activation. Only ct=1000 value=1 does that."""

--- a/tests/test_print_history.py
+++ b/tests/test_print_history.py
@@ -46,6 +46,33 @@ def test_record_finish_and_fail_update_active_entries(tmp_path):
     assert entries[1]["progress"] == 100
 
 
+def test_record_start_dedupes_completed_task_id(tmp_path):
+    history = PrintHistory(db_path=tmp_path / "history.db")
+
+    first_id = history.record_start(
+        "cube.gcode",
+        task_id="task-finished",
+        archive_relpath="saved/cube.gcode",
+        archive_size=1234,
+    )
+    history.record_finish(task_id="task-finished", progress=100)
+
+    duplicate_id = history.record_start(
+        "cube.gcode",
+        task_id="task-finished",
+        preview_url="https://example.test/cube.png",
+    )
+
+    entries = history.get_history(limit=10)
+
+    assert duplicate_id == first_id
+    assert history.get_count() == 1
+    assert entries[0]["status"] == "finished"
+    assert entries[0]["archive_relpath"] == "saved/cube.gcode"
+    assert entries[0]["archive_size"] == 1234
+    assert entries[0]["preview_url"] == "https://example.test/cube.png"
+
+
 def test_history_prunes_to_max_entries(tmp_path):
     history = PrintHistory(db_path=tmp_path / "history.db", max_entries=2)
 

--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime
-from threading import Lock
+from threading import Event, Lock
 from types import SimpleNamespace
 
 import pytest
@@ -225,6 +225,64 @@ def test_video_queue_disable_cancels_recovery_with_connected_viewer():
 
     assert stop_calls == []
     assert queue.wanted is False
+
+
+def test_video_queue_request_live_recovery_sets_worker_flag(monkeypatch):
+    queue = object.__new__(VideoQueue)
+    queue.video_enabled = True
+    queue.wanted = True
+    queue.state = RunState.Running
+    queue._manual_recovery_requested = False
+    queue._manual_recovery_reason = None
+    queue._manual_recovery_force_pppp = False
+    queue._manual_recovery_requested_at = 0.0
+    queue._event = Event()
+
+    monkeypatch.setattr("web.service.video.time.monotonic", lambda: 10.0)
+
+    assert queue.request_live_recovery("timelapse stalled", force_pppp_recycle=True) is True
+    assert queue._manual_recovery_requested is True
+    assert queue._manual_recovery_reason == "timelapse stalled"
+    assert queue._manual_recovery_force_pppp is True
+    assert queue._event.is_set() is True
+
+
+def test_video_queue_worker_run_honors_manual_recovery_request(monkeypatch):
+    queue = object.__new__(VideoQueue)
+    queue.video_enabled = True
+    queue.wanted = True
+    queue.handlers = []
+    queue.idle = lambda timeout=None: None
+    queue._in_place_recovery = False
+    queue._live_started_at = 100.0
+    queue.last_frame_at = 100.0
+    queue._last_live_refresh_at = 0.0
+    queue._last_no_frame_log_at = 0.0
+    queue._last_start_live_at = 0.0
+    queue._live_active = True
+    queue._stall_retry_count = 0
+    queue._manual_recovery_requested = True
+    queue._manual_recovery_reason = "timelapse stalled"
+    queue._manual_recovery_force_pppp = False
+    api = object()
+    queue.pppp = SimpleNamespace(connected=True, _api=api)
+    queue.api_id = id(api)
+    refresh_calls = []
+
+    monkeypatch.setattr("web.service.video.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        queue,
+        "_attempt_stall_recovery",
+        lambda pppp, warn_msg, retry_fail_msg, exhaust_msg: refresh_calls.append(
+            (warn_msg, retry_fail_msg, exhaust_msg)
+        ),
+    )
+
+    queue.worker_run(timeout=0.1)
+
+    assert len(refresh_calls) == 1
+    assert "timelapse stalled" in refresh_calls[0][0]
+    assert queue._manual_recovery_requested is False
 
 
 def test_video_queue_api_profile_and_mode_validation():

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -192,6 +192,25 @@ def test_timelapse_start_capture_resumes_pending_session(monkeypatch, tmp_path):
     assert calls == ["stop-thread", "cancel-finalize", "enable-video", "thread-start"]
 
 
+def test_timelapse_discard_pending_resume(tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    resume_dir = tmp_path / _IN_PROGRESS_SUBDIR / "resume_discard"
+    resume_dir.mkdir(parents=True, exist_ok=True)
+    (resume_dir / "frame_00000.jpg").write_bytes(b"x")
+    svc._resume_dir = str(resume_dir)
+    svc._resume_filename = "cube.gcode"
+    svc._resume_frame_count = 1
+
+    discarded = svc.discard_pending_resume("cube.gcode")
+
+    assert discarded is True
+    assert svc._resume_dir is None
+    assert svc._resume_filename is None
+    assert svc._resume_frame_count == 0
+    assert not resume_dir.exists()
+
+
 def test_timelapse_take_snapshot_retries_and_restores_light(monkeypatch, tmp_path):
     cfg = FakeConfigManager(tmp_path)
     svc = TimelapseService(cfg, captures_dir=tmp_path)

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -4,6 +4,7 @@ import time
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+import web
 from web.service.timelapse import TimelapseService, _IN_PROGRESS_SUBDIR, _resolve_ffmpeg_path
 
 
@@ -288,3 +289,122 @@ def test_capture_thread_crash_clears_ref(tmp_path):
     svc._capture_thread.join(timeout=2)
 
     assert svc._capture_thread is None, "_capture_thread should be None after crash"
+
+
+def test_stop_capture_thread_clears_stale_dead_thread_reference(tmp_path):
+    import threading
+
+    config_mgr = SimpleNamespace(config_root=str(tmp_path))
+    svc = TimelapseService(config_mgr, captures_dir=str(tmp_path))
+
+    stale_thread = threading.Thread(target=lambda: None, daemon=True)
+    stale_thread.start()
+    stale_thread.join(timeout=2)
+    assert stale_thread.is_alive() is False
+
+    svc._capture_thread = stale_thread
+    svc._stop_capture_thread()
+
+    assert svc._capture_thread is None
+
+
+def test_capture_loop_skips_snapshots_while_capture_is_paused(tmp_path):
+    import threading
+
+    config_mgr = SimpleNamespace(config_root=str(tmp_path))
+    svc = TimelapseService(config_mgr, captures_dir=str(tmp_path))
+    svc._interval = 0.01
+
+    snapshot_called = threading.Event()
+
+    def fake_snapshot():
+        snapshot_called.set()
+        svc._stop_event.set()
+
+    svc._take_snapshot = fake_snapshot
+    svc.set_capture_paused(True, reason="filament_change")
+    svc._capture_thread = threading.Thread(target=svc._capture_loop, daemon=True)
+    svc._capture_thread.start()
+
+    time.sleep(0.05)
+    assert snapshot_called.is_set() is False
+
+    svc.set_capture_paused(False)
+    svc._capture_thread.join(timeout=2)
+
+    assert snapshot_called.is_set() is True
+
+
+def test_await_video_frame_requests_recovery_when_frames_go_stale(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    requests = []
+    videoqueue = SimpleNamespace(
+        last_frame_at=None,
+        pppp=SimpleNamespace(connected=False),
+        request_live_recovery=lambda **kwargs: requests.append(kwargs) or True,
+    )
+    old_svc = web.app.svc
+    web.app.svc = SimpleNamespace(svcs={"videoqueue": videoqueue})
+
+    try:
+        monkeypatch.setattr("web.service.timelapse.time.sleep", lambda seconds: None)
+        assert svc._await_video_frame(timeout=0.01, max_age=1.5) is False
+    finally:
+        web.app.svc = old_svc
+
+    assert len(requests) == 1
+    assert requests[0]["reason"] == "timelapse has no recent video frame"
+    assert requests[0]["force_pppp_recycle"] is True
+
+
+def test_snapshot_timeout_requests_video_recovery(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    svc._current_dir = str(tmp_path / "capture")
+    svc._current_filename = "cube.gcode"
+    svc._frame_count = 0
+    os.makedirs(svc._current_dir, exist_ok=True)
+
+    requests = []
+    videoqueue = SimpleNamespace(
+        request_live_recovery=lambda **kwargs: requests.append(kwargs) or True,
+    )
+    old_svc = web.app.svc
+    old_api_key = web.app.config.get("api_key")
+    web.app.svc = SimpleNamespace(svcs={"videoqueue": videoqueue})
+    web.app.config["api_key"] = None
+
+    def fake_run(*args, **kwargs):
+        raise __import__("subprocess").TimeoutExpired(cmd="ffmpeg", timeout=10)
+
+    try:
+        monkeypatch.setattr("web.service.timelapse._resolve_ffmpeg_path", lambda: "resolved-ffmpeg")
+        monkeypatch.setattr(TimelapseService, "_await_video_frame", lambda self: True)
+        monkeypatch.setattr("web.service.timelapse.subprocess.run", fake_run)
+        monkeypatch.setattr("web.service.timelapse.time.sleep", lambda seconds: None)
+        svc._take_snapshot()
+    finally:
+        web.app.svc = old_svc
+        web.app.config["api_key"] = old_api_key
+
+    assert len(requests) == 1
+    assert requests[0]["reason"] == "timelapse snapshot timed out waiting for a camera frame"
+    assert requests[0]["force_pppp_recycle"] is True
+
+
+def test_timelapse_runtime_state_reports_recovery(tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+
+    svc._set_recovery_state(True, "timelapse has no recent video frame")
+    state = svc.get_runtime_state()
+
+    assert state["recovering"] is True
+    assert state["recovery_reason"] == "timelapse has no recent video frame"
+    assert state["detail"] == "Recovering video stream..."
+
+    svc._set_recovery_state(False)
+    cleared = svc.get_runtime_state()
+    assert cleared["recovering"] is False
+    assert cleared["detail"] is None

--- a/tests/test_web_helpers_and_api.py
+++ b/tests/test_web_helpers_and_api.py
@@ -343,6 +343,52 @@ def test_api_printers_and_switch_active_printer(monkeypatch):
             app.config[key] = value
 
 
+def test_api_printer_runtime_state_returns_filament_details():
+    mqtt = SimpleNamespace(
+        get_state=lambda: {
+            "print": {
+                "print_state": "paused",
+                "state": 2,
+                "pause_reason": "filament_runout",
+                "pause_reason_label": "Filament runout",
+            },
+            "filament": {
+                "state": "not_loaded",
+                "label": "Not Loaded",
+                "issue": "runout",
+                "issue_label": "Filament runout",
+                "detail": "Printer paused for filament reload.",
+                "pause_reason": "filament_runout",
+                "pause_reason_label": "Filament runout",
+            },
+        }
+    )
+    client = app.test_client()
+    old_values = {
+        "login": app.config.get("login"),
+        "api_key": app.config.get("api_key"),
+    }
+    old_svc = app.svc
+
+    app.config["login"] = True
+    app.config["api_key"] = None
+    app.svc = FakeServices(mqtt)
+
+    try:
+        response = client.get("/api/printer/runtime-state")
+    finally:
+        app.svc = old_svc
+        for key, value in old_values.items():
+            app.config[key] = value
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["print"]["pause_reason_label"] == "Filament runout"
+    assert data["filament"]["issue"] == "runout"
+    assert data["filament"]["detail"] == "Printer paused for filament reload."
+
+
 def test_root_shows_ffmpeg_warning_only_for_camera_capable_devices(monkeypatch):
     cfg = Config(
         account=Account(

--- a/tests/test_web_helpers_and_api.py
+++ b/tests/test_web_helpers_and_api.py
@@ -428,6 +428,51 @@ def test_api_printer_runtime_state_returns_filament_details():
     assert data["timelapse"]["detail"] == "Recovering video stream..."
 
 
+def test_api_timelapse_current_start_and_dismiss():
+    calls = []
+    mqtt = SimpleNamespace(
+        start_timelapse_for_current_print=lambda: calls.append("start") or "cube.gcode",
+        dismiss_timelapse_start_offer=lambda: calls.append("dismiss"),
+        get_state=lambda: {
+            "print": {
+                "print_state": "printing",
+                "state": 1,
+            },
+            "timelapse": {
+                "enabled": True,
+                "capturing": "start" in calls,
+                "prompt_start": "dismiss" not in calls and "start" not in calls,
+                "prompt_filename": "cube.gcode",
+            },
+        },
+    )
+    client = app.test_client()
+    old_values = {
+        "login": app.config.get("login"),
+        "api_key": app.config.get("api_key"),
+    }
+    old_svc = app.svc
+
+    app.config["login"] = True
+    app.config["api_key"] = None
+    app.svc = FakeServices(mqtt)
+
+    try:
+        start_response = client.post("/api/timelapse/current/start")
+        dismiss_response = client.post("/api/timelapse/current/dismiss")
+    finally:
+        app.svc = old_svc
+        for key, value in old_values.items():
+            app.config[key] = value
+
+    assert start_response.status_code == 200
+    assert dismiss_response.status_code == 200
+    assert calls == ["start", "dismiss"]
+    assert start_response.get_json()["filename"] == "cube.gcode"
+    assert start_response.get_json()["timelapse"]["capturing"] is True
+    assert dismiss_response.get_json()["timelapse"]["prompt_start"] is False
+
+
 def test_api_printer_alerts_returns_recent_entries(monkeypatch):
     calls = []
 

--- a/tests/test_web_helpers_and_api.py
+++ b/tests/test_web_helpers_and_api.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 from cli.model import Account, Config, Printer
 from libflagship import resolve_root_dir
-from web import _AccessLogNoiseFilter, _ConsoleLogBuffer
+from web import _AccessLogNoiseFilter, _ConsoleLogBuffer, _PrinterAlertBuffer
 from web import (
     _build_command_group,
     _build_filament_move_gcode,
@@ -222,6 +222,30 @@ def test_console_log_buffer_supports_recent_tail_and_incremental_updates():
     assert truncated["truncated"] is True
 
 
+def test_printer_alert_buffer_supports_recent_tail_and_incremental_updates():
+    buffer = _PrinterAlertBuffer(max_entries=3)
+    for idx in range(1, 6):
+        buffer.append(
+            printer_index=0,
+            printer_name="Thing 1",
+            alert_type="filament_runout",
+            title="Filament runout",
+            message=f"alert {idx}",
+            cooldown_sec=0,
+        )
+
+    recent = buffer.snapshot(limit=10)
+    incremental = buffer.snapshot(after_id=3, limit=10)
+    truncated = buffer.snapshot(after_id=1, limit=10)
+
+    assert [entry["message"] for entry in recent["entries"]] == ["alert 3", "alert 4", "alert 5"]
+    assert recent["first_id"] == 3
+    assert recent["last_id"] == 5
+    assert [entry["message"] for entry in incremental["entries"]] == ["alert 4", "alert 5"]
+    assert incremental["truncated"] is False
+    assert truncated["truncated"] is True
+
+
 def test_access_log_noise_filter_suppresses_console_polling_and_static_assets():
     filt = _AccessLogNoiseFilter()
 
@@ -235,6 +259,11 @@ def test_access_log_noise_filter_suppresses_console_polling_and_static_assets():
         msg='127.0.0.1 - - [08/Apr/2026 17:57:47] "GET /static/ankersrv.js HTTP/1.1" 304 -',
         args=(), exc_info=None,
     )
+    runtime_record = logging.LogRecord(
+        name="werkzeug", level=logging.INFO, pathname=__file__, lineno=0,
+        msg='127.0.0.1 - - [09/Apr/2026 10:15:00] "GET /api/printer/runtime-state HTTP/1.1" 200 -',
+        args=(), exc_info=None,
+    )
     api_record = logging.LogRecord(
         name="werkzeug", level=logging.INFO, pathname=__file__, lineno=0,
         msg='127.0.0.1 - - [08/Apr/2026 17:57:47] "GET /api/health HTTP/1.1" 200 -',
@@ -243,6 +272,7 @@ def test_access_log_noise_filter_suppresses_console_polling_and_static_assets():
 
     assert filt.filter(console_record) is False
     assert filt.filter(static_record) is False
+    assert filt.filter(runtime_record) is False
     assert filt.filter(api_record) is True
 
 
@@ -357,9 +387,16 @@ def test_api_printer_runtime_state_returns_filament_details():
                 "label": "Not Loaded",
                 "issue": "runout",
                 "issue_label": "Filament runout",
-                "detail": "Printer paused for filament reload.",
+                "detail": "Paused: Filament runout. Reload filament to continue.",
                 "pause_reason": "filament_runout",
                 "pause_reason_label": "Filament runout",
+            },
+            "timelapse": {
+                "enabled": True,
+                "capturing": True,
+                "recovering": True,
+                "recovery_reason": "timelapse has no recent video frame",
+                "detail": "Recovering video stream...",
             },
         }
     )
@@ -386,7 +423,52 @@ def test_api_printer_runtime_state_returns_filament_details():
     assert data["status"] == "ok"
     assert data["print"]["pause_reason_label"] == "Filament runout"
     assert data["filament"]["issue"] == "runout"
-    assert data["filament"]["detail"] == "Printer paused for filament reload."
+    assert data["filament"]["detail"] == "Paused: Filament runout. Reload filament to continue."
+    assert data["timelapse"]["recovering"] is True
+    assert data["timelapse"]["detail"] == "Recovering video stream..."
+
+
+def test_api_printer_alerts_returns_recent_entries(monkeypatch):
+    calls = []
+
+    class FakeAlertBuffer:
+        def snapshot(self, *, limit=20, after_id=None):
+            calls.append((limit, after_id))
+            return {
+                "entries": [{
+                    "id": 9,
+                    "printer_index": 0,
+                    "printer_name": "Thing 1",
+                    "type": "filament_runout",
+                    "title": "Filament runout",
+                    "message": "Filament runout or break detected.",
+                    "level": "warning",
+                }],
+                "first_id": 9,
+                "last_id": 9,
+                "next_after": 9,
+                "truncated": False,
+                "max_entries": 100,
+            }
+
+    client = app.test_client()
+    old_values = {
+        "login": app.config.get("login"),
+        "api_key": app.config.get("api_key"),
+    }
+    app.config["login"] = True
+    app.config["api_key"] = None
+    monkeypatch.setattr(web_module, "_get_printer_alert_buffer", lambda: FakeAlertBuffer())
+
+    try:
+        response = client.get("/api/printer/alerts?limit=15&after=3")
+    finally:
+        for key, value in old_values.items():
+            app.config[key] = value
+
+    assert response.status_code == 200
+    assert response.get_json()["entries"][0]["title"] == "Filament runout"
+    assert calls == [(15, 3)]
 
 
 def test_root_shows_ffmpeg_warning_only_for_camera_capable_devices(monkeypatch):

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -46,6 +46,8 @@ class _AccessLogNoiseFilter(logging.Filter):
         '"GET /static/',
         '"GET /favicon.ico',
         '"GET /api/console/logs',
+        '"GET /api/printer/alerts',
+        '"GET /api/printer/runtime-state',
     )
 
     def filter(self, record):
@@ -147,6 +149,99 @@ class _ConsoleLogBufferHandler(logging.Handler):
                 self.buffer.append(line)
         except Exception:
             self.handleError(record)
+
+
+class _PrinterAlertBuffer:
+    def __init__(self, max_entries=100):
+        self._entries = deque(maxlen=max_entries)
+        self._next_id = 1
+        self._recent_keys = {}
+        self._lock = threading.Lock()
+
+    @property
+    def max_entries(self):
+        return self._entries.maxlen or 0
+
+    def append(
+        self,
+        *,
+        printer_index,
+        printer_name,
+        alert_type,
+        title,
+        message,
+        level="warning",
+        cooldown_sec=30,
+    ):
+        message = str(message or "").strip()
+        if not message:
+            return None
+
+        title = str(title or "").strip() or message
+        level = str(level or "warning").strip() or "warning"
+        alert_key = f"{printer_index}:{alert_type}:{title}:{message}"
+        now = time.monotonic()
+
+        with self._lock:
+            if cooldown_sec:
+                last_seen = self._recent_keys.get(alert_key)
+                if last_seen is not None and now - last_seen < float(cooldown_sec):
+                    return None
+            self._recent_keys[alert_key] = now
+            stale_before = now - max(float(cooldown_sec or 0) * 4, 60.0)
+            self._recent_keys = {
+                key: seen_at
+                for key, seen_at in self._recent_keys.items()
+                if seen_at >= stale_before
+            }
+
+            entry = {
+                "id": self._next_id,
+                "created_at": time.time(),
+                "printer_index": printer_index,
+                "printer_name": printer_name,
+                "type": alert_type,
+                "title": title,
+                "message": message,
+                "level": level,
+            }
+            self._entries.append(entry)
+            self._next_id += 1
+            return entry["id"]
+
+    def snapshot(self, *, limit=50, after_id=None):
+        limit = max(1, min(int(limit), self.max_entries or 1))
+        with self._lock:
+            entries = list(self._entries)
+
+        first_id = entries[0]["id"] if entries else 0
+        last_id = entries[-1]["id"] if entries else 0
+        truncated = False
+
+        if after_id is None:
+            selected = entries[-limit:]
+        else:
+            try:
+                after_id = int(after_id)
+            except (TypeError, ValueError):
+                after_id = 0
+
+            if entries and after_id < first_id - 1:
+                truncated = True
+
+            selected = [entry for entry in entries if entry["id"] > after_id]
+            if len(selected) > limit:
+                truncated = True
+                selected = selected[-limit:]
+
+        return {
+            "entries": [dict(entry) for entry in selected],
+            "first_id": first_id,
+            "last_id": last_id,
+            "next_after": last_id,
+            "truncated": truncated,
+            "max_entries": self.max_entries,
+        }
 
 
 from secrets import token_urlsafe as token
@@ -301,9 +396,41 @@ def _get_console_log_buffer():
     root.addHandler(handler)
     return buffer
 
+
+def _get_printer_alert_buffer():
+    buffer = getattr(app, "printer_alert_buffer", None)
+    if buffer is None:
+        max_entries = _env_int("ANKERCTL_PRINTER_ALERT_BUFFER_SIZE", 100, min_value=10)
+        buffer = _PrinterAlertBuffer(max_entries=max_entries)
+        app.printer_alert_buffer = buffer
+    return buffer
+
+
+def _record_printer_alert(
+    *,
+    printer_index,
+    printer_name,
+    alert_type,
+    title,
+    message,
+    level="warning",
+    cooldown_sec=30,
+):
+    buffer = _get_printer_alert_buffer()
+    return buffer.append(
+        printer_index=printer_index,
+        printer_name=printer_name,
+        alert_type=alert_type,
+        title=title,
+        message=message,
+        level=level,
+        cooldown_sec=cooldown_sec,
+    )
+
 # Session cookie security
 app.config['SESSION_COOKIE_SAMESITE'] = 'Strict'
 app.config['SESSION_COOKIE_HTTPONLY'] = True
+app.record_printer_alert = _record_printer_alert
 
 # Resolve log directory once: honour env var, fall back to None on bare metal
 _log_dir = os.getenv("ANKERCTL_LOG_DIR") or ("/logs" if os.path.isdir("/logs") else None)
@@ -2482,6 +2609,14 @@ def app_api_printer_runtime_state():
             return {"error": "Service unavailable"}, 503
         state = mqtt.get_state()
     return {"status": "ok", **state}
+
+
+@app.get("/api/printer/alerts")
+def app_api_printer_alerts():
+    buffer = _get_printer_alert_buffer()
+    limit = request.args.get("limit", 20, type=int)
+    after = request.args.get("after", None, type=int)
+    return buffer.snapshot(limit=limit, after_id=after)
 
 
 @app.get("/api/printer/bed-leveling/last")

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -2475,6 +2475,15 @@ def app_api_printer_settings_summary():
         return {"error": str(exc)}, 503
 
 
+@app.get("/api/printer/runtime-state")
+def app_api_printer_runtime_state():
+    with borrow_mqtt() as mqtt:
+        if not mqtt:
+            return {"error": "Service unavailable"}, 503
+        state = mqtt.get_state()
+    return {"status": "ok", **state}
+
+
 @app.get("/api/printer/bed-leveling/last")
 def app_api_printer_bed_leveling_last():
     """Return the most recently saved bed leveling grid from the log directory."""

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3226,6 +3226,29 @@ def app_api_timelapses():
     return {"videos": videos, "enabled": enabled}
 
 
+@app.post("/api/timelapse/current/start")
+def app_api_timelapse_current_start():
+    with borrow_mqtt() as mqtt:
+        if not mqtt:
+            return {"error": "Service unavailable"}, 503
+        try:
+            filename = mqtt.start_timelapse_for_current_print()
+        except RuntimeError as exc:
+            return {"error": str(exc)}, 409
+        state = mqtt.get_state()
+    return {"status": "ok", "filename": filename, **state}
+
+
+@app.post("/api/timelapse/current/dismiss")
+def app_api_timelapse_current_dismiss():
+    with borrow_mqtt() as mqtt:
+        if not mqtt:
+            return {"error": "Service unavailable"}, 503
+        mqtt.dismiss_timelapse_start_offer()
+        state = mqtt.get_state()
+    return {"status": "ok", **state}
+
+
 @app.get("/api/timelapse/<filename>")
 def app_api_timelapse_download(filename):
     """Download a timelapse video."""

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -232,7 +232,9 @@ class PrintHistory:
         """Record a print start. Returns the row id.
 
         If an open 'started' entry exists with the same task_id, it is resumed.
-        Otherwise, any existing open entries are closed (orphaned) and a new one is created.
+        If a completed entry already exists with the same task_id, it is reused instead of
+        creating a duplicate row for stale post-finish firmware updates. Otherwise, any
+        existing open entries are closed (orphaned) and a new one is created.
 
         Returns None immediately if *filename* is a placeholder (empty, 'unknown', etc.)
         to avoid polluting history with uninformative entries.
@@ -243,19 +245,35 @@ class PrintHistory:
 
         with self._lock:
             with self._connect() as conn:
-                # 1. Resume existing open entry for the same task_id
+                # 1. Reuse existing entry for the same task_id. The printer can emit
+                # late duplicate updates for an already-finished job; task_id is the
+                # safest stable identity we have for deduplicating those.
                 if task_id:
                     existing = conn.execute(
-                        "SELECT id FROM print_history WHERE status='started' AND task_id=?",
+                        "SELECT id, status, archive_relpath, archive_size, preview_url "
+                        "FROM print_history WHERE task_id=? ORDER BY id DESC LIMIT 1",
                         (task_id,)
                     ).fetchone()
                     if existing:
-                        if preview_url:
+                        if archive_relpath or archive_size is not None or preview_url:
                             conn.execute(
-                                "UPDATE print_history SET preview_url=COALESCE(?, preview_url) WHERE id=?",
-                                (preview_url, existing["id"]),
+                                "UPDATE print_history "
+                                "SET archive_relpath=COALESCE(archive_relpath, ?), "
+                                "    archive_size=COALESCE(archive_size, ?), "
+                                "    preview_url=COALESCE(preview_url, ?) "
+                                "WHERE id=?",
+                                (archive_relpath, archive_size, preview_url, existing["id"]),
                             )
-                        log.info(f"History: resuming entry id={existing['id']} for task_id={task_id}")
+                        if existing["status"] == "started":
+                            log.info(f"History: resuming entry id={existing['id']} for task_id={task_id}")
+                        else:
+                            log.info(
+                                "History: ignoring duplicate start for completed task_id=%s "
+                                "(existing id=%s status=%s)",
+                                task_id,
+                                existing["id"],
+                                existing["status"],
+                            )
                         conn.commit()
                         return existing["id"]
 

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -67,6 +67,7 @@ STORED_FILE_SELECTION_TIMEOUT_SEC = 2.0
 STORED_FILE_START_CONFIRM_TIMEOUT_SEC = 12.0
 STORED_FILE_ONBOARD_START_CONFIRM_TIMEOUT_SEC = 20.0
 STORED_FILE_LIST_PAGE_SIZE = 47
+RECENT_COMPLETION_GUARD_SEC = 120.0
 STORED_FILE_SOURCE_ROOTS = (
     "/tmp/udisk/",
     "/usr/data/local/model/",
@@ -143,6 +144,9 @@ class MqttQueue(Service):
         self._preview_file_path = None
         self._last_g28_command = None
         self._last_g28_command_at = 0.0
+        self._recent_completion_filename = None
+        self._recent_completion_task_id = None
+        self._recent_completion_at = 0.0
 
     def set_gcode_layer_count(self, count: int):
         """Store the layer count extracted from a GCode header for UI display."""
@@ -184,6 +188,7 @@ class MqttQueue(Service):
 
     def _record_failure(self, payload, progress, reason):
         """Record a print failure: history, timelapse, HA state, and notification event."""
+        self._remember_recent_completion()
         self._history.record_fail(filename=self._last_filename, reason=reason, task_id=self._last_task_id)
         self._timelapse.fail_capture()
         self._ha.update_state(print_status="failed")
@@ -325,6 +330,35 @@ class MqttQueue(Service):
         self._pending_archive_info = None
         return archive_info
 
+    def _clear_recent_completion(self):
+        self._recent_completion_filename = None
+        self._recent_completion_task_id = None
+        self._recent_completion_at = 0.0
+
+    def _remember_recent_completion(self, filename=None, task_id=None):
+        saved_filename = os.path.basename(str(filename or self._last_filename or "")).strip()
+        saved_task_id = str(task_id or self._last_task_id or "").strip()
+        self._recent_completion_filename = saved_filename or None
+        self._recent_completion_task_id = saved_task_id or None
+        self._recent_completion_at = time.monotonic()
+
+    def _recent_completion_matches(self, *, task_id=None, filename=None):
+        recent_completion_at = getattr(self, "_recent_completion_at", 0.0)
+        if not recent_completion_at:
+            return False
+        if (time.monotonic() - recent_completion_at) > RECENT_COMPLETION_GUARD_SEC:
+            return False
+
+        recent_task_id = getattr(self, "_recent_completion_task_id", None)
+        recent_filename = getattr(self, "_recent_completion_filename", None)
+        normalized_task_id = str(task_id or "").strip() or None
+        normalized_filename = os.path.basename(str(filename or "")).strip() or None
+        if normalized_task_id and recent_task_id == normalized_task_id:
+            return True
+        if normalized_filename and recent_filename == normalized_filename:
+            return True
+        return False
+
     def mark_pending_print_start(self, filename=None, task_id=None, archive_info=None):
         with self._state_lock:
             if filename:
@@ -337,6 +371,7 @@ class MqttQueue(Service):
                     "archive_relpath": archive_info.get("archive_relpath"),
                     "archive_size": archive_info.get("archive_size"),
                 }
+            self._clear_recent_completion()
             self._state = PrintState.PREPARING
             self._stop_requested = False
         log.info("Marked pending print start for %r", self._last_filename)
@@ -1010,7 +1045,18 @@ class MqttQueue(Service):
                 if self._transition_from_paused_to_printing():
                     log.info("Print resumed (ct 1000 value=1)")
             elif value == 1:
-                self._transition_to_active(payload, progress=0)
+                if (
+                    previous_state == PrintState.IDLE
+                    and not self._last_filename
+                    and not self._last_task_id
+                    and not was_preparing_print
+                    and not was_pending_start
+                    and getattr(self, "_recent_completion_at", 0.0)
+                    and (time.monotonic() - getattr(self, "_recent_completion_at", 0.0)) <= RECENT_COMPLETION_GUARD_SEC
+                ):
+                    log.info("Ignoring bare ct 1000 value=1 immediately after print completion")
+                else:
+                    self._transition_to_active(payload, progress=0)
             elif value == 2 and self._state == PrintState.PRINTING:
                 self._state = PrintState.PAUSED
                 self._ha.update_state(print_status="paused")
@@ -1027,6 +1073,7 @@ class MqttQueue(Service):
                     else:
                         # Print ended normally
                         log.info(f"History: print finished (ct 1000 value=0), filename={self._last_filename!r}")
+                        self._remember_recent_completion()
                         self._history.record_finish(filename=self._last_filename, task_id=self._last_task_id)
                         self._timelapse.finish_capture(final=True)
                         self._ha.update_state(print_status="complete", print_progress=100)
@@ -1091,6 +1138,20 @@ class MqttQueue(Service):
         prev_filename = self._last_filename
 
         task_id = self._extract_task_id(payload)
+        incoming_filename = self._extract_filename(payload)
+        if (
+            task_id
+            and self._state == PrintState.IDLE
+            and not self.has_pending_print_start
+            and not self.is_preparing_print
+            and self._recent_completion_matches(task_id=task_id, filename=incoming_filename)
+        ):
+            log.info(
+                "Ignoring stale post-completion update for task_id=%s filename=%r",
+                task_id,
+                incoming_filename,
+            )
+            return
         if task_id:
             if self._last_task_id and task_id != self._last_task_id and self._state == PrintState.PRINTING:
                 if progress <= 1:
@@ -1101,7 +1162,7 @@ class MqttQueue(Service):
             else:
                 self._last_task_id = task_id
 
-        filename = self._extract_filename(payload)
+        filename = incoming_filename
         if filename:
             if command_type == MqttMsgType.ZZ_MQTT_CMD_PRINT_SCHEDULE:
                 self._last_print_schedule_filename = filename
@@ -1150,6 +1211,7 @@ class MqttQueue(Service):
                     self._build_payload(payload, 100),
                     include_image=True,
                 )
+                self._remember_recent_completion()
                 self._history.record_finish(filename=self._last_filename, task_id=self._last_task_id)
                 self._timelapse.finish_capture(final=True)
                 self._ha.update_state(print_status="complete", print_progress=100)
@@ -1162,6 +1224,7 @@ class MqttQueue(Service):
                 self._build_payload(payload, 100),
                 include_image=True,
             )
+            self._remember_recent_completion()
             self._history.record_finish(filename=self._last_filename, task_id=self._last_task_id)
             self._timelapse.finish_capture(final=True)
             self._ha.update_state(print_status="complete", print_progress=100)

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -69,6 +69,7 @@ PAUSE_REASON_LABELS = {
 }
 
 FILAMENT_RUNOUT_ERROR_CODE = "0xFF01030001"
+FILAMENT_RUNOUT_CONFIRM_WINDOW_SEC = 8.0
 
 G28_DEDUPE_WINDOW_SEC = 10.0
 STORED_FILE_SELECTION_TIMEOUT_SEC = 2.0
@@ -126,6 +127,8 @@ class MqttQueue(Service):
                 printer_name = getattr(printer, "name", None) or "AnkerMake M5"
         self._ha = HomeAssistantService(app.config["config"], printer_sn=printer_sn, printer_name=printer_name)
         self._ha.start()
+        self._printer_name = printer_name or "AnkerMake M5"
+        self._printer_sn = printer_sn
 
         self._reset_print_state()
         self._gcode_layer_count = None  # Override from GCode header, survives print resets
@@ -145,6 +148,8 @@ class MqttQueue(Service):
         self._filament_issue = None
         self._filament_issue_code = None
         self._pause_reason = None
+        self._filament_runout_pending = False
+        self._filament_runout_pending_at = 0.0
         self._stored_file_selection_cond = threading.Condition(self._state_lock)
         self._stored_file_preview_request_lock = threading.Lock()
         self._stored_file_preview_cache = {}
@@ -194,6 +199,10 @@ class MqttQueue(Service):
         self._last_print_schedule_filename = None
         self._last_print_schedule_seen_at = 0.0
         self._pause_reason = None
+        self._filament_runout_pending = False
+        self._filament_runout_pending_at = 0.0
+        if hasattr(self, "_timelapse"):
+            self._sync_timelapse_capture_pause()
         # Preserve debug setting across resets if possible, but init here if missing
         if not hasattr(self, "_debug_log_payloads"):
              self._debug_log_payloads = False
@@ -211,6 +220,22 @@ class MqttQueue(Service):
         self._failure_sent = True
         self._state = PrintState.FAILED
 
+    def _sync_timelapse_capture_pause(self):
+        set_capture_paused = getattr(self._timelapse, "set_capture_paused", None)
+        if not callable(set_capture_paused):
+            return
+
+        reason = None
+        if (
+            getattr(self, "_filament_issue", None) == "runout"
+            or getattr(self, "_pause_reason", None) == "filament_runout"
+        ):
+            reason = "filament_runout"
+        elif getattr(self, "_filament_state", None) == "changing":
+            reason = "filament_change"
+
+        set_capture_paused(reason is not None, reason=reason)
+
     @staticmethod
     def _print_state_value_label(value):
         return MQTT_PRINT_STATE_LABELS.get(value, f"unknown_{value}")
@@ -219,9 +244,16 @@ class MqttQueue(Service):
         if self._state != PrintState.PAUSED:
             return False
 
+        if getattr(self, "_pause_reason", None) == "filament_runout":
+            self._filament_issue = None
+            self._filament_issue_code = None
+            if getattr(self, "_filament_state", "unknown") in ("unknown", "not_loaded", "changing"):
+                self._filament_state = "loaded"
+
         self._state = PrintState.PRINTING
         self._pause_reason = None
         self._ha.update_state(print_status="printing")
+        self._sync_timelapse_capture_pause()
         return True
 
     def _transition_to_active(self, payload, progress, filename=None):
@@ -911,10 +943,58 @@ class MqttQueue(Service):
 
         if issue == "runout":
             if self._state == PrintState.PAUSED:
-                return "Printer paused for filament reload."
+                return "Paused: Filament runout. Reload filament to continue."
             return "Filament runout or break detected."
 
         return None
+
+    def _clear_filament_runout_pending(self):
+        self._filament_runout_pending = False
+        self._filament_runout_pending_at = 0.0
+
+    def _mark_filament_runout_pending(self):
+        self._filament_runout_pending = True
+        self._filament_runout_pending_at = time.monotonic()
+
+    def _has_recent_filament_runout_pending(self):
+        if not getattr(self, "_filament_runout_pending", False):
+            return False
+        pending_at = getattr(self, "_filament_runout_pending_at", 0.0)
+        if not pending_at:
+            return False
+        return (time.monotonic() - pending_at) <= FILAMENT_RUNOUT_CONFIRM_WINDOW_SEC
+
+    def _record_printer_alert(self, *, alert_type, title, message, level="warning", cooldown_sec=30):
+        record = getattr(app, "record_printer_alert", None)
+        if callable(record):
+            return record(
+                printer_index=self.printer_index,
+                printer_name=getattr(self, "_printer_name", f"Printer {self.printer_index + 1}"),
+                alert_type=alert_type,
+                title=title,
+                message=message,
+                level=level,
+                cooldown_sec=cooldown_sec,
+            )
+        return None
+
+    def _mark_filament_runout(self):
+        newly_detected = getattr(self, "_filament_issue", None) != "runout"
+        self._clear_filament_runout_pending()
+        self._filament_state = "not_loaded"
+        self._filament_issue = "runout"
+        self._filament_issue_code = FILAMENT_RUNOUT_ERROR_CODE
+        if self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
+            self._pause_reason = "filament_runout"
+        if newly_detected:
+            self._record_printer_alert(
+                alert_type="filament_runout",
+                title="Filament runout",
+                message="Filament runout or break detected.",
+                level="warning",
+                cooldown_sec=45,
+            )
+        return newly_detected
 
     def _update_filament_state(self, payload):
         if not isinstance(payload, dict):
@@ -929,18 +1009,37 @@ class MqttQueue(Service):
             else:
                 step_len_raw = payload.get("step_len")
             self._filament_change_step_len = self._safe_int(step_len_raw)
-            self._filament_state = self._normalize_filament_state(payload)
-            if self._filament_state in ("changing", "loaded"):
+            normalized_state = self._normalize_filament_state(payload)
+            in_filament_runout_pause = (
+                self._state == PrintState.PAUSED
+                and getattr(self, "_pause_reason", None) == "filament_runout"
+                and getattr(self, "_filament_issue", None) == "runout"
+            )
+
+            if in_filament_runout_pause and normalized_state == "loaded":
+                # The firmware can emit a transient value=0 between unload/reload
+                # stages during a runout recovery. Keep the UI conservative until
+                # the print actually resumes.
+                self._filament_state = "not_loaded"
+            else:
+                self._filament_state = normalized_state
+
+            if getattr(self, "_filament_issue", None) != "runout" and self._filament_state in ("changing", "loaded"):
+                self._clear_filament_runout_pending()
+            if not in_filament_runout_pause and self._filament_state in ("changing", "loaded"):
                 self._filament_issue = None
                 self._filament_issue_code = None
+            self._sync_timelapse_capture_pause()
             return
 
         if command_type == 1085 and str(payload.get("errorCode") or "") == FILAMENT_RUNOUT_ERROR_CODE:
-            self._filament_state = "not_loaded"
-            self._filament_issue = "runout"
-            self._filament_issue_code = FILAMENT_RUNOUT_ERROR_CODE
-            if self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
-                self._pause_reason = "filament_runout"
+            self._mark_filament_runout_pending()
+            return
+
+        if command_type == 1086 and str(payload.get("errorCode") or "") == FILAMENT_RUNOUT_ERROR_CODE:
+            if getattr(self, "_filament_issue", None) != "runout":
+                self._clear_filament_runout_pending()
+                self._sync_timelapse_capture_pause()
             return
 
         if (
@@ -948,11 +1047,8 @@ class MqttQueue(Service):
             and self._safe_int(payload.get("subType")) == 2
             and self._safe_int(payload.get("value")) == 6
         ):
-            self._filament_state = "not_loaded"
-            self._filament_issue = "runout"
-            self._filament_issue_code = FILAMENT_RUNOUT_ERROR_CODE
-            if self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
-                self._pause_reason = "filament_runout"
+            self._mark_filament_runout()
+            self._sync_timelapse_capture_pause()
             return
 
     def _forward_to_ha(self, payload):
@@ -1103,9 +1199,12 @@ class MqttQueue(Service):
                 else:
                     self._transition_to_active(payload, progress=0)
             elif value == 2 and self._state == PrintState.PRINTING:
+                if self._has_recent_filament_runout_pending() and getattr(self, "_filament_issue", None) != "runout":
+                    self._mark_filament_runout()
                 self._state = PrintState.PAUSED
                 if getattr(self, "_filament_issue", None) == "runout":
                     self._pause_reason = "filament_runout"
+                self._sync_timelapse_capture_pause()
                 self._ha.update_state(print_status="paused")
                 log.info("Print paused (ct 1000 value=2)")
             elif value == 3 and self._state == PrintState.PAUSED:
@@ -1351,6 +1450,15 @@ class MqttQueue(Service):
 
     def get_state(self):
         """Return structured internal state for debug inspection."""
+        timelapse_state_getter = getattr(self._timelapse, "get_runtime_state", None)
+        if callable(timelapse_state_getter):
+            timelapse_state = timelapse_state_getter()
+        else:
+            capture_thread = getattr(self._timelapse, "_capture_thread", None)
+            timelapse_state = {
+                "enabled": getattr(self._timelapse, "enabled", None),
+                "capturing": bool(capture_thread and capture_thread.is_alive()),
+            }
         return {
             "print": {
                 "print_state": self._state.value,
@@ -1391,10 +1499,7 @@ class MqttQueue(Service):
                 "step_len": getattr(self, "_filament_change_step_len", None),
             },
             "debug_logging": getattr(self, "_debug_log_payloads", False),
-            "timelapse": {
-                "enabled": getattr(self._timelapse, "enabled", None),
-                "capturing": bool(getattr(self._timelapse, "_capture_thread", None)),
-            },
+            "timelapse": timelapse_state,
         }
 
     def simulate_event(self, event_type, payload=None):

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -1041,6 +1041,17 @@ class MqttQueue(Service):
             )
         return newly_detected
 
+    def _record_print_complete_alert(self, filename=None):
+        finished_name = os.path.basename(str(filename or self._last_filename or "")).strip()
+        message = f"{finished_name} finished printing." if finished_name else "Print finished."
+        self._record_printer_alert(
+            alert_type="print_complete",
+            title="Print complete",
+            message=message,
+            level="success",
+            cooldown_sec=60,
+        )
+
     def _update_filament_state(self, payload):
         if not isinstance(payload, dict):
             return
@@ -1279,6 +1290,7 @@ class MqttQueue(Service):
                     else:
                         # Print ended normally
                         log.info(f"History: print finished (ct 1000 value=0), filename={self._last_filename!r}")
+                        self._record_print_complete_alert()
                         self._remember_recent_completion()
                         self._history.record_finish(filename=self._last_filename, task_id=self._last_task_id)
                         self._timelapse.finish_capture(final=True)
@@ -1412,6 +1424,7 @@ class MqttQueue(Service):
         status_text = self._extract_status_text(payload)
         if self._state == PrintState.PRINTING and status_text:
             if any(word in status_text for word in ("finish", "complete", "done")):
+                self._record_print_complete_alert()
                 self._send_event(
                     EVENT_PRINT_FINISHED,
                     self._build_payload(payload, 100),
@@ -1425,6 +1438,7 @@ class MqttQueue(Service):
                 return
 
         if self._state == PrintState.PRINTING and progress >= 100:
+            self._record_print_complete_alert()
             self._send_event(
                 EVENT_PRINT_FINISHED,
                 self._build_payload(payload, 100),

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -70,6 +70,10 @@ PAUSE_REASON_LABELS = {
 
 FILAMENT_RUNOUT_ERROR_CODE = "0xFF01030001"
 FILAMENT_RUNOUT_CONFIRM_WINDOW_SEC = 8.0
+TIMELAPSE_START_PROMPT_BOOT_WINDOW_SEC = 20.0
+STOP_CONFIRMATION_COMMAND_TYPES = {
+    1057,  # Observed firmware stop-complete reply on stored-file jobs
+}
 
 G28_DEDUPE_WINDOW_SEC = 10.0
 STORED_FILE_SELECTION_TIMEOUT_SEC = 2.0
@@ -177,6 +181,9 @@ class MqttQueue(Service):
         self._reset_print_state()
         self._ha.update_state(mqtt_connected=True)
         self._last_query = 0
+        self._timelapse_start_prompt_window_until = (
+            time.monotonic() + TIMELAPSE_START_PROMPT_BOOT_WINDOW_SEC
+        )
 
     def _reset_print_state(self):
         self._state = PrintState.IDLE
@@ -198,6 +205,7 @@ class MqttQueue(Service):
         self._last_selected_storage_file_name = None
         self._last_print_schedule_filename = None
         self._last_print_schedule_seen_at = 0.0
+        self._clear_timelapse_start_offer()
         self._pause_reason = None
         self._filament_runout_pending = False
         self._filament_runout_pending_at = 0.0
@@ -236,6 +244,23 @@ class MqttQueue(Service):
 
         set_capture_paused(reason is not None, reason=reason)
 
+    def _clear_timelapse_start_offer(self):
+        self._timelapse_start_prompt_pending = False
+        self._timelapse_start_prompt_filename = None
+
+    def _mark_timelapse_start_offer(self, filename=None):
+        normalized = os.path.basename(str(filename or self._last_filename or "")).strip()
+        self._timelapse_start_prompt_pending = True
+        self._timelapse_start_prompt_filename = normalized or None
+
+    def _should_prompt_for_timelapse_start(self):
+        if not getattr(self._timelapse, "enabled", False):
+            return False
+        if self._state != PrintState.IDLE:
+            return False
+        window_until = getattr(self, "_timelapse_start_prompt_window_until", 0.0)
+        return bool(window_until) and time.monotonic() <= window_until
+
     @staticmethod
     def _print_state_value_label(value):
         return MQTT_PRINT_STATE_LABELS.get(value, f"unknown_{value}")
@@ -267,6 +292,12 @@ class MqttQueue(Service):
         if self._state not in (PrintState.IDLE, PrintState.PREPARING, PrintState.PRE_PRINT, PrintState.FAILED):
             return False
 
+        previous_state = self._state
+        defer_timelapse_start = (
+            previous_state == PrintState.IDLE
+            and self._should_prompt_for_timelapse_start()
+        )
+
         self._state = PrintState.PRINTING
         self._print_started_at = time.monotonic()
         self._failure_sent = False
@@ -286,10 +317,21 @@ class MqttQueue(Service):
             self._history.record_start(effective_filename, **record_kwargs)
             self._pending_history_start = False
             log.info(f"Print started, filename={effective_filename!r}")
-            self._timelapse.start_capture(effective_filename)
+            if defer_timelapse_start:
+                self._mark_timelapse_start_offer(effective_filename)
+                log.info(
+                    "Timelapse: active print detected on startup; waiting for user confirmation"
+                )
+            else:
+                self._clear_timelapse_start_offer()
+                self._timelapse.start_capture(effective_filename)
         else:
             self._pending_history_start = True
-            log.info("Print started, history deferred (no filename yet)")
+            if defer_timelapse_start:
+                self._mark_timelapse_start_offer()
+                log.info("Print started, history deferred and timelapse awaiting user confirmation")
+            else:
+                log.info("Print started, history deferred (no filename yet)")
 
         self._ha.update_state(print_status="printing")
         self._send_event(EVENT_PRINT_STARTED, self._build_payload(payload, progress))
@@ -307,7 +349,10 @@ class MqttQueue(Service):
             if self._preview_url:
                 record_kwargs["preview_url"] = self._preview_url
             self._history.record_start(self._last_filename, **record_kwargs)
-            self._timelapse.start_capture(self._last_filename)
+            if getattr(self, "_timelapse_start_prompt_pending", False):
+                self._mark_timelapse_start_offer(self._last_filename)
+            else:
+                self._timelapse.start_capture(self._last_filename)
             self._pending_history_start = False
             log.info(f"Print start completed after filename arrived, filename={self._last_filename!r}")
 
@@ -1172,6 +1217,21 @@ class MqttQueue(Service):
                 log.info("Early print activation via ct 1044")
             return
 
+        if (
+            command_type in STOP_CONFIRMATION_COMMAND_TYPES
+            and payload.get("reply") == 0
+            and self._stop_requested
+            and self._state in (PrintState.PREPARING, PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED)
+        ):
+            log.info(
+                "History: print cancelled (firmware stop confirmation %s), filename=%r",
+                command_type,
+                self._last_filename,
+            )
+            self._record_failure(payload, self._last_progress or 0, "cancelled")
+            self._reset_print_state()
+            return
+
         # --- commandType 1000: printer state machine transitions ---
         if command_type == 1000:
             value = payload.get("value")
@@ -1459,6 +1519,19 @@ class MqttQueue(Service):
                 "enabled": getattr(self._timelapse, "enabled", None),
                 "capturing": bool(capture_thread and capture_thread.is_alive()),
             }
+        prompt_filename = (
+            getattr(self, "_timelapse_start_prompt_filename", None)
+            or self._last_filename
+        )
+        timelapse_state = dict(timelapse_state)
+        timelapse_state["prompt_start"] = bool(
+            getattr(self, "_timelapse_start_prompt_pending", False)
+            and self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED)
+            and not timelapse_state.get("capturing")
+        )
+        timelapse_state["prompt_filename"] = prompt_filename
+        if timelapse_state["prompt_start"] and not timelapse_state.get("detail"):
+            timelapse_state["detail"] = "Open Timelapse to continue or dismiss capture for this print."
         return {
             "print": {
                 "print_state": self._state.value,
@@ -1501,6 +1574,30 @@ class MqttQueue(Service):
             "debug_logging": getattr(self, "_debug_log_payloads", False),
             "timelapse": timelapse_state,
         }
+
+    def start_timelapse_for_current_print(self):
+        with self._state_lock:
+            if not getattr(self._timelapse, "enabled", False):
+                raise RuntimeError("Timelapse is disabled.")
+            if self._state not in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
+                raise RuntimeError("No active print is available for timelapse.")
+            filename = os.path.basename(str(self._last_filename or "")).strip()
+            if not filename:
+                raise RuntimeError("Current print filename is not available yet.")
+            self._clear_timelapse_start_offer()
+
+        self._timelapse.start_capture(filename)
+        return filename
+
+    def dismiss_timelapse_start_offer(self):
+        with self._state_lock:
+            filename = os.path.basename(
+                str(getattr(self, "_timelapse_start_prompt_filename", None) or self._last_filename or "")
+            ).strip() or None
+            self._clear_timelapse_start_offer()
+        discard_pending_resume = getattr(self._timelapse, "discard_pending_resume", None)
+        if callable(discard_pending_resume):
+            discard_pending_resume(filename)
 
     def simulate_event(self, event_type, payload=None):
         """Simulate an MQTT event for testing.

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -60,6 +60,14 @@ FILAMENT_STATE_LABELS = {
     "not_loaded": "Not Loaded",
 }
 
+FILAMENT_ISSUE_LABELS = {
+    "runout": "Filament runout",
+}
+
+PAUSE_REASON_LABELS = {
+    "filament_runout": "Filament runout",
+}
+
 FILAMENT_RUNOUT_ERROR_CODE = "0xFF01030001"
 
 G28_DEDUPE_WINDOW_SEC = 10.0
@@ -134,6 +142,9 @@ class MqttQueue(Service):
         self._filament_change_value = None
         self._filament_change_progress = None
         self._filament_change_step_len = None
+        self._filament_issue = None
+        self._filament_issue_code = None
+        self._pause_reason = None
         self._stored_file_selection_cond = threading.Condition(self._state_lock)
         self._stored_file_preview_request_lock = threading.Lock()
         self._stored_file_preview_cache = {}
@@ -182,6 +193,7 @@ class MqttQueue(Service):
         self._last_selected_storage_file_name = None
         self._last_print_schedule_filename = None
         self._last_print_schedule_seen_at = 0.0
+        self._pause_reason = None
         # Preserve debug setting across resets if possible, but init here if missing
         if not hasattr(self, "_debug_log_payloads"):
              self._debug_log_payloads = False
@@ -208,6 +220,7 @@ class MqttQueue(Service):
             return False
 
         self._state = PrintState.PRINTING
+        self._pause_reason = None
         self._ha.update_state(print_status="printing")
         return True
 
@@ -226,6 +239,7 @@ class MqttQueue(Service):
         self._print_started_at = time.monotonic()
         self._failure_sent = False
         self._last_progress_bucket = None
+        self._pause_reason = None
 
         effective_filename = filename or self._last_filename
 
@@ -882,6 +896,26 @@ class MqttQueue(Service):
             return "unknown"
         return "changing"
 
+    def _filament_detail(self):
+        state = getattr(self, "_filament_state", "unknown")
+        issue = getattr(self, "_filament_issue", None)
+        progress = getattr(self, "_filament_change_progress", None)
+
+        if state == "changing":
+            if progress is not None and 0 < progress < 100:
+                return f"Filament swap in progress ({progress}%)"
+            return "Filament swap in progress"
+
+        if state == "loaded" and getattr(self, "_pause_reason", None) == "filament_runout" and self._state == PrintState.PAUSED:
+            return "Filament loaded. Resume the print when ready."
+
+        if issue == "runout":
+            if self._state == PrintState.PAUSED:
+                return "Printer paused for filament reload."
+            return "Filament runout or break detected."
+
+        return None
+
     def _update_filament_state(self, payload):
         if not isinstance(payload, dict):
             return
@@ -896,10 +930,17 @@ class MqttQueue(Service):
                 step_len_raw = payload.get("step_len")
             self._filament_change_step_len = self._safe_int(step_len_raw)
             self._filament_state = self._normalize_filament_state(payload)
+            if self._filament_state in ("changing", "loaded"):
+                self._filament_issue = None
+                self._filament_issue_code = None
             return
 
         if command_type == 1085 and str(payload.get("errorCode") or "") == FILAMENT_RUNOUT_ERROR_CODE:
             self._filament_state = "not_loaded"
+            self._filament_issue = "runout"
+            self._filament_issue_code = FILAMENT_RUNOUT_ERROR_CODE
+            if self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
+                self._pause_reason = "filament_runout"
             return
 
         if (
@@ -908,6 +949,10 @@ class MqttQueue(Service):
             and self._safe_int(payload.get("value")) == 6
         ):
             self._filament_state = "not_loaded"
+            self._filament_issue = "runout"
+            self._filament_issue_code = FILAMENT_RUNOUT_ERROR_CODE
+            if self._state in (PrintState.PRE_PRINT, PrintState.PRINTING, PrintState.PAUSED):
+                self._pause_reason = "filament_runout"
             return
 
     def _forward_to_ha(self, payload):
@@ -1059,6 +1104,8 @@ class MqttQueue(Service):
                     self._transition_to_active(payload, progress=0)
             elif value == 2 and self._state == PrintState.PRINTING:
                 self._state = PrintState.PAUSED
+                if getattr(self, "_filament_issue", None) == "runout":
+                    self._pause_reason = "filament_runout"
                 self._ha.update_state(print_status="paused")
                 log.info("Print paused (ct 1000 value=2)")
             elif value == 3 and self._state == PrintState.PAUSED:
@@ -1319,6 +1366,8 @@ class MqttQueue(Service):
                 "last_task_id": self._last_task_id,
                 "failure_sent": self._failure_sent,
                 "preview_url": self._preview_url,
+                "pause_reason": getattr(self, "_pause_reason", None),
+                "pause_reason_label": PAUSE_REASON_LABELS.get(getattr(self, "_pause_reason", None)),
             },
             "temperature": {
                 "nozzle": self._nozzle_temp,
@@ -1331,6 +1380,12 @@ class MqttQueue(Service):
                 "state": getattr(self, "_filament_state", "unknown"),
                 "label": FILAMENT_STATE_LABELS.get(getattr(self, "_filament_state", "unknown"), "Unknown"),
                 "loaded": True if getattr(self, "_filament_state", "unknown") == "loaded" else None,
+                "issue": getattr(self, "_filament_issue", None),
+                "issue_label": FILAMENT_ISSUE_LABELS.get(getattr(self, "_filament_issue", None)),
+                "issue_code": getattr(self, "_filament_issue_code", None),
+                "detail": self._filament_detail(),
+                "pause_reason": getattr(self, "_pause_reason", None),
+                "pause_reason_label": PAUSE_REASON_LABELS.get(getattr(self, "_pause_reason", None)),
                 "raw_value": getattr(self, "_filament_change_value", None),
                 "progress": getattr(self, "_filament_change_progress", None),
                 "step_len": getattr(self, "_filament_change_step_len", None),

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -20,6 +20,8 @@ _SNAPSHOT_TIMEOUT = 10
 _RESUME_WINDOW_SEC = 60 * 60  # 60 minutes
 _IN_PROGRESS_SUBDIR = "in_progress"
 _MAX_ORPHAN_AGE_SEC = 24 * 3600  # 24 hours
+_RECOVERY_REQUEST_COOLDOWN_SEC = 8.0
+_RECOVERY_WAIT_SEC = 4.0
 
 
 def _resolve_ffmpeg_path():
@@ -49,6 +51,10 @@ class TimelapseService:
         self._current_dir = None
         self._current_filename = None
         self._frame_count = 0
+        self._capture_pause_reason = None
+        self._last_recovery_request_at = 0.0
+        self._recovery_active = False
+        self._recovery_reason = None
 
         # Set defaults to ensure attributes exist even if config is None
         self._enabled = False
@@ -104,6 +110,60 @@ class TimelapseService:
     @property
     def enabled(self):
         return self._enabled
+
+    def get_runtime_state(self):
+        capture_thread = self._capture_thread
+        return {
+            "enabled": self._enabled,
+            "capturing": bool(capture_thread and capture_thread.is_alive()),
+            "paused": self._capture_pause_reason is not None,
+            "pause_reason": self._capture_pause_reason,
+            "recovering": self._recovery_active,
+            "recovery_reason": self._recovery_reason,
+            "detail": self._runtime_detail(),
+        }
+
+    def _runtime_detail(self):
+        if self._recovery_active:
+            return "Recovering video stream..."
+        if self._capture_pause_reason == "filament_runout":
+            return "Paused for filament runout."
+        if self._capture_pause_reason == "filament_change":
+            return "Paused for filament change."
+        return None
+
+    def _set_recovery_state(self, active, reason=None):
+        recovery_reason = str(reason or "").strip() or None
+        with self._lock:
+            changed = (
+                self._recovery_active != bool(active)
+                or self._recovery_reason != recovery_reason
+            )
+            self._recovery_active = bool(active)
+            self._recovery_reason = recovery_reason if active else None
+        if not changed:
+            return
+        if active and recovery_reason:
+            log.info(f"Timelapse: recovery active ({recovery_reason})")
+        elif active:
+            log.info("Timelapse: recovery active")
+        else:
+            log.info("Timelapse: recovery cleared")
+
+    def set_capture_paused(self, paused, reason=None):
+        pause_reason = str(reason or "paused").strip() if paused else None
+        with self._lock:
+            if self._capture_pause_reason == pause_reason:
+                return
+            self._capture_pause_reason = pause_reason
+        if pause_reason:
+            log.info(f"Timelapse: capture paused ({pause_reason})")
+        else:
+            log.info("Timelapse: capture resumed")
+
+    def is_capture_paused(self):
+        with self._lock:
+            return self._capture_pause_reason is not None
 
     def _enable_video_for_timelapse(self):
         """Start video streaming for timelapse capture if not already active."""
@@ -175,19 +235,67 @@ class TimelapseService:
         from web import app
         vq = app.svc.svcs.get("videoqueue")
         if not vq or not hasattr(vq, "last_frame_at"):
+            self._set_recovery_state(False)
             return True
         now = time.monotonic()
-        last_frame = getattr(vq, "last_frame_at", None)
-        if last_frame and (now - last_frame) <= max_age:
+        if self._has_recent_video_frame(vq, now=now, max_age=max_age):
+            self._set_recovery_state(False)
             return True
         deadline = now + timeout
         while time.monotonic() < deadline:
-            last_frame = getattr(vq, "last_frame_at", None)
-            if last_frame and (time.monotonic() - last_frame) <= max_age:
+            if self._has_recent_video_frame(vq, max_age=max_age):
+                self._set_recovery_state(False)
                 return True
             time.sleep(0.1)
+        requested = self._request_video_recovery(
+            "timelapse has no recent video frame",
+            force_pppp_recycle=not bool(getattr(getattr(vq, "pppp", None), "connected", False)),
+        )
+        if requested:
+            recovery_deadline = time.monotonic() + _RECOVERY_WAIT_SEC
+            while time.monotonic() < recovery_deadline:
+                if self._has_recent_video_frame(vq, max_age=max_age):
+                    self._set_recovery_state(False)
+                    log.info("Timelapse: video frame recovered after restart request")
+                    return True
+                time.sleep(0.1)
         log.debug("Timelapse: _await_video_frame timed out")
         return False
+
+    @staticmethod
+    def _has_recent_video_frame(vq, now=None, max_age=1.5):
+        last_frame = getattr(vq, "last_frame_at", None)
+        if not last_frame:
+            return False
+        now = time.monotonic() if now is None else now
+        return (now - last_frame) <= max_age
+
+    def _request_video_recovery(self, reason, force_pppp_recycle=False):
+        from web import app
+
+        vq = app.svc.svcs.get("videoqueue")
+        if not vq:
+            return False
+
+        request_recovery = getattr(vq, "request_live_recovery", None)
+        if not callable(request_recovery):
+            return False
+
+        now = time.monotonic()
+        if (now - self._last_recovery_request_at) < _RECOVERY_REQUEST_COOLDOWN_SEC:
+            return False
+
+        requested = bool(
+            request_recovery(
+                reason=reason,
+                force_pppp_recycle=force_pppp_recycle,
+            )
+        )
+        if requested:
+            self._last_recovery_request_at = now
+            self._set_recovery_state(True, reason)
+            log.info(f"Timelapse: requested video recovery ({reason})")
+        return requested
 
     def _cancel_finalize_timer(self):
         """Cancel any pending delayed assembly timer."""
@@ -272,6 +380,10 @@ class TimelapseService:
 
         with self._lock:
             self._stop_capture_thread()
+            self._capture_pause_reason = None
+            self._last_recovery_request_at = 0.0
+            self._recovery_active = False
+            self._recovery_reason = None
 
             # Check if we can seamlessly resume a previous capture of the same print
             can_resume = (
@@ -333,6 +445,9 @@ class TimelapseService:
         assemble_frame_count = 0
         with self._lock:
             self._stop_capture_thread()
+            self._capture_pause_reason = None
+            self._recovery_active = False
+            self._recovery_reason = None
             if not self._current_dir:
                 if not self._resume_dir:
                     self._disable_video_for_timelapse()
@@ -383,6 +498,9 @@ class TimelapseService:
         assemble_frame_count = 0
         with self._lock:
             self._stop_capture_thread()
+            self._capture_pause_reason = None
+            self._recovery_active = False
+            self._recovery_reason = None
             self._cancel_pending_resume()
             if self._current_dir and self._frame_count >= 2:
                 log.info("Timelapse: print failed, assembling partial timelapse")
@@ -407,12 +525,15 @@ class TimelapseService:
         if self._capture_thread and self._capture_thread.is_alive():
             self._stop_event.set()
             self._capture_thread.join(timeout=5)
-            self._capture_thread = None
+        self._capture_thread = None
 
     def _capture_loop(self):
         """Periodically capture snapshots from the video stream."""
         try:
             while not self._stop_event.is_set():
+                if self.is_capture_paused():
+                    self._stop_event.wait(min(self._interval, 1.0))
+                    continue
                 try:
                     self._take_snapshot()
                 except Exception as err:
@@ -486,6 +607,7 @@ class TimelapseService:
                 )
 
             if result.returncode == 0 and os.path.exists(frame_path) and os.path.getsize(frame_path) > 0:
+                self._set_recovery_state(False)
                 self._frame_count += 1
                 self._write_meta(self._current_dir, self._current_filename, self._frame_count)
             else:
@@ -498,12 +620,17 @@ class TimelapseService:
                     log.warning(f"Timelapse: snapshot failed: {stderr}")
                 else:
                     log.warning("Timelapse: snapshot failed")
+                self._request_video_recovery("timelapse snapshot failed to decode live stream")
         except subprocess.TimeoutExpired:
             try:
                 os.remove(frame_path)
             except OSError:
                 pass
             log.warning("Timelapse: snapshot timed out waiting for a camera frame")
+            self._request_video_recovery(
+                "timelapse snapshot timed out waiting for a camera frame",
+                force_pppp_recycle=True,
+            )
         except OSError as err:
             try:
                 os.remove(frame_path)

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -112,16 +112,20 @@ class TimelapseService:
         return self._enabled
 
     def get_runtime_state(self):
-        capture_thread = self._capture_thread
-        return {
-            "enabled": self._enabled,
-            "capturing": bool(capture_thread and capture_thread.is_alive()),
-            "paused": self._capture_pause_reason is not None,
-            "pause_reason": self._capture_pause_reason,
-            "recovering": self._recovery_active,
-            "recovery_reason": self._recovery_reason,
-            "detail": self._runtime_detail(),
-        }
+        with self._lock:
+            capture_thread = self._capture_thread
+            return {
+                "enabled": self._enabled,
+                "capturing": bool(capture_thread and capture_thread.is_alive()),
+                "paused": self._capture_pause_reason is not None,
+                "pause_reason": self._capture_pause_reason,
+                "recovering": self._recovery_active,
+                "recovery_reason": self._recovery_reason,
+                "resume_available": bool(self._resume_dir),
+                "resume_filename": self._resume_filename,
+                "resume_frame_count": self._resume_frame_count,
+                "detail": self._runtime_detail(),
+            }
 
     def _runtime_detail(self):
         if self._recovery_active:
@@ -315,6 +319,27 @@ class TimelapseService:
             self._resume_dir = None
             self._resume_filename = None
             self._resume_frame_count = 0
+
+    def discard_pending_resume(self, filename=None):
+        """Discard a pending resumable capture, optionally scoped by filename."""
+        with self._lock:
+            if self._capture_thread and self._capture_thread.is_alive():
+                return False
+
+            requested = os.path.basename(str(filename or "")).strip() or None
+            current = os.path.basename(str(self._resume_filename or "")).strip() or None
+            if requested and current and requested != current:
+                return False
+            if not self._resume_dir:
+                return False
+
+            log.info(f"Timelapse: discarded pending capture for '{self._resume_filename}'")
+            self._cancel_pending_resume()
+            self._capture_pause_reason = None
+            self._recovery_active = False
+            self._recovery_reason = None
+            self._disable_video_for_timelapse()
+            return True
 
     def _schedule_finalize(self, dir_path, filename, frame_count, suffix=""):
         """Save capture state and schedule delayed assembly.

--- a/web/service/video.py
+++ b/web/service/video.py
@@ -7,6 +7,7 @@ from queue import Empty
 _STALL_TIMEOUT = 5.0  # seconds without a frame before soft restart; 3 failures → ServiceRestartSignal
 _STALL_MAX_RETRIES = 3  # escalate to hard restart after this many consecutive soft-reset failures
 _LIVE_REFRESH_COOLDOWN = 4.0
+_EXTERNAL_RECOVERY_COOLDOWN = 3.0
 
 log = logging.getLogger(__name__)
 
@@ -68,6 +69,10 @@ class VideoQueue(Service):
         self._pending_disable = False
         self._in_place_recovery = False
         self._pppp_recycle_requested_at = None
+        self._manual_recovery_requested = False
+        self._manual_recovery_reason = None
+        self._manual_recovery_force_pppp = False
+        self._manual_recovery_requested_at = 0.0
         super().__init__()
 
     def api_start_live(self):
@@ -281,6 +286,63 @@ class VideoQueue(Service):
         self._pending_disable = False
         self._in_place_recovery = False
         self._pppp_recycle_requested_at = None
+        self._manual_recovery_requested = False
+        self._manual_recovery_reason = None
+        self._manual_recovery_force_pppp = False
+        self._manual_recovery_requested_at = 0.0
+
+    def request_live_recovery(self, reason="manual recovery", force_pppp_recycle=False):
+        """Ask the worker thread to refresh the live stream for a stalled client."""
+        if not self.video_enabled:
+            log.debug("VideoQueue: ignoring live recovery request because video is disabled")
+            return False
+
+        now = time.monotonic()
+        if (
+            getattr(self, "_manual_recovery_requested", False)
+            and (now - getattr(self, "_manual_recovery_requested_at", 0.0)) < _EXTERNAL_RECOVERY_COOLDOWN
+        ):
+            return False
+
+        self._manual_recovery_requested = True
+        self._manual_recovery_reason = str(reason or "manual recovery").strip() or "manual recovery"
+        self._manual_recovery_force_pppp = bool(force_pppp_recycle)
+        self._manual_recovery_requested_at = now
+
+        if self.state == RunState.Stopped and not self.wanted:
+            self.start()
+        else:
+            self._event.set()
+        return True
+
+    def _handle_requested_recovery(self, pppp):
+        if not getattr(self, "_manual_recovery_requested", False):
+            return False
+
+        reason = getattr(self, "_manual_recovery_reason", None) or "manual recovery"
+        force_pppp_recycle = bool(getattr(self, "_manual_recovery_force_pppp", False))
+        self._manual_recovery_requested = False
+        self._manual_recovery_reason = None
+        self._manual_recovery_force_pppp = False
+
+        if (
+            force_pppp_recycle
+            or pppp is None
+            or not getattr(pppp, "connected", False)
+            or not hasattr(pppp, "_api")
+            or getattr(self, "api_id", None) is None
+        ):
+            log.warning(f"VideoQueue: {reason}; recycling PPPP in place")
+            self._recycle_pppp_in_place()
+            return True
+
+        self._attempt_stall_recovery(
+            pppp,
+            f"VideoQueue: {reason}; refreshing live stream",
+            f"VideoQueue: failed recovery request ({reason})",
+            f"Video recovery request exhausted ({reason})",
+        )
+        return True
 
     def _recycle_pppp_in_place(self):
         """Recycle the PPPP session without restarting the VideoQueue service.
@@ -377,6 +439,9 @@ class VideoQueue(Service):
 
         if not self.pppp:
             self.pppp = self._ensure_pppp_ready()
+            if self._handle_requested_recovery(self.pppp):
+                time.sleep(0.1)
+                return
             if not self.pppp:
                 log.debug("VideoQueue: PPPP not available yet")
                 time.sleep(0.5)
@@ -387,6 +452,10 @@ class VideoQueue(Service):
         pppp = self.pppp
         if pppp is None:
             raise ServiceRestartSignal("PPPP reference lost during video session")
+
+        if self._handle_requested_recovery(pppp):
+            time.sleep(0.1)
+            return
 
         if not getattr(pppp, "connected", False):
             log.debug("VideoQueue: PPPP exists but is not connected yet")


### PR DESCRIPTION
Fixed a bug where one finished print could create many duplicate History entries.

What was happening:

The printer was sending stale follow-up MQTT updates after the job had already finished. ankerctl treated those late messages like brand-new print starts. That created extra zero-second History rows, and only the real first row kept the Reprint button. What I changed:

Added MQTT guards to ignore stale post-finish updates for the same print. Added history deduping by task_id so repeated finished-job starts reuse the existing row instead of creating a new one. Result:

One completed print should now make one History entry. The proper Reprint button should stay on that single entry. Verified:

Targeted tests passed: 67 passed.