### PR TITLE
More bug fixes.

### DIFF
--- a/cli/model.py
+++ b/cli/model.py
@@ -75,11 +75,15 @@ def default_home_assistant_config():
 def default_filament_service_config():
     return {
         "allow_legacy_swap": os.getenv("FILAMENT_ALLOW_LEGACY_SWAP", "false").lower() in ("true", "1", "yes"),
-        "manual_swap_preheat_temp_c": int(os.getenv("FILAMENT_MANUAL_SWAP_PREHEAT_TEMP_C", 140)),
+        "manual_swap_preheat_temp_c": int(os.getenv("FILAMENT_MANUAL_SWAP_PREHEAT_TEMP_C", 180)),
         "quick_move_length_mm": float(os.getenv("FILAMENT_QUICK_MOVE_LENGTH_MM", 40)),
         "swap_prime_length_mm": float(os.getenv("FILAMENT_SWAP_PRIME_LENGTH_MM", 10)),
-        "swap_unload_length_mm": float(os.getenv("FILAMENT_SWAP_UNLOAD_LENGTH_MM", 50)),
+        "swap_unload_length_mm": float(os.getenv("FILAMENT_SWAP_UNLOAD_LENGTH_MM", 60)),
         "swap_load_length_mm": float(os.getenv("FILAMENT_SWAP_LOAD_LENGTH_MM", 120)),
+        "swap_home_pause_s": float(os.getenv(
+            "FILAMENT_SWAP_HOME_PAUSE_S",
+            os.getenv("FILAMENT_SWAP_HOME_SETTLE_S", 55),
+        )),
     }
 
 

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -5791,11 +5791,12 @@ $(function () {
     };
     let _filamentSwapSettings = {
         allow_legacy_swap: false,
-        manual_swap_preheat_temp_c: 140,
+        manual_swap_preheat_temp_c: 180,
         quick_move_length_mm: 40,
         swap_prime_length_mm: 10,
-        swap_unload_length_mm: 50,
+        swap_unload_length_mm: 60,
         swap_load_length_mm: 120,
+        swap_home_pause_s: 55,
     };
 
     function filamentFindProfileById(profileId) {
@@ -5902,6 +5903,7 @@ $(function () {
             "filament-swap-prime-length",
             "filament-swap-unload-length",
             "filament-swap-load-length",
+            "filament-swap-home-pause",
         ].forEach(id => {
             const el = document.getElementById(id);
             if (el) el.disabled = !legacyEnabled;
@@ -5911,7 +5913,7 @@ $(function () {
         if (!stateEl || _filamentSwapToken) return;
 
         if (legacyEnabled) {
-            stateEl.textContent = "Guided automatic swap enabled. Start Swap will home, park, prime, retract, and then wait for you to load the new filament.";
+            stateEl.textContent = "Guided automatic swap enabled. Start Swap will heat, home, raise Z, prime, retract, and then wait for you to load the new filament.";
         } else {
             stateEl.textContent =
                 `Recommended guided swap enabled. Start Swap will preheat to ${_filamentSwapSettings.manual_swap_preheat_temp_c}°C and wait for a manual filament change.`;
@@ -5933,12 +5935,14 @@ $(function () {
             const primeLengthEl = document.getElementById("filament-swap-prime-length");
             const unloadLengthEl = document.getElementById("filament-swap-unload-length");
             const loadLengthEl = document.getElementById("filament-swap-load-length");
+            const homePauseEl = document.getElementById("filament-swap-home-pause");
             if (quickLengthEl) quickLengthEl.value = _filamentSwapSettings.quick_move_length_mm ?? 40;
-            if (tempEl) tempEl.value = _filamentSwapSettings.manual_swap_preheat_temp_c ?? 140;
+            if (tempEl) tempEl.value = _filamentSwapSettings.manual_swap_preheat_temp_c ?? 180;
             if (legacyEl) legacyEl.checked = !!_filamentSwapSettings.allow_legacy_swap;
             if (primeLengthEl) primeLengthEl.value = _filamentSwapSettings.swap_prime_length_mm ?? 10;
-            if (unloadLengthEl) unloadLengthEl.value = _filamentSwapSettings.swap_unload_length_mm ?? 50;
+            if (unloadLengthEl) unloadLengthEl.value = _filamentSwapSettings.swap_unload_length_mm ?? 60;
             if (loadLengthEl) loadLengthEl.value = _filamentSwapSettings.swap_load_length_mm ?? 120;
+            if (homePauseEl) homePauseEl.value = _filamentSwapSettings.swap_home_pause_s ?? 55;
             filamentUpdateSwapModeUi();
             filamentSetSwapSettingsStatus(
                 _filamentSwapSettings.allow_legacy_swap
@@ -5967,18 +5971,20 @@ $(function () {
 
     function filamentUpdateSwapState(data) {
         const stateEl = document.getElementById("filament-swap-state");
+        const startBtn = document.getElementById("filament-swap-start-btn");
         const confirmBtn = document.getElementById("filament-swap-confirm-btn");
         const cancelBtn = document.getElementById("filament-swap-cancel-btn");
         const swap = data && data.pending ? data.swap : null;
         const previousSwapToken = _filamentSwapToken;
         const previousSwapMode = _filamentSwapMode;
-        const running = swap && ["homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"].includes(swap.phase);
+        const running = swap && ["homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading", "cooling_down"].includes(swap.phase);
 
         _filamentSwapToken = swap ? swap.token : null;
         _filamentSwapMode = swap ? swap.mode : null;
 
+        if (startBtn) startBtn.disabled = !!swap;
         if (confirmBtn) confirmBtn.disabled = !swap || running;
-        if (cancelBtn) cancelBtn.disabled = !swap || running;
+        if (cancelBtn) cancelBtn.disabled = !swap;
 
         if (swap) {
             filamentStartSwapPolling();
@@ -6250,9 +6256,11 @@ $(function () {
     const filamentSwapStartBtn = document.getElementById("filament-swap-start-btn");
     if (filamentSwapStartBtn) {
         filamentSwapStartBtn.addEventListener("click", async function () {
+            let keepStartDisabled = false;
+            this.disabled = true;
             try {
                 const legacyEnabled = !!document.getElementById("filament-allow-legacy-swap")?.checked;
-                const manualTempC = parseInt(document.getElementById("filament-manual-swap-temp")?.value || "140", 10);
+                const manualTempC = parseInt(document.getElementById("filament-manual-swap-temp")?.value || "180", 10);
                 let payload = {
                     allow_legacy_swap: legacyEnabled,
                     manual_swap_preheat_temp_c: manualTempC,
@@ -6263,6 +6271,7 @@ $(function () {
                     const primeLengthMm = parseFloat(document.getElementById("filament-swap-prime-length")?.value || "0");
                     const unloadLengthMm = parseFloat(document.getElementById("filament-swap-unload-length")?.value || "0");
                     const loadLengthMm = parseFloat(document.getElementById("filament-swap-load-length")?.value || "0");
+                    const homePauseS = parseFloat(document.getElementById("filament-swap-home-pause")?.value || "55");
                     if (!Number.isFinite(unloadProfileId) || !Number.isFinite(loadProfileId)) {
                         filamentSetServiceStatus("Select unload and load profiles first.", "warning");
                         return;
@@ -6277,19 +6286,25 @@ $(function () {
                         prime_length_mm: primeLengthMm,
                         unload_length_mm: unloadLengthMm,
                         load_length_mm: loadLengthMm,
+                        home_pause_s: homePauseS,
                     };
                 }
                 filamentSetServiceStatus(
                     legacyEnabled
-                        ? "Guided automatic swap started. Homing and parking before unload..."
+                        ? "Guided automatic swap started. Heating, homing, and raising Z before unload..."
                         : `Recommended guided swap started. Preheating to ${manualTempC}°C...`,
                     "warning"
                 );
                 const res = await filamentServiceRequest("/api/filaments/service/swap/start", payload);
                 filamentUpdateSwapState(res);
+                keepStartDisabled = !!res.pending;
                 filamentSetServiceStatus(res.message, legacyEnabled ? "primary" : "warning");
             } catch (err) {
                 filamentSetServiceStatus(`Swap start failed: ${err.message}`, "danger");
+            } finally {
+                if (!keepStartDisabled && !_filamentSwapToken) {
+                    this.disabled = false;
+                }
             }
         });
     }
@@ -6337,7 +6352,8 @@ $(function () {
             const primeLengthEl = document.getElementById("filament-swap-prime-length");
             const unloadLengthEl = document.getElementById("filament-swap-unload-length");
             const loadLengthEl = document.getElementById("filament-swap-load-length");
-            const tempC = parseInt(tempEl?.value || "140", 10);
+            const homePauseEl = document.getElementById("filament-swap-home-pause");
+            const tempC = parseInt(tempEl?.value || "180", 10);
             try {
                 const res = await filamentServiceRequest("/api/settings/filament-service", {
                     filament_service: {
@@ -6345,17 +6361,19 @@ $(function () {
                         manual_swap_preheat_temp_c: tempC,
                         quick_move_length_mm: parseFloat(quickLengthEl?.value || "40"),
                         swap_prime_length_mm: parseFloat(primeLengthEl?.value || "10"),
-                        swap_unload_length_mm: parseFloat(unloadLengthEl?.value || "50"),
+                        swap_unload_length_mm: parseFloat(unloadLengthEl?.value || "60"),
                         swap_load_length_mm: parseFloat(loadLengthEl?.value || "120"),
+                        swap_home_pause_s: parseFloat(homePauseEl?.value || "55"),
                     },
                 });
                 _filamentSwapSettings = res.filament_service || _filamentSwapSettings;
                 if (quickLengthEl) quickLengthEl.value = _filamentSwapSettings.quick_move_length_mm ?? 40;
-                if (tempEl) tempEl.value = _filamentSwapSettings.manual_swap_preheat_temp_c ?? 140;
+                if (tempEl) tempEl.value = _filamentSwapSettings.manual_swap_preheat_temp_c ?? 180;
                 if (legacyEl) legacyEl.checked = !!_filamentSwapSettings.allow_legacy_swap;
                 if (primeLengthEl) primeLengthEl.value = _filamentSwapSettings.swap_prime_length_mm ?? 10;
-                if (unloadLengthEl) unloadLengthEl.value = _filamentSwapSettings.swap_unload_length_mm ?? 50;
+                if (unloadLengthEl) unloadLengthEl.value = _filamentSwapSettings.swap_unload_length_mm ?? 60;
                 if (loadLengthEl) loadLengthEl.value = _filamentSwapSettings.swap_load_length_mm ?? 120;
+                if (homePauseEl) homePauseEl.value = _filamentSwapSettings.swap_home_pause_s ?? 55;
                 filamentUpdateSwapModeUi();
                 filamentSetSwapSettingsStatus("Filament service settings saved.", "success");
             } catch (err) {

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -3299,8 +3299,13 @@ $(function () {
     $("#camera-source-select").on("change", async function () {
         const select = $(this);
         const selected = select.val() || "printer";
+        const previousExternalPreviewEnabled = _externalCameraPreviewEnabled;
         select.prop("disabled", true);
         try {
+            if (selected === "external") {
+                _externalCameraPreviewEnabled = false;
+                _cameraState.previewError = null;
+            }
             const successMessage = selected === "external"
                 ? (_cameraState.externalConfigured
                     ? "Camera source switched to external camera."
@@ -3308,6 +3313,7 @@ $(function () {
                 : "Camera source switched to printer camera.";
             await saveCameraSettings({ source: selected }, successMessage);
         } catch (err) {
+            _externalCameraPreviewEnabled = previousExternalPreviewEnabled;
             flash_message(`Failed to switch camera source: ${err.message || err}`, "danger");
             await loadCameraSettings();
         } finally {

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -549,7 +549,7 @@ $(function () {
     let _externalCameraPreviewTimer = null;
     let _externalCameraPreviewToken = 0;
     let _externalCameraPreviewObjectUrl = null;
-    let _externalCameraPreviewEnabled = true;
+    let _externalCameraPreviewEnabled = false;
     let _externalCameraPreviewContextKey = null;
     let _externalCameraPreviewStreamActive = false;
     let videoEnabled = false;
@@ -823,8 +823,8 @@ $(function () {
         if (!controls.find("#external-preview-toggle").length) {
             const toggleCol = $(`
                 <div class="col-6">
-                    <button class="w-100 btn btn-secondary camera-control-btn external-preview-toggle" id="external-preview-toggle" aria-pressed="true">
-                        <i class="bi bi-camera-video-off"></i> Disable Preview
+                    <button class="w-100 btn btn-secondary camera-control-btn external-preview-toggle" id="external-preview-toggle" aria-pressed="false">
+                        <i class="bi bi-camera-video"></i> Enable Preview
                     </button>
                 </div>
             `);
@@ -3300,11 +3300,14 @@ $(function () {
         const select = $(this);
         const selected = select.val() || "printer";
         const previousExternalPreviewEnabled = _externalCameraPreviewEnabled;
+        const previousPrinterVideoEnabled = videoEnabled;
         select.prop("disabled", true);
         try {
             if (selected === "external") {
                 _externalCameraPreviewEnabled = false;
                 _cameraState.previewError = null;
+            } else {
+                setPrinterVideoEnabled(false);
             }
             const successMessage = selected === "external"
                 ? (_cameraState.externalConfigured
@@ -3314,6 +3317,9 @@ $(function () {
             await saveCameraSettings({ source: selected }, successMessage);
         } catch (err) {
             _externalCameraPreviewEnabled = previousExternalPreviewEnabled;
+            if (previousPrinterVideoEnabled !== videoEnabled) {
+                setPrinterVideoEnabled(previousPrinterVideoEnabled);
+            }
             flash_message(`Failed to switch camera source: ${err.message || err}`, "danger");
             await loadCameraSettings();
         } finally {

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1851,7 +1851,11 @@ $(function () {
             }
             if (data.status === "connected") {
                 setConnectionBadge(this.badge, "success");
-                setConnectionBadge("#badge-ctrl", "success");
+                if (data.source === "service") {
+                    setConnectionBadge("#badge-ctrl", "success");
+                } else {
+                    setConnectionBadge("#badge-ctrl", "warning");
+                }
             } else if (data.status === "disconnected") {
                 setConnectionBadge(this.badge, "warning");
                 setConnectionBadge("#badge-ctrl", "warning");

--- a/static/tabs/debug.html
+++ b/static/tabs/debug.html
@@ -104,11 +104,6 @@
                                         Log MQTT Payloads (Full JSON)
                                     </label>
                                 </div>
-                                <hr>
-                                <h6 class="text-muted small mb-2">Quick Actions</h6>
-                                <button class="btn btn-sm btn-outline-warning disabled">
-                                    {{ macro.bi_icon("ban") }} Force Close Orphans (TODO)
-                                </button>
                             </div>
                         </div>
                     </div>

--- a/static/tabs/filaments.html
+++ b/static/tabs/filaments.html
@@ -72,9 +72,14 @@
                                 <div class="border rounded-3 p-3 h-100">
                                     <div class="fw-semibold mb-2">Swap Filament</div>
                                     <div class="alert alert-warning py-2 small mb-3">
+                                        Recommended method: preheat the nozzle, release the extruder lever,
+                                        and pull the filament manually to reduce the risk of debris or melted filament
+                                        sticking to the drive gear.
+                                        <!--
                                         Recommended method: preheat the nozzle to 130-150°C, release the extruder lever,
                                         and pull the filament manually to reduce the risk of debris or melted filament
                                         sticking to the drive gear.
+                                        -->
                                     </div>
                                     <div class="row g-3">
                                         <div class="col-12">
@@ -83,8 +88,8 @@
                                                 <div class="row g-3 align-items-end">
                                                     <div class="col-sm-6">
                                                         <label for="filament-manual-swap-temp" class="form-label">Manual Swap Preheat (°C)</label>
-                                                        <input type="number" class="form-control" id="filament-manual-swap-temp" min="130" max="150" step="1" value="140">
-                                                        <div class="form-text">Used by the recommended guided swap flow.</div>
+                                                        <input type="number" class="form-control" id="filament-manual-swap-temp" min="130" max="300" step="1" value="180">
+                                                        <div class="form-text">Manual flow preheat and legacy safe-home trigger.</div>
                                                     </div>
                                                     <div class="col-sm-6">
                                                         <div class="form-check mt-sm-4 pt-sm-2">
@@ -93,7 +98,12 @@
                                                                 Enable guided automatic unload / purge
                                                             </label>
                                                         </div>
-                                                        <div class="form-text">This will home, lift Z 50 mm, park at X0 Y230, then move filament automatically.</div>
+                                                        <div class="form-text">This will heat, home, lift Z 50 mm, then move filament automatically.</div>
+                                                    </div>
+                                                    <div class="col-sm-6">
+                                                        <label for="filament-swap-home-pause" class="form-label">Home Pause (seconds)</label>
+                                                        <input type="number" class="form-control" id="filament-swap-home-pause" min="0" max="180" step="1" value="55">
+                                                        <div class="form-text">Wait after Home All before raising Z and moving filament.</div>
                                                     </div>
                                                     <div class="col-12 d-flex flex-wrap gap-2 align-items-center">
                                                         <button class="btn btn-outline-secondary btn-sm" id="filament-save-swap-settings-btn">
@@ -122,7 +132,7 @@
                                         </div>
                                         <div class="col-sm-4">
                                             <label for="filament-swap-unload-length" class="form-label">Unload Retract (mm)</label>
-                                            <input type="number" class="form-control" id="filament-swap-unload-length" min="1" max="300" step="1" value="50">
+                                            <input type="number" class="form-control" id="filament-swap-unload-length" min="1" max="300" step="1" value="60">
                                         </div>
                                         <div class="col-sm-4">
                                             <label for="filament-swap-load-length" class="form-label">Load / Purge Length (mm)</label>

--- a/static/tabs/instructions.html
+++ b/static/tabs/instructions.html
@@ -201,7 +201,7 @@
                             </li>
                             <li class="mb-2">
                                 <strong>Enable guided automatic unload / purge</strong> only when the printer is ready
-                                for movement. It will warn first, home the printer, lift Z 50 mm, park at X0 Y230, prime,
+                                for movement. It will warn first, home the printer, lift Z 50 mm, prime,
                                 retract, wait for Continue, purge the new filament, and turn the nozzle heater off.
                             </li>
                             <li class="mb-0">

--- a/static/tabs/instructions.html
+++ b/static/tabs/instructions.html
@@ -113,7 +113,7 @@
                         <ol class="mb-0">
                             <li class="mb-2">
                                 Recommended: open <strong>eufyMake Studio</strong>, sign in, then go to
-                                <strong>Setup -&gt; Account</strong> and click <strong>Import From Open eufyMake Studio</strong>.
+                                <strong>Setup -&gt; Account</strong> and click <strong>Import From eufyMake Studio</strong>.
                             </li>
                             <li class="mb-2">
                                 If you prefer, use <strong>Fetch Config From AnkerMake Server</strong> and sign in with

--- a/static/tabs/instructions.html
+++ b/static/tabs/instructions.html
@@ -17,7 +17,8 @@
                             </li>
                             <li class="mb-2">
                                 If needed, switch to each printer from the navbar and save that printer's
-                                <strong>External Camera</strong>, <strong>Timelapse</strong>, and notification settings.
+                                <strong>External Camera</strong> and <strong>Timelapse</strong> settings. Then review
+                                notification settings if you use alerts.
                             </li>
                             <li class="mb-2">
                                 Connect your slicer with the OctoPrint-compatible upload settings below, then use
@@ -136,12 +137,20 @@
                         <ol class="mb-0">
                             <li class="mb-2">Switch to the printer you want to configure in the navbar first.</li>
                             <li class="mb-2">Open <strong>Setup -&gt; Camera</strong>.</li>
-                            <li class="mb-2">Enter an external camera label and stream URL.</li>
-                            <li class="mb-2">Add a direct snapshot URL if your camera supports one for faster captures.</li>
+                            <li class="mb-2">
+                                Enter an external camera label and an FFmpeg-readable stream URL, such as RTSP or MJPEG.
+                                The stream URL drives the Home page live preview.
+                            </li>
+                            <li class="mb-2">
+                                Add a direct snapshot URL if your camera supports one for faster still snapshots and
+                                fallback capture.
+                            </li>
                             <li class="mb-2">Click <strong>Save External Camera</strong>.</li>
                             <li class="mb-0">
                                 On the <strong>Home</strong> page, switch between the printer camera and external camera.
-                                Manual snapshots follow the selected camera source; timelapse can be pinned separately in <strong>Setup -&gt; Timelapse</strong>.
+                                Manual snapshots follow the selected camera source. Timelapse has its own source setting
+                                in <strong>Setup -&gt; Timelapse</strong>, so Home page viewing does not have to interrupt
+                                captures.
                             </li>
                         </ol>
                     </div>
@@ -158,6 +167,11 @@
                             <li class="mb-2">Select the printer you want to configure from the printer selector.</li>
                             <li class="mb-2">Open <strong>Setup -&gt; Timelapse</strong>.</li>
                             <li class="mb-2">Enable timelapse, choose interval, retention, persistence, camera source, and light behavior.</li>
+                            <li class="mb-2">
+                                Use <strong>Follow Home camera selection</strong> only if you want Home page camera
+                                changes to affect capture. Choose <strong>Printer camera</strong> or <strong>External
+                                camera</strong> to pin timelapse to one source.
+                            </li>
                             <li class="mb-2">Click <strong>Save</strong> for that printer.</li>
                             <li class="mb-2">
                                 Repeat for each printer. Timelapse settings are stored per printer, so Thing 1 and Thing 2
@@ -168,6 +182,56 @@
                                 manual snapshots appear on the <strong>Snapshots</strong> page.
                             </li>
                         </ol>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="card h-100">
+                    <div class="card-header fs-4">{{ macro.bi_icon("thermometer-half") }} Filament Service</div>
+                    <div class="card-body">
+                        <ol class="mb-0">
+                            <li class="mb-2">Open the <strong>Filaments</strong> page to manage material profiles and printer-side filament moves.</li>
+                            <li class="mb-2">
+                                Use <strong>Quick Extrude / Retract</strong> for simple profile-based preheat, extrude,
+                                retract, and cooldown commands.
+                            </li>
+                            <li class="mb-2">
+                                The recommended swap flow preheats to <strong>Manual Swap Preheat</strong> and waits for
+                                you to change filament before pressing <strong>Continue / Load New Filament</strong>.
+                            </li>
+                            <li class="mb-2">
+                                <strong>Enable guided automatic unload / purge</strong> only when the printer is ready
+                                for movement. It will warn first, home the printer, lift Z 50 mm, park at X0 Y230, prime,
+                                retract, wait for Continue, purge the new filament, and turn the nozzle heater off.
+                            </li>
+                            <li class="mb-0">
+                                Save filament service settings after changing quick move length, swap preheat, unload
+                                profile, load profile, or prime/unload/load lengths.
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row g-3 mb-3">
+            <div class="col-lg-6">
+                <div class="card h-100">
+                    <div class="card-header fs-4">{{ macro.bi_icon("activity") }} Status Badges</div>
+                    <div class="card-body">
+                        <ul class="mb-3">
+                            <li><strong>MQTT</strong> is the printer cloud message connection.</li>
+                            <li><strong>PPPP</strong> is the local printer control/video reachability check.</li>
+                            <li><strong>VIDEO</strong> is the active video stream when printer video is in use.</li>
+                            <li><strong>CTRL</strong> is the browser-to-ankerctl control channel, with printer control availability tied to PPPP reachability.</li>
+                        </ul>
+                        <div class="fw-semibold mb-2">Badge colors</div>
+                        <ul class="mb-0">
+                            <li><strong>Green</strong>: connected or reachable.</li>
+                            <li><strong>Yellow</strong>: waiting, reconnecting, or reachability is not confirmed yet.</li>
+                            <li><strong>Gray</strong>: dormant or inactive.</li>
+                            <li><strong>Red</strong>: connection or service error.</li>
+                        </ul>
                     </div>
                 </div>
             </div>
@@ -187,8 +251,13 @@
                                 </a>
                             </li>
                             <li>
+                                <a href="https://support.eufymake.com/s/" target="_blank" rel="noopener noreferrer">
+                                    eufyMake support center
+                                </a>
+                            </li>
+                            <li>
                                 <a href="https://service.eufymake.com/" target="_blank" rel="noopener noreferrer">
-                                    eufyMake support
+                                    eufyMake service portal
                                 </a>
                             </li>
                         </ul>

--- a/tests/test_camera_helpers.py
+++ b/tests/test_camera_helpers.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import threading
 
 from web.camera import (
     CameraCaptureError,
@@ -121,3 +122,26 @@ def test_iter_mjpeg_frames_extracts_jpegs_from_chunked_stream():
         b"\xff\xd8one\xff\xd9",
         b"\xff\xd8two\xff\xd9",
     ]
+
+
+def test_iter_mjpeg_frames_stops_when_ffmpeg_stdout_stalls():
+    read_started = threading.Event()
+    release_read = threading.Event()
+
+    class FakeStdout:
+        def read(self, _size):
+            read_started.set()
+            release_read.wait(timeout=1.0)
+            return b""
+
+    class FakeProc:
+        stdout = FakeStdout()
+
+        def poll(self):
+            return None
+
+    try:
+        assert list(iter_mjpeg_frames(FakeProc(), stale_timeout=0.01)) == []
+        assert read_started.wait(timeout=0.5)
+    finally:
+        release_read.set()

--- a/tests/test_filament_api.py
+++ b/tests/test_filament_api.py
@@ -272,7 +272,7 @@ def test_filament_swap_routes_follow_manual_guided_flow_by_default(tmp_path):
     assert confirmed.get_json()["pending"] is False
     assert cancelled.status_code == 200
     assert cancelled.get_json()["pending"] is False
-    assert sent == ["M104 S140"]
+    assert sent == ["M104 S180"]
 
 
 def test_filament_swap_state_is_scoped_per_printer(tmp_path):
@@ -353,16 +353,22 @@ def test_filament_swap_state_is_scoped_per_printer(tmp_path):
     assert still0.get_json()["swap"]["token"] == token0
     assert confirmed0.status_code == 200
     assert confirmed0.get_json()["pending"] is False
-    assert sent0 == ["M104 S140"]
-    assert sent1 == ["M104 S140"]
+    assert sent0 == ["M104 S180"]
+    assert sent1 == ["M104 S180"]
 
 
 def test_filament_swap_routes_cover_legacy_start_confirm_and_cancel(tmp_path, monkeypatch):
     sent = []
+    home_calls = []
+    home_waits = []
+    motion_waits = []
+    park_waits = []
+    target_waits = []
     mqtt = SimpleNamespace(
         is_printing=False,
-        nozzle_temp=230,
+        nozzle_temp=250,
         send_gcode=lambda gcode: sent.append(gcode),
+        send_home=lambda axis: home_calls.append(axis),
     )
     client = app.test_client()
     old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
@@ -376,16 +382,39 @@ def test_filament_swap_routes_cover_legacy_start_confirm_and_cancel(tmp_path, mo
         background_calls.append((target, token))
         return SimpleNamespace()
 
+    def fake_motion_wait(length_mm, feedrate_mm_min, should_continue=None):
+        motion_waits.append((length_mm, feedrate_mm_min))
+        assert should_continue is None or should_continue()
+
+    def fake_park_wait(z_lift_mm, park_x_mm, park_y_mm, should_continue=None):
+        park_waits.append((z_lift_mm, park_x_mm, park_y_mm))
+        assert should_continue is None or should_continue()
+
+    def fake_home_wait(should_continue=None, pause_s=None):
+        home_waits.append(pause_s)
+        assert should_continue is None or should_continue()
+
+    def fake_target_wait(mqtt, target_temp_c, should_continue=None):
+        target_waits.append(target_temp_c)
+        assert should_continue is None or should_continue()
+        return target_temp_c
+
     monkeypatch.setattr(web_module, "_filament_swap_start_background", fake_start_background)
+    monkeypatch.setattr(web_module, "_wait_for_filament_swap_home", fake_home_wait)
+    monkeypatch.setattr(web_module, "_wait_for_filament_swap_motion", fake_motion_wait)
+    monkeypatch.setattr(web_module, "_wait_for_filament_swap_park", fake_park_wait)
+    monkeypatch.setattr(web_module, "_wait_for_filament_service_nozzle_target", fake_target_wait)
+    monkeypatch.setattr(web_module, "FILAMENT_SERVICE_SWAP_COOLDOWN_DELAY_S", 0)
 
     try:
-        unload = app.filaments.create({"name": "PLA Black", "nozzle_temp": 220, "retract_speed": 40})
-        load = app.filaments.create({"name": "PETG White", "nozzle_temp": 240, "retract_speed": 12})
+        unload = app.filaments.create({"name": "PLA Black", "nozzle_temp_other_layer": 220, "retract_speed": 40})
+        load = app.filaments.create({"name": "PETG White", "nozzle_temp_other_layer": 240, "retract_speed": 12})
         started = client.post(
             "/api/filaments/service/swap/start",
             json={
                 "unload_profile_id": unload["id"],
                 "load_profile_id": load["id"],
+                "home_pause_s": 42,
             },
             headers={"X-Api-Key": API_KEY},
         )
@@ -418,10 +447,153 @@ def test_filament_swap_routes_cover_legacy_start_confirm_and_cancel(tmp_path, mo
     assert confirmed.get_json()["pending"] is True
     assert cancelled.status_code == 200
     assert cancelled.get_json()["pending"] is False
-    assert "G28" in sent[0]
-    assert "G1 Z50 F600" in sent[0]
-    assert "G1 X0 Y230 F9000" in sent[0]
-    assert "G1 E10 F240" in sent[1]
-    assert "G1 E-55 F240" in sent[2]
-    assert "G1 E65 F240" in sent[3]
-    assert sent[4] == "M104 S0"
+    assert home_calls == ["all"]
+    assert home_waits == [42.0]
+    assert sent[0] == "M104 S180"
+    assert sent[1] == "M104 S220"
+    assert sent[2] == "M104 S220"
+    assert "G0 Z50 F600" in sent[3]
+    assert sent[4] == "M104 S220"
+    assert "G1 E10 F240" in sent[5]
+    assert "G1 E-55 F2700" in sent[6]
+    assert sent[7] == "M104 S240"
+    assert "G1 E65 F240" in sent[8]
+    assert sent[9] == "M104 S0"
+    assert target_waits == [220, 220, 220]
+    assert motion_waits == [(10, 240), (55, 2700), (65, 240)]
+    assert park_waits == [(50.0, 0.0, 230.0)]
+
+
+def test_legacy_swap_sends_heat_before_homing_when_nozzle_is_cold(tmp_path, monkeypatch):
+    sent = []
+    home_calls = []
+    home_waits = []
+    wait_calls = []
+    motion_waits = []
+    park_waits = []
+    target_waits = []
+    mqtt = SimpleNamespace(
+        is_printing=False,
+        nozzle_temp=25,
+        send_gcode=lambda gcode: sent.append(gcode),
+        send_home=lambda axis: home_calls.append(axis),
+    )
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+    app.config["config"].cfg.filament_service["allow_legacy_swap"] = True
+    background_calls = []
+
+    def fake_start_background(target, token):
+        background_calls.append((target, token))
+        return SimpleNamespace()
+
+    def fake_wait_for_nozzle(mqtt, target_temp_c, should_continue=None, tolerance_c=5):
+        wait_calls.append((target_temp_c, tolerance_c))
+        assert should_continue is None or should_continue()
+        return target_temp_c
+
+    def fake_motion_wait(length_mm, feedrate_mm_min, should_continue=None):
+        motion_waits.append((length_mm, feedrate_mm_min))
+        assert should_continue is None or should_continue()
+
+    def fake_park_wait(z_lift_mm, park_x_mm, park_y_mm, should_continue=None):
+        park_waits.append((z_lift_mm, park_x_mm, park_y_mm))
+        assert should_continue is None or should_continue()
+
+    def fake_home_wait(should_continue=None, pause_s=None):
+        home_waits.append(pause_s)
+        assert should_continue is None or should_continue()
+
+    def fake_target_wait(mqtt, target_temp_c, should_continue=None):
+        target_waits.append(target_temp_c)
+        assert should_continue is None or should_continue()
+        return target_temp_c
+
+    monkeypatch.setattr(web_module, "_filament_swap_start_background", fake_start_background)
+    monkeypatch.setattr(web_module, "_wait_for_filament_swap_home", fake_home_wait)
+    monkeypatch.setattr(web_module, "_wait_for_filament_swap_motion", fake_motion_wait)
+    monkeypatch.setattr(web_module, "_wait_for_filament_swap_park", fake_park_wait)
+    monkeypatch.setattr(web_module, "_wait_for_filament_service_nozzle", fake_wait_for_nozzle)
+    monkeypatch.setattr(web_module, "_wait_for_filament_service_nozzle_target", fake_target_wait)
+
+    try:
+        unload = app.filaments.create({"name": "PLA Cold", "nozzle_temp_other_layer": 220})
+        load = app.filaments.create({"name": "PETG Cold", "nozzle_temp_other_layer": 240})
+        started = client.post(
+            "/api/filaments/service/swap/start",
+            json={
+                "unload_profile_id": unload["id"],
+                "load_profile_id": load["id"],
+            },
+            headers={"X-Api-Key": API_KEY},
+        )
+        start_target, token = background_calls.pop()
+        start_target(token)
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert started.status_code == 200
+    assert sent[0] == "M104 S180"
+    assert sent[1] == "M104 S220"
+    assert sent[2] == "M104 S220"
+    assert home_calls == ["all"]
+    assert home_waits == [55.0]
+    assert "G0 Z50 F600" in sent[3]
+    assert sent[4] == "M104 S220"
+    assert "G1 E10 F240" in sent[5]
+    assert "G1 E-60 F2700" in sent[6]
+    assert wait_calls == [(180, 0), (220, 5)]
+    assert target_waits == [220, 220, 220]
+    assert motion_waits == [(10.0, 240), (60.0, 2700)]
+    assert park_waits == [(50.0, 0.0, 230.0)]
+
+
+def test_legacy_swap_cancel_is_allowed_while_stage_is_running(tmp_path, monkeypatch):
+    sent = []
+    mqtt = SimpleNamespace(
+        is_printing=False,
+        nozzle_temp=25,
+        send_gcode=lambda gcode: sent.append(gcode),
+    )
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+    app.config["config"].cfg.filament_service["allow_legacy_swap"] = True
+    background_calls = []
+
+    def fake_start_background(target, token):
+        background_calls.append((target, token))
+        return SimpleNamespace()
+
+    monkeypatch.setattr(web_module, "_filament_swap_start_background", fake_start_background)
+
+    try:
+        unload = app.filaments.create({"name": "PLA Running", "nozzle_temp_other_layer": 220})
+        load = app.filaments.create({"name": "PETG Running", "nozzle_temp_other_layer": 240})
+        started = client.post(
+            "/api/filaments/service/swap/start",
+            json={
+                "unload_profile_id": unload["id"],
+                "load_profile_id": load["id"],
+            },
+            headers={"X-Api-Key": API_KEY},
+        )
+        token = started.get_json()["swap"]["token"]
+        cancelled = client.post(
+            "/api/filaments/service/swap/cancel",
+            json={"token": token},
+            headers={"X-Api-Key": API_KEY},
+        )
+        state = client.get(
+            "/api/filaments/service/swap",
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert started.status_code == 200
+    assert background_calls
+    assert cancelled.status_code == 200
+    assert cancelled.get_json()["pending"] is False
+    assert state.status_code == 200
+    assert state.get_json()["pending"] is False
+    assert sent == ["M104 S0"]

--- a/tests/test_filament_api.py
+++ b/tests/test_filament_api.py
@@ -44,13 +44,17 @@ class FakeConfigManager:
 
 class FakeServices:
     def __init__(self, mqtt):
-        self._mqtt = mqtt
-        self.svcs = {"mqttqueue": mqtt}
+        if isinstance(mqtt, dict):
+            self._services = dict(mqtt)
+        else:
+            self._services = {"mqttqueue": mqtt, "mqttqueue:0": mqtt}
+        self.svcs = dict(self._services)
 
     @contextmanager
     def borrow(self, name):
-        assert name == "mqttqueue"
-        yield self._mqtt
+        if name not in self._services:
+            raise KeyError(name)
+        yield self._services[name]
 
 
 def _base_config():
@@ -84,7 +88,7 @@ def _install_state(tmp_path, mqtt):
     app.config["unsupported_device"] = False
     app.svc = FakeServices(mqtt)
     app.filaments = FilamentStore(tmp_path / "filaments.db")
-    app.filament_swap_state = None
+    app.filament_swap_state = {}
 
     return old_values, old_svc, old_filaments, old_swap
 
@@ -269,6 +273,88 @@ def test_filament_swap_routes_follow_manual_guided_flow_by_default(tmp_path):
     assert cancelled.status_code == 200
     assert cancelled.get_json()["pending"] is False
     assert sent == ["M104 S140"]
+
+
+def test_filament_swap_state_is_scoped_per_printer(tmp_path):
+    sent0 = []
+    sent1 = []
+    mqtt0 = SimpleNamespace(
+        is_printing=False,
+        nozzle_temp=150,
+        send_gcode=lambda gcode: sent0.append(gcode),
+    )
+    mqtt1 = SimpleNamespace(
+        is_printing=False,
+        nozzle_temp=150,
+        send_gcode=lambda gcode: sent1.append(gcode),
+    )
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(
+        tmp_path,
+        {"mqttqueue:0": mqtt0, "mqttqueue:1": mqtt1},
+    )
+    app.config["config"].cfg.printers.append(_printer("SN2", "Printer 2"))
+
+    try:
+        started0 = client.post(
+            "/api/filaments/service/swap/start?printer_index=0",
+            headers={"X-Api-Key": API_KEY},
+        )
+        started1 = client.post(
+            "/api/filaments/service/swap/start?printer_index=1",
+            headers={"X-Api-Key": API_KEY},
+        )
+        token0 = (started0.get_json().get("swap") or {}).get("token")
+        token1 = (started1.get_json().get("swap") or {}).get("token")
+        state0 = client.get(
+            "/api/filaments/service/swap?printer_index=0",
+            headers={"X-Api-Key": API_KEY},
+        )
+        state1 = client.get(
+            "/api/filaments/service/swap?printer_index=1",
+            headers={"X-Api-Key": API_KEY},
+        )
+        mismatch = client.post(
+            "/api/filaments/service/swap/confirm?printer_index=1",
+            json={"token": token0},
+            headers={"X-Api-Key": API_KEY},
+        )
+        confirmed1 = client.post(
+            "/api/filaments/service/swap/confirm?printer_index=1",
+            json={"token": token1},
+            headers={"X-Api-Key": API_KEY},
+        )
+        still0 = client.get(
+            "/api/filaments/service/swap?printer_index=0",
+            headers={"X-Api-Key": API_KEY},
+        )
+        confirmed0 = client.post(
+            "/api/filaments/service/swap/confirm?printer_index=0",
+            json={"token": token0},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert started0.status_code == 200
+    assert started1.status_code == 200
+    assert token0 is not None
+    assert token1 is not None
+    assert token0 != token1
+    assert state0.status_code == 200
+    assert state0.get_json()["swap"]["printer_index"] == 0
+    assert state1.status_code == 200
+    assert state1.get_json()["swap"]["printer_index"] == 1
+    assert mismatch.status_code == 409
+    assert confirmed1.status_code == 200
+    assert confirmed1.get_json()["pending"] is False
+    assert still0.status_code == 200
+    assert still0.get_json()["pending"] is True
+    assert still0.get_json()["swap"]["token"] == token0
+    assert confirmed0.status_code == 200
+    assert confirmed0.get_json()["pending"] is False
+    assert sent0 == ["M104 S140"]
+    assert sent1 == ["M104 S140"]
 
 
 def test_filament_swap_routes_cover_legacy_start_confirm_and_cancel(tmp_path, monkeypatch):

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -1008,6 +1008,24 @@ def test_snapshot_and_camera_frame_routes_support_external_camera(monkeypatch):
     assert all(call["ffmpeg_path"] == "/usr/bin/ffmpeg" for call in captures)
 
 
+def test_external_camera_stream_requires_auth_when_api_key_enabled():
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(
+        video_supported=False,
+        videoqueue=None,
+    )
+
+    try:
+        unauthorized = client.get("/api/camera/stream")
+        authorized = client.get("/api/camera/stream", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert unauthorized.status_code == 401
+    assert authorized.status_code == 400
+    assert authorized.get_json()["error"] == "External camera is not the active camera source."
+
+
 def test_camera_frame_route_reports_external_capture_errors_as_bad_gateway(monkeypatch):
     cfg = _base_config()
     cfg.camera = {

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -3,9 +3,103 @@ Test suite for security validation
 Tests SQL injection, XSS, path traversal, input validation
 """
 
+from contextlib import contextmanager
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock, patch, MagicMock
-from flask import Flask
+
+from cli.model import Account, Config, Printer
+from web import app
+from web.service.filament import FilamentStore
+
+
+API_KEY = "secret-key-123456"
+
+
+def _pending_security_coverage(reason):
+    pytest.skip(f"Pending security coverage: {reason}")
+
+
+def _printer(sn="SN1", name="Printer", model="V8111"):
+    return Printer(
+        id=sn,
+        sn=sn,
+        name=name,
+        model=model,
+        create_time=datetime(2024, 1, 1, 12, 0, 0),
+        update_time=datetime(2024, 1, 1, 12, 0, 0),
+        wifi_mac="aabbccddeeff",
+        ip_addr="192.168.1.10",
+        mqtt_key=b"\x01\x02",
+        api_hosts=["api.example"],
+        p2p_hosts=["p2p.example"],
+        p2p_duid=f"duid-{sn}",
+        p2p_key="secret",
+    )
+
+
+def _base_config():
+    return Config(
+        account=Account(
+            auth_token="token",
+            region="eu",
+            user_id="user-1",
+            email="user@example.com",
+        ),
+        printers=[_printer()],
+    )
+
+
+class FakeConfigManager:
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    @contextmanager
+    def open(self):
+        yield self.cfg
+
+    @contextmanager
+    def modify(self):
+        yield self.cfg
+
+
+def _install_security_state(tmp_path):
+    old_values = {
+        "api_key": app.config.get("api_key"),
+        "config": app.config.get("config"),
+        "login": app.config.get("login"),
+        "printer_index": app.config.get("printer_index"),
+        "printer_index_locked": app.config.get("printer_index_locked"),
+        "unsupported_device": app.config.get("unsupported_device"),
+        "video_supported": app.config.get("video_supported"),
+    }
+    old_svc = app.svc
+    old_filaments = getattr(app, "filaments", None)
+
+    app.config["api_key"] = API_KEY
+    app.config["config"] = FakeConfigManager(_base_config())
+    app.config["login"] = True
+    app.config["printer_index"] = 0
+    app.config["printer_index_locked"] = False
+    app.config["unsupported_device"] = False
+    app.config["video_supported"] = True
+    app.svc = SimpleNamespace(svcs={})
+    app.filaments = FilamentStore(tmp_path / "security-filaments.db")
+
+    return old_values, old_svc, old_filaments
+
+
+def _restore_security_state(old_values, old_svc, old_filaments):
+    app.svc = old_svc
+    app.filaments = old_filaments
+    for key, value in old_values.items():
+        app.config[key] = value
+
+
+def _auth_headers():
+    return {"X-Api-Key": API_KEY}
 
 
 class TestSQLInjectionProtection:
@@ -61,17 +155,11 @@ class TestPathTraversalProtection:
 
     def test_log_viewer_path_traversal_blocked(self):
         """GET /api/debug/logs/../../../etc/passwd is blocked"""
-        # This would need actual Flask test client
-        # Skeleton for implementation:
-        # 1. Request /api/debug/logs/../../../etc/passwd
-        # 2. Assert 400 Bad Request or path normalized to logs dir
-        pass
+        _pending_security_coverage("debug log file path traversal")
 
     def test_timelapse_filename_path_traversal(self):
         """Timelapse download with ../ in filename is blocked"""
-        # Test GET /api/timelapse/../../etc/passwd
-        # Should return 404 or 400
-        pass
+        _pending_security_coverage("timelapse download path traversal")
 
     def test_file_upload_path_sanitization(self):
         """File upload with path separators is sanitized"""
@@ -91,15 +179,11 @@ class TestXSSProtection:
 
     def test_gcode_filename_xss_escaped_in_response(self):
         """GCode filename with XSS payload is escaped in API response"""
-        # Test that <script>alert('XSS')</script>.gcode is escaped
-        # in JSON responses and HTML rendering
-        pass
+        _pending_security_coverage("G-code filename escaping in rendered UI")
 
     def test_printer_name_xss_escaped(self):
         """Printer name with HTML tags is escaped"""
-        # Test renaming printer to <img src=x onerror=alert(1)>
-        # Should be escaped in web UI
-        pass
+        _pending_security_coverage("printer name escaping in rendered UI")
 
 
 class TestInputValidation:
@@ -107,53 +191,76 @@ class TestInputValidation:
 
     def test_oversized_file_upload_rejected(self):
         """File upload exceeding UPLOAD_MAX_MB returns 413"""
-        # Mock file upload > UPLOAD_MAX_MB
-        # Assert HTTP 413 Payload Too Large
-        pass
+        _pending_security_coverage("oversized G-code upload request")
 
-    def test_invalid_api_key_format_rejected(self):
+    def test_invalid_api_key_format_rejected(self, tmp_path):
         """Malformed API key in X-Api-Key header is rejected"""
-        # Test with: null, empty string, SQL injection, XSS
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            for value in ("", "' OR 1=1 --", "<script>alert(1)</script>"):
+                response = client.get("/api/filaments", headers={"X-Api-Key": value})
+                assert response.status_code == 401
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
 
     def test_invalid_upload_rate_rejected(self):
         """Upload rate outside valid range (5,10,25,50,100) is rejected"""
-        from web import app as web_app
+        _pending_security_coverage("upload rate validation in settings/update routes")
 
-        # Test with invalid values: 0, -1, 999, "abc", null
-        invalid_values = [0, -1, 999, 1000, "abc", None]
-
-        for value in invalid_values:
-            # Should either reject or fall back to default
-            pass
-
-    def test_negative_printer_index_rejected(self):
+    def test_negative_printer_index_rejected(self, tmp_path):
         """Negative printer index in POST /api/printers/active is rejected"""
-        # Test index=-1, should return 400 or 404
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.post(
+                "/api/printers/active",
+                json={"index": -1},
+                headers=_auth_headers(),
+            )
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_invalid_json_in_request_body(self):
+        assert response.status_code == 400
+
+    def test_invalid_json_in_request_body(self, tmp_path):
         """Malformed JSON in POST request returns 400"""
-        # Send invalid JSON to /api/filaments
-        # Assert 400 Bad Request
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.post(
+                "/api/filaments",
+                data="{bad json",
+                content_type="application/json",
+                headers=_auth_headers(),
+            )
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_missing_required_fields_in_filament_create(self):
+        assert response.status_code == 400
+
+    def test_missing_required_fields_in_filament_create(self, tmp_path):
         """Creating filament without required fields returns 400"""
-        # POST /api/filaments with missing 'name' field
-        # Assert 400 Bad Request with clear error message
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.post(
+                "/api/filaments",
+                json={"material": "PLA"},
+                headers=_auth_headers(),
+            )
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert response.status_code == 400
 
     def test_excessively_long_filament_name(self):
         """Filament name > reasonable length is rejected or truncated"""
-        # Test with 10,000 character name
-        pass
+        _pending_security_coverage("maximum filament profile name length")
 
     def test_invalid_temperature_values(self):
         """Negative or extremely high temperatures are validated"""
-        # nozzle_temp=-10, bed_temp=1000
-        # Should be rejected or clamped
-        pass
+        _pending_security_coverage("filament temperature bounds validation")
 
 
 class TestMQTTCommandInjection:
@@ -161,37 +268,54 @@ class TestMQTTCommandInjection:
 
     def test_gcode_command_newline_injection(self):
         """GCode with embedded newlines doesn't inject multiple commands"""
-        # Attempt to inject multiple commands via newline
-        malicious_gcode = "G28\nM104 S300\nM140 S150"
-
-        # Should either reject or sanitize
-        # (Implementation-specific: might allow, split, or reject)
-        assert "\n" in malicious_gcode
-        pass
+        _pending_security_coverage("multi-command raw G-code policy")
 
     def test_printer_name_mqtt_injection(self):
         """Printer name with MQTT control chars is sanitized"""
-        # Test renaming with embedded null bytes, control chars
-        pass
+        _pending_security_coverage("printer name control-character sanitization")
 
 
 class TestAuthenticationBypass:
     """Test authentication bypass attempts"""
 
-    def test_empty_api_key_rejected(self):
+    def test_empty_api_key_rejected(self, tmp_path):
         """Empty API key in header is rejected"""
-        # X-Api-Key: "" should be treated as missing
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.get("/api/filaments", headers={"X-Api-Key": ""})
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_api_key_in_query_string_disabled_for_sensitive_endpoints(self):
-        """API key in query string doesn't work for login/config endpoints"""
-        # For security, sensitive operations should require header auth
-        pass
+        assert response.status_code == 401
 
-    def test_session_cookie_without_api_key_on_protected_endpoint(self):
-        """Session cookie alone doesn't grant access to protected endpoints"""
-        # When ANKERCTL_API_KEY is set, session alone insufficient
-        pass
+    def test_api_key_query_string_bootstraps_session_and_strips_url(self, tmp_path):
+        """Valid URL API key starts a browser session and redirects to a clean URL."""
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.get(f"/api/filaments?apikey={API_KEY}&foo=bar")
+            assert response.status_code == 302
+            assert "apikey" not in response.headers["Location"]
+
+            session_response = client.get("/api/filaments")
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert session_response.status_code == 200
+
+    def test_session_cookie_allows_browser_access_to_protected_endpoint(self, tmp_path):
+        """Authenticated browser session can access protected GET endpoints."""
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            with client.session_transaction() as session:
+                session["authenticated"] = True
+            response = client.get("/api/filaments")
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert response.status_code == 200
 
 
 class TestCSRFProtection:
@@ -199,8 +323,7 @@ class TestCSRFProtection:
 
     def test_post_without_csrf_token(self):
         """POST request without CSRF token (if implemented) is rejected"""
-        # If CSRF protection is added in future
-        pass
+        _pending_security_coverage("CSRF enforcement when that feature exists")
 
 
 class TestRateLimiting:
@@ -208,8 +331,7 @@ class TestRateLimiting:
 
     def test_excessive_api_requests_rate_limited(self):
         """Excessive API calls are rate-limited"""
-        # If rate limiting is implemented
-        pass
+        _pending_security_coverage("rate limiting when that feature exists")
 
 
 class TestEnvironmentVariableInjection:
@@ -217,9 +339,7 @@ class TestEnvironmentVariableInjection:
 
     def test_env_var_with_shell_metacharacters(self):
         """Environment variables with shell metacharacters are safe"""
-        # Test FLASK_HOST="; rm -rf /"
-        # Should not execute shell commands
-        pass
+        _pending_security_coverage("environment value shell-metacharacter handling")
 
 
 class TestFileSystemSecurity:
@@ -227,19 +347,15 @@ class TestFileSystemSecurity:
 
     def test_log_directory_creation_safe_permissions(self):
         """Log directory created with safe permissions (not world-writable)"""
-        # Check ANKERCTL_LOG_DIR creation
-        pass
+        _pending_security_coverage("log directory permissions across platforms")
 
     def test_config_file_permissions(self):
         """Config file (default.json) has restricted permissions"""
-        # Should not be world-readable (contains tokens)
-        pass
+        _pending_security_coverage("config file permissions across platforms")
 
     def test_timelapse_temp_files_cleaned_up(self):
         """Temporary timelapse files are cleaned up on error"""
-        # Simulate capture failure
-        # Assert temp files removed
-        pass
+        _pending_security_coverage("timelapse temp-file cleanup on failure")
 
 
 # Integration test: Full security audit
@@ -247,25 +363,63 @@ class TestFileSystemSecurity:
 class TestSecurityIntegration:
     """Integration tests combining multiple attack vectors"""
 
-    def test_full_attack_chain_blocked(self):
+    def test_full_attack_chain_blocked(self, tmp_path):
         """Combined SQL injection + XSS + path traversal is blocked"""
-        # Complex attack scenario combining multiple vectors
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.get(
+                "/api/debug/state/..%2F..%2Fetc%2Fpasswd",
+                query_string={
+                    "name": "<script>alert(1)</script>",
+                    "filter": "' OR 1=1 --",
+                },
+                headers={"X-Api-Key": "' OR 1=1 --"},
+            )
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_anonymous_user_cannot_access_protected_endpoints(self):
+        assert response.status_code == 401
+
+    def test_anonymous_user_cannot_access_protected_endpoints(self, tmp_path):
         """All protected endpoints require authentication"""
-        protected_endpoints = [
-            "/api/printer/gcode",
-            "/api/printer/control",
-            "/api/filaments",
-            "/api/debug/state",
-            "/api/ankerctl/server/reload",
+        protected_requests = [
+            ("post", "/api/printer/gcode", {"gcode": "G28"}),
+            ("post", "/api/printer/control", {"value": 1}),
+            ("get", "/api/filaments", None),
+            ("get", "/api/debug/state", None),
+            ("get", "/api/ankerctl/server/reload", None),
+            ("get", "/api/camera/frame", None),
+            ("get", "/api/camera/stream", None),
+            ("get", "/api/snapshot", None),
         ]
 
-        # Test each without auth, assert 401/403
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            responses = []
+            for method, path, payload in protected_requests:
+                request_method = getattr(client, method)
+                kwargs = {"json": payload} if payload is not None else {}
+                responses.append((path, request_method(path, **kwargs).status_code))
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_authenticated_user_can_access_allowed_endpoints(self):
+        assert responses
+        assert all(status == 401 for _, status in responses), responses
+
+    def test_authenticated_user_can_access_allowed_endpoints(self, tmp_path):
         """Authenticated user can access non-restricted endpoints"""
-        # Test with valid API key
-        pass
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            health = client.get("/api/health")
+            filaments = client.get("/api/filaments", headers=_auth_headers())
+            camera_stream = client.get("/api/camera/stream", headers=_auth_headers())
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert health.status_code == 200
+        assert filaments.status_code == 200
+        assert isinstance(filaments.get_json().get("filaments"), list)
+        assert camera_stream.status_code != 401

--- a/tests/test_service_framework.py
+++ b/tests/test_service_framework.py
@@ -36,7 +36,7 @@ class FakeManagedService:
         self.state = RunState.Running
         return True
 
-    def await_stopped(self):
+    def await_stopped(self, timeout=None):
         self.await_stopped_calls += 1
         self.state = RunState.Stopped
         return True
@@ -130,6 +130,46 @@ def test_service_manager_restart_all_stream_and_atexit():
     assert wanted.shutdown_calls == 1
     assert wanted_stops.shutdown_calls == 1
     assert idle.shutdown_calls == 1
+
+
+def test_service_manager_replace_service_waits_for_old_service_stop_before_swap():
+    manager = ServiceManager()
+
+    class ReplaceableService(FakeManagedService):
+        def __init__(self):
+            super().__init__(wanted=True, state=RunState.Running)
+            self.force_close_calls = 0
+            self.join_calls = 0
+            self.join_timeout = None
+
+        def _force_close_api(self):
+            self.force_close_calls += 1
+
+        def await_stopped(self, timeout=None):
+            self.await_stopped_calls += 1
+            assert manager.svcs["pppp:0"] is self
+            assert timeout is not None
+            self.state = RunState.Stopped
+            return True
+
+        def join(self, timeout=None):
+            self.join_calls += 1
+            self.join_timeout = timeout
+
+    old = ReplaceableService()
+    new = FakeManagedService()
+    manager.register("pppp:0", old)
+
+    manager.replace_service("pppp:0", new)
+
+    assert old.stop_calls == 1
+    assert old.await_stopped_calls == 1
+    assert old.force_close_calls == 1
+    assert old.running is False
+    assert old.join_calls == 1
+    assert old.join_timeout is not None
+    assert manager.svcs["pppp:0"] is new
+    assert manager.refs["pppp:0"] == 0
 
 
 def test_service_stream_bounded_queue_drops_oldest_items():

--- a/tests/test_settings_and_notifications_api.py
+++ b/tests/test_settings_and_notifications_api.py
@@ -359,6 +359,7 @@ def test_filament_service_settings_endpoints_persist_manual_and_legacy_modes():
                     "swap_prime_length_mm": 10,
                     "swap_unload_length_mm": 55,
                     "swap_load_length_mm": 65,
+                    "swap_home_pause_s": 42,
                 }
             },
             headers={"X-Api-Key": "secret-key-123456"},
@@ -376,8 +377,9 @@ def test_filament_service_settings_endpoints_persist_manual_and_legacy_modes():
     assert got.get_json()["filament_service"]["allow_legacy_swap"] is False
     assert got.get_json()["filament_service"]["quick_move_length_mm"] == 40
     assert got.get_json()["filament_service"]["swap_prime_length_mm"] == 10
-    assert got.get_json()["filament_service"]["swap_unload_length_mm"] == 50
+    assert got.get_json()["filament_service"]["swap_unload_length_mm"] == 60
     assert got.get_json()["filament_service"]["swap_load_length_mm"] == 120
+    assert got.get_json()["filament_service"]["swap_home_pause_s"] == 55
     assert updated.status_code == 200
     assert updated.get_json()["filament_service"]["allow_legacy_swap"] is True
     assert updated.get_json()["filament_service"]["manual_swap_preheat_temp_c"] == 149
@@ -385,11 +387,13 @@ def test_filament_service_settings_endpoints_persist_manual_and_legacy_modes():
     assert updated.get_json()["filament_service"]["swap_prime_length_mm"] == 10
     assert updated.get_json()["filament_service"]["swap_unload_length_mm"] == 55
     assert updated.get_json()["filament_service"]["swap_load_length_mm"] == 65
+    assert updated.get_json()["filament_service"]["swap_home_pause_s"] == 42
     assert clamped.status_code == 200
     assert cfg.filament_service["allow_legacy_swap"] is True
     assert cfg.filament_service["quick_move_length_mm"] == 12.5
     assert cfg.filament_service["swap_prime_length_mm"] == 10
     assert cfg.filament_service["swap_unload_length_mm"] == 55
     assert cfg.filament_service["swap_load_length_mm"] == 65
-    assert cfg.filament_service["manual_swap_preheat_temp_c"] == 150
-    assert clamped.get_json()["filament_service"]["manual_swap_preheat_temp_c"] == 150
+    assert cfg.filament_service["swap_home_pause_s"] == 42
+    assert cfg.filament_service["manual_swap_preheat_temp_c"] == 300
+    assert clamped.get_json()["filament_service"]["manual_swap_preheat_temp_c"] == 300

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -4,6 +4,8 @@ import time
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+import pytest
+
 import web
 from web.service.timelapse import TimelapseService, _IN_PROGRESS_SUBDIR, _resolve_ffmpeg_path
 
@@ -612,15 +614,12 @@ def test_capture_thread_crash_clears_ref(tmp_path):
     """If _capture_loop() crashes from an uncaught exception, the
     try/finally should clear _capture_thread so start_capture() knows
     the thread is dead."""
-    import threading
-    from types import SimpleNamespace
-
     class CaptureLoopCrash(BaseException):
         """Uncatchable by except Exception — simulates a fatal crash."""
 
     config_mgr = SimpleNamespace(config_root=str(tmp_path))
     svc = TimelapseService(config_mgr, captures_dir=str(tmp_path))
-    svc._interval = 0.01
+    svc._interval = 0
 
     call_count = [0]
 
@@ -630,9 +629,10 @@ def test_capture_thread_crash_clears_ref(tmp_path):
             raise CaptureLoopCrash("Simulated fatal crash")
 
     svc._take_snapshot = crashing_snapshot
-    svc._capture_thread = threading.Thread(target=svc._capture_loop, daemon=True)
-    svc._capture_thread.start()
-    svc._capture_thread.join(timeout=2)
+    svc._capture_thread = object()
+
+    with pytest.raises(CaptureLoopCrash, match="Simulated fatal crash"):
+        svc._capture_loop()
 
     assert svc._capture_thread is None, "_capture_thread should be None after crash"
 

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -35,7 +35,11 @@ def test_timelapse_meta_and_video_file_helpers(tmp_path):
     meta_dir.mkdir()
     svc._write_meta(meta_dir, "cube.gcode", 3)
 
-    assert svc._read_meta(meta_dir) == {"filename": "cube.gcode", "frame_count": 3}
+    meta = svc._read_meta(meta_dir)
+    assert meta["filename"] == "cube.gcode"
+    assert meta["frame_count"] == 3
+    assert meta["printer_index"] == 0
+    assert meta["printer_scope"] == "printer_SN1"
 
     video_a = tmp_path / "a.mp4"
     video_b = tmp_path / "b.mp4"
@@ -245,6 +249,95 @@ def test_timelapse_scan_recovers_or_resumes_in_progress(monkeypatch, tmp_path):
     assert scheduled and scheduled[0][1] == "young.gcode"
     assert assembled and assembled[0][1] == "old.gcode" and assembled[0][3] == "_recovered"
     assert pruned == [True]
+
+
+def test_timelapse_scan_only_recovers_matching_printer_capture(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    cfg._cfg.printers.append(SimpleNamespace(sn="SN2", name="Printer 2", model="V8111"))
+    base = tmp_path / _IN_PROGRESS_SUBDIR
+    base.mkdir()
+
+    printer_zero = base / "printer_SN1_zero_capture"
+    printer_zero.mkdir()
+    (printer_zero / "frame_00000.jpg").write_bytes(b"x")
+    (printer_zero / "frame_00001.jpg").write_bytes(b"y")
+    with open(printer_zero / ".meta", "w") as fh:
+        json.dump({
+            "filename": "zero.gcode",
+            "frame_count": 2,
+            "printer_index": 0,
+            "printer_scope": "printer_SN1",
+        }, fh)
+
+    printer_one = base / "printer_SN2_one_capture"
+    printer_one.mkdir()
+    (printer_one / "frame_00000.jpg").write_bytes(b"x")
+    (printer_one / "frame_00001.jpg").write_bytes(b"y")
+    with open(printer_one / ".meta", "w") as fh:
+        json.dump({
+            "filename": "one.gcode",
+            "frame_count": 2,
+            "printer_index": 1,
+            "printer_scope": "printer_SN2",
+        }, fh)
+
+    scheduled = []
+    finalized = []
+
+    monkeypatch.setattr(
+        TimelapseService,
+        "_schedule_finalize",
+        lambda self, d, f, c, suffix="": scheduled.append((self._printer_index, d, f, c, suffix)),
+    )
+    monkeypatch.setattr(
+        TimelapseService,
+        "_finalize_capture_dir",
+        lambda self, d, f, c, suffix="": finalized.append((self._printer_index, d, f, c, suffix)),
+    )
+
+    svc0 = TimelapseService(cfg, captures_dir=tmp_path, printer_index=0)
+    assert svc0._resume_filename == "zero.gcode"
+    assert scheduled == [(0, str(printer_zero), "zero.gcode", 2, "")]
+    assert finalized == []
+
+    scheduled.clear()
+    svc1 = TimelapseService(cfg, captures_dir=tmp_path, printer_index=1)
+    assert svc1._resume_filename == "one.gcode"
+    assert scheduled == [(1, str(printer_one), "one.gcode", 2, "")]
+    assert finalized == []
+
+
+def test_timelapse_archived_media_listing_is_scoped_per_printer(tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    cfg._cfg.printers.append(SimpleNamespace(sn="SN2", name="Printer 2", model="V8111"))
+
+    svc0 = TimelapseService(cfg, captures_dir=tmp_path, printer_index=0)
+    svc1 = TimelapseService(cfg, captures_dir=tmp_path, printer_index=1)
+
+    (tmp_path / "printer_SN1_zero.mp4").write_bytes(b"zero")
+    (tmp_path / "printer_SN2_one.mp4").write_bytes(b"one")
+    (tmp_path / "legacy.mp4").write_bytes(b"legacy")
+
+    snapshots = tmp_path / "snapshots"
+    zero_snapshots = snapshots / "printer_SN1_zero"
+    zero_snapshots.mkdir(parents=True)
+    (zero_snapshots / "frame_00000.jpg").write_bytes(b"zero")
+    svc0._write_meta(zero_snapshots, "zero.gcode", 1)
+
+    one_snapshots = snapshots / "printer_SN2_one"
+    one_snapshots.mkdir(parents=True)
+    (one_snapshots / "frame_00000.jpg").write_bytes(b"one")
+    svc1._write_meta(one_snapshots, "one.gcode", 1)
+
+    assert [video["filename"] for video in svc0.list_videos()] == [
+        "printer_SN1_zero.mp4",
+        "legacy.mp4",
+    ]
+    assert [video["filename"] for video in svc1.list_videos()] == ["printer_SN2_one.mp4"]
+    assert [collection["id"] for collection in svc0.list_snapshots()] == ["printer_SN1_zero"]
+    assert [collection["id"] for collection in svc1.list_snapshots()] == ["printer_SN2_one"]
+    assert svc0.get_video_path("legacy.mp4") == str(tmp_path / "legacy.mp4")
+    assert svc1.get_video_path("legacy.mp4") is None
 
 
 def test_timelapse_finish_and_fail_paths(monkeypatch, tmp_path):

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -892,6 +892,40 @@ def test_timelapse_service_uses_per_printer_settings_when_present(tmp_path):
     assert svc1._camera_source == "external"
 
 
+def test_timelapse_reload_config_applies_saved_output_dir(tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    initial_dir = tmp_path / "captures-initial"
+    updated_dir = tmp_path / "captures-updated"
+    cfg._cfg.timelapse["output_dir"] = str(initial_dir)
+
+    svc = TimelapseService(cfg)
+
+    assert svc._captures_dir == str(initial_dir)
+    assert initial_dir.is_dir()
+
+    cfg._cfg.timelapse["output_dir"] = str(updated_dir)
+    svc.reload_config()
+
+    assert svc._captures_dir == str(updated_dir)
+    assert updated_dir.is_dir()
+
+    (updated_dir / "updated.mp4").write_bytes(b"video")
+    assert svc.get_video_path("updated.mp4") == str(updated_dir / "updated.mp4")
+
+
+def test_timelapse_explicit_captures_dir_overrides_saved_output_dir(tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    explicit_dir = tmp_path / "explicit"
+    configured_dir = tmp_path / "configured"
+    cfg._cfg.timelapse["output_dir"] = str(configured_dir)
+
+    svc = TimelapseService(cfg, captures_dir=explicit_dir)
+
+    assert svc._captures_dir == str(explicit_dir)
+    assert explicit_dir.is_dir()
+    assert not configured_dir.exists()
+
+
 def test_timelapse_runtime_state_reports_recovery(tmp_path):
     cfg = FakeConfigManager(tmp_path)
     svc = TimelapseService(cfg, captures_dir=tmp_path)

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -198,10 +198,23 @@ def test_timelapse_prunes_old_videos(tmp_path):
         path.write_bytes(name.encode())
         time.sleep(0.01)
 
+    old_snapshots = tmp_path / "snapshots" / "old"
+    old_snapshots.mkdir(parents=True)
+    (old_snapshots / "frame_00000.jpg").write_bytes(b"old-frame")
+    svc._write_meta(
+        old_snapshots,
+        "old.gcode",
+        1,
+        video_filename="old.mp4",
+        archived_at="2026-04-10T12:00:00",
+        status="archived",
+    )
+
     svc._prune_old_videos()
 
     remaining = sorted(p.name for p in tmp_path.glob("*.mp4"))
     assert remaining == ["mid.mp4", "new.mp4"]
+    assert not old_snapshots.exists()
 
 
 def test_timelapse_resolves_ffmpeg_through_web_fallback(monkeypatch):

--- a/tests/test_web_helpers_and_api.py
+++ b/tests/test_web_helpers_and_api.py
@@ -709,6 +709,51 @@ def test_root_shows_ffmpeg_warning_only_for_camera_capable_devices(monkeypatch):
     assert "Camera features need `ffmpeg`" not in no_camera.get_data(as_text=True)
 
 
+def test_root_handles_config_with_no_printers(monkeypatch):
+    cfg = Config(
+        account=Account(
+            auth_token="token",
+            region="eu",
+            user_id="user-1",
+            email="user@example.com",
+        ),
+        printers=[],
+    )
+    manager = FakeConfigManager(cfg)
+    client = app.test_client()
+
+    old_values = {
+        "config": app.config.get("config"),
+        "printer_index": app.config.get("printer_index"),
+        "printer_index_locked": app.config.get("printer_index_locked"),
+        "video_supported": app.config.get("video_supported"),
+        "login": app.config.get("login"),
+        "unsupported_device": app.config.get("unsupported_device"),
+        "api_key": app.config.get("api_key"),
+    }
+
+    app.config["config"] = manager
+    app.config["printer_index"] = 0
+    app.config["printer_index_locked"] = False
+    app.config["video_supported"] = True
+    app.config["login"] = True
+    app.config["unsupported_device"] = False
+    app.config["api_key"] = None
+
+    try:
+        monkeypatch.setattr("web._ffmpeg_available", lambda: False)
+        response = client.get("/")
+    finally:
+        for key, value in old_values.items():
+            app.config[key] = value
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "No printers are configured for this account" in html
+    assert 'id="setup"' in html
+    assert "Camera features need `ffmpeg`" not in html
+
+
 def test_probe_printer_storage_files_uses_one_shot_mqtt_probe(monkeypatch):
     cfg = Config(
         account=Account(

--- a/tests/test_web_helpers_and_api.py
+++ b/tests/test_web_helpers_and_api.py
@@ -394,6 +394,11 @@ def test_access_log_noise_filter_suppresses_console_polling_and_static_assets():
         msg='127.0.0.1 - - [09/Apr/2026 10:15:00] "GET /api/printer/runtime-state HTTP/1.1" 200 -',
         args=(), exc_info=None,
     )
+    swap_record = logging.LogRecord(
+        name="werkzeug", level=logging.INFO, pathname=__file__, lineno=0,
+        msg='127.0.0.1 - - [13/Apr/2026 20:50:30] "GET /api/filaments/service/swap?printer_index=0 HTTP/1.1" 200 -',
+        args=(), exc_info=None,
+    )
     api_record = logging.LogRecord(
         name="werkzeug", level=logging.INFO, pathname=__file__, lineno=0,
         msg='127.0.0.1 - - [08/Apr/2026 17:57:47] "GET /api/health HTTP/1.1" 200 -',
@@ -403,6 +408,7 @@ def test_access_log_noise_filter_suppresses_console_polling_and_static_assets():
     assert filt.filter(console_record) is False
     assert filt.filter(static_record) is False
     assert filt.filter(runtime_record) is False
+    assert filt.filter(swap_record) is False
     assert filt.filter(api_record) is True
 
 

--- a/tests/test_websockets_and_debug.py
+++ b/tests/test_websockets_and_debug.py
@@ -384,7 +384,7 @@ def test_pppp_probe_helper_and_state_websocket_emit_status(monkeypatch):
     assert json.loads(sock.sent[0]) == {"status": "connected", "source": "probe"}
 
 
-def test_pppp_state_websocket_marks_stale_probe_success_dormant(monkeypatch):
+def test_pppp_state_websocket_marks_stale_probe_success_dormant_without_reprobe(monkeypatch):
     with web_module.app.pppp_probe_lock:
         web_module.app.pppp_probe = {
             "result": True,
@@ -430,7 +430,7 @@ def test_pppp_state_websocket_marks_stale_probe_success_dormant(monkeypatch):
             }
 
     assert json.loads(sock.sent[0]) == {"status": "dormant", "source": "none"}
-    assert probe_calls == [("cached probe stale", 0)]
+    assert probe_calls == []
 
 
 def test_pppp_probe_helper_skips_when_services_are_already_recovering(monkeypatch):

--- a/tests/test_websockets_and_debug.py
+++ b/tests/test_websockets_and_debug.py
@@ -341,7 +341,11 @@ def test_pppp_probe_helper_and_state_websocket_emit_status(monkeypatch):
             "client_count": 1,
         }
 
-    old_values, old_svc = _install_app_state(web_module, config=FakeConfigManager(_base_config()), printer_index=0)
+    old_values, old_svc = _install_app_state(
+        web_module,
+        config=FakeConfigManager(_base_config()),
+        printer_index=0,
+    )
     monkeypatch.setattr("web.service.pppp.probe_pppp", lambda config, idx: True)
     monkeypatch.setattr("web.time.time", lambda: 100.0)
 
@@ -360,7 +364,10 @@ def test_pppp_probe_helper_and_state_websocket_emit_status(monkeypatch):
             }
         )
         web_module.app.svc = services
-        monkeypatch.setattr("web._maybe_start_pppp_probe", lambda reason="scheduled": None)
+        monkeypatch.setattr(
+            "web._maybe_start_pppp_probe",
+            lambda reason="scheduled", printer_index=None: None,
+        )
         monkeypatch.setattr("web.time.sleep", lambda seconds: None)
         _ws_handler(web_module, "pppp_state")(sock)
     finally:
@@ -374,7 +381,56 @@ def test_pppp_probe_helper_and_state_websocket_emit_status(monkeypatch):
                 "client_count": 0,
             }
 
-    assert json.loads(sock.sent[0]) == {"status": "connected"}
+    assert json.loads(sock.sent[0]) == {"status": "connected", "source": "probe"}
+
+
+def test_pppp_state_websocket_marks_stale_probe_success_dormant(monkeypatch):
+    with web_module.app.pppp_probe_lock:
+        web_module.app.pppp_probe = {
+            "result": True,
+            "last_time": 100.0,
+            "fail_count": 0,
+            "thread": None,
+            "client_count": 1,
+        }
+
+    old_values, old_svc = _install_app_state(
+        web_module,
+        config=FakeConfigManager(_base_config()),
+        printer_index=0,
+    )
+    probe_calls = []
+
+    def record_probe(reason="scheduled", printer_index=None):
+        probe_calls.append((reason, printer_index))
+
+    try:
+        sock = FakeSock(close_after_sends=1)
+        mqtt_name = web_module.mqtt_service_name(0)
+        services = FakeServices(
+            svcs={
+                "pppp": SimpleNamespace(connected=False, wanted=False),
+                mqtt_name: SimpleNamespace(last_message_time=0.0),
+            }
+        )
+        web_module.app.svc = services
+        monkeypatch.setattr("web._maybe_start_pppp_probe", record_probe)
+        monkeypatch.setattr("web.time.time", lambda: 120.0)
+        monkeypatch.setattr("web.time.sleep", lambda seconds: None)
+        _ws_handler(web_module, "pppp_state")(sock)
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
+        with web_module.app.pppp_probe_lock:
+            web_module.app.pppp_probe = {
+                "result": None,
+                "last_time": 0.0,
+                "fail_count": 0,
+                "thread": None,
+                "client_count": 0,
+            }
+
+    assert json.loads(sock.sent[0]) == {"status": "dormant", "source": "none"}
+    assert probe_calls == [("cached probe stale", 0)]
 
 
 def test_pppp_probe_helper_skips_when_services_are_already_recovering(monkeypatch):

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -289,7 +289,7 @@ if not app.secret_key:
     app.secret_key = token(24)
 app.svc = ServiceManager()
 app.filament_swap_lock = threading.Lock()
-app.filament_swap_state = None
+app.filament_swap_state = {}
 app.pppp_probe_lock = threading.Lock()
 
 
@@ -1186,33 +1186,106 @@ def _serialize_filament_swap_state(state):
     }
 
 
-def _filament_swap_state_get(token=None):
+def _filament_swap_states_locked():
+    states = app.filament_swap_state
+    if states is None:
+        app.filament_swap_state = {}
+        return app.filament_swap_state
+
+    if isinstance(states, dict) and "token" in states:
+        printer_index = _service_printer_index(states.get("printer_index"))
+        states["printer_index"] = printer_index
+        app.filament_swap_state = {printer_index: states}
+        return app.filament_swap_state
+
+    if not isinstance(states, dict):
+        app.filament_swap_state = {}
+        return app.filament_swap_state
+
+    normalized = {}
+    changed = False
+    for raw_printer_index, state in list(states.items()):
+        if not isinstance(state, dict):
+            changed = True
+            continue
+        printer_index = _service_printer_index(raw_printer_index)
+        state["printer_index"] = printer_index
+        normalized[printer_index] = state
+        changed = changed or printer_index != raw_printer_index
+
+    if changed:
+        app.filament_swap_state = normalized
+        return app.filament_swap_state
+    return states
+
+
+def _filament_swap_state_by_token_locked(states, token, printer_index=None):
+    if token is None:
+        return None, None
+
+    if printer_index is not None:
+        resolved_index = _service_printer_index(printer_index)
+        state = states.get(resolved_index)
+        if state is not None and state.get("token") == token:
+            return resolved_index, state
+        return None, None
+
+    for resolved_index, state in states.items():
+        if state is not None and state.get("token") == token:
+            return resolved_index, state
+    return None, None
+
+
+def _filament_swap_state_get(token=None, printer_index=None):
     with app.filament_swap_lock:
-        state = app.filament_swap_state
+        states = _filament_swap_states_locked()
+        if token is not None:
+            _, state = _filament_swap_state_by_token_locked(states, token, printer_index=printer_index)
+            return dict(state) if state is not None else None
+
+        state = states.get(_service_printer_index(printer_index))
         if state is None:
-            return None
-        if token is not None and state.get("token") != token:
             return None
         return dict(state)
 
 
-def _filament_swap_state_update(token, **updates):
+def _filament_swap_state_set_if_absent(state):
     with app.filament_swap_lock:
-        state = app.filament_swap_state
-        if state is None or state.get("token") != token:
+        states = _filament_swap_states_locked()
+        state = dict(state)
+        printer_index = _service_printer_index(state.get("printer_index"))
+        if states.get(printer_index) is not None:
+            return None
+        state["printer_index"] = printer_index
+        states[printer_index] = state
+        return dict(state)
+
+
+def _filament_swap_state_update(token, printer_index=None, **updates):
+    with app.filament_swap_lock:
+        states = _filament_swap_states_locked()
+        _, state = _filament_swap_state_by_token_locked(states, token, printer_index=printer_index)
+        if state is None:
             return None
         state.update(updates)
         return dict(state)
 
 
-def _filament_swap_state_clear(token=None):
+def _filament_swap_state_clear(token=None, printer_index=None):
     with app.filament_swap_lock:
-        state = app.filament_swap_state
+        states = _filament_swap_states_locked()
+        if token is not None:
+            resolved_index, state = _filament_swap_state_by_token_locked(
+                states,
+                token,
+                printer_index=printer_index,
+            )
+        else:
+            resolved_index = _service_printer_index(printer_index)
+            state = states.get(resolved_index)
         if state is None:
             return None
-        if token is not None and state.get("token") != token:
-            return None
-        app.filament_swap_state = None
+        states.pop(resolved_index, None)
         return dict(state)
 
 
@@ -3776,8 +3849,8 @@ def app_api_filaments_duplicate(profile_id):
 
 @app.get("/api/filaments/service/swap")
 def app_api_filament_service_swap_state():
-    with app.filament_swap_lock:
-        return _serialize_filament_swap_state(app.filament_swap_state)
+    printer_index = _requested_printer_index()
+    return _serialize_filament_swap_state(_filament_swap_state_get(printer_index=printer_index))
 
 
 @app.post("/api/filaments/service/preheat")
@@ -3924,9 +3997,8 @@ def app_api_filament_service_swap_start():
         unload_feedrate_mm_min = FILAMENT_SERVICE_SWAP_UNLOAD_FEEDRATE_MM_MIN
         load_feedrate_mm_min = FILAMENT_SERVICE_SWAP_LOAD_FEEDRATE_MM_MIN
 
-    with app.filament_swap_lock:
-        if app.filament_swap_state is not None:
-            return {"error": "A filament swap is already in progress"}, 409
+    if _filament_swap_state_get(printer_index=printer_index) is not None:
+        return {"error": "A filament swap is already in progress"}, 409
 
     swap_state = {
         "token": token(12),
@@ -3967,8 +4039,8 @@ def app_api_filament_service_swap_start():
             "then confirm. Use Quick Extrude afterward if you need to purge."
         )
 
-    with app.filament_swap_lock:
-        app.filament_swap_state = swap_state
+    if _filament_swap_state_set_if_absent(swap_state) is None:
+        return {"error": "A filament swap is already in progress"}, 409
 
     try:
         with borrow_mqtt(printer_index) as mqtt:
@@ -3978,13 +4050,13 @@ def app_api_filament_service_swap_start():
             else:
                 mqtt.send_gcode(f"M104 S{manual_swap_preheat_temp_c}")
     except RuntimeError as exc:
-        _filament_swap_state_clear(swap_state["token"])
+        _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
         return {"error": str(exc)}, 409
     except TimeoutError as exc:
-        _filament_swap_state_clear(swap_state["token"])
+        _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
         return {"error": str(exc)}, 504
     except ConnectionError as exc:
-        _filament_swap_state_clear(swap_state["token"])
+        _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
         return {"error": str(exc)}, 503
 
     return {
@@ -3999,19 +4071,18 @@ def app_api_filament_service_swap_start():
 def app_api_filament_service_swap_confirm():
     printer_index = _requested_printer_index()
     payload = request.get_json(silent=True) or {}
-    with app.filament_swap_lock:
-        swap_state = app.filament_swap_state
-        if swap_state is None:
-            return {"error": "No filament swap is in progress"}, 409
-        provided_token = payload.get("token")
-        if provided_token and provided_token != swap_state["token"]:
-            return {"error": "Swap token mismatch"}, 409
-        if swap_state.get("phase") in {"homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"}:
-            return {"error": "Swap stage is still running; wait for it to finish first"}, 409
-        printer_index = _service_printer_index(swap_state.get("printer_index", printer_index))
+    swap_state = _filament_swap_state_get(printer_index=printer_index)
+    if swap_state is None:
+        return {"error": "No filament swap is in progress"}, 409
+    provided_token = payload.get("token")
+    if provided_token and provided_token != swap_state["token"]:
+        return {"error": "Swap token mismatch"}, 409
+    if swap_state.get("phase") in {"homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"}:
+        return {"error": "Swap stage is still running; wait for it to finish first"}, 409
+    printer_index = _service_printer_index(swap_state.get("printer_index", printer_index))
 
     if swap_state.get("mode") == "manual":
-        completed_swap = _filament_swap_state_clear(swap_state["token"])
+        completed_swap = _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
         return {
             "status": "ok",
             "message": (
@@ -4025,6 +4096,7 @@ def app_api_filament_service_swap_confirm():
 
     _filament_swap_state_update(
         swap_state["token"],
+        printer_index=printer_index,
         phase="heating_load",
         message=(
             f"Heating for automatic load / purge of {swap_state['load_profile_name']} "
@@ -4036,14 +4108,26 @@ def app_api_filament_service_swap_confirm():
         with borrow_mqtt(printer_index) as mqtt:
             _assert_filament_service_ready(mqtt)
     except RuntimeError as exc:
-        _filament_swap_state_update(swap_state["token"], phase="error", message=str(exc), error=str(exc))
+        _filament_swap_state_update(
+            swap_state["token"],
+            printer_index=printer_index,
+            phase="error",
+            message=str(exc),
+            error=str(exc),
+        )
         return {"error": str(exc)}, 409
     except ConnectionError as exc:
-        _filament_swap_state_update(swap_state["token"], phase="error", message=str(exc), error=str(exc))
+        _filament_swap_state_update(
+            swap_state["token"],
+            printer_index=printer_index,
+            phase="error",
+            message=str(exc),
+            error=str(exc),
+        )
         return {"error": str(exc)}, 503
 
     _filament_swap_start_background(_run_legacy_swap_load, swap_state["token"])
-    current_state = _filament_swap_state_get(swap_state["token"])
+    current_state = _filament_swap_state_get(swap_state["token"], printer_index=printer_index)
     if current_state is None:
         return {
             "status": "ok",
@@ -4060,22 +4144,22 @@ def app_api_filament_service_swap_confirm():
 
 @app.post("/api/filaments/service/swap/cancel")
 def app_api_filament_service_swap_cancel():
+    printer_index = _requested_printer_index()
     payload = request.get_json(silent=True) or {}
-    with app.filament_swap_lock:
-        swap_state = app.filament_swap_state
-        if swap_state is None:
-            return {"status": "ok", "pending": False, "swap": None}
-        provided_token = payload.get("token")
-        if provided_token and provided_token != swap_state["token"]:
-            return {"error": "Swap token mismatch"}, 409
-        if swap_state.get("phase") in {"homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"}:
-            return {"error": "Cannot cancel while an automatic swap stage is running"}, 409
-        app.filament_swap_state = None
+    swap_state = _filament_swap_state_get(printer_index=printer_index)
+    if swap_state is None:
+        return {"status": "ok", "pending": False, "swap": None}
+    provided_token = payload.get("token")
+    if provided_token and provided_token != swap_state["token"]:
+        return {"error": "Swap token mismatch"}, 409
+    if swap_state.get("phase") in {"homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"}:
+        return {"error": "Cannot cancel while an automatic swap stage is running"}, 409
+    cancelled_swap = _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
 
     return {
         "status": "ok",
         "message": "Filament swap cancelled.",
-        "cancelled_swap": swap_state,
+        "cancelled_swap": cancelled_swap,
         "pending": False,
         "swap": None,
     }

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1839,13 +1839,14 @@ def pppp_state(sock):
                 )
                 stale_probe_success = probe_result is True and not probe_success_fresh
 
+                # A stale successful probe should only stop cached-green badges; it should not
+                # cause another passive probe by itself or the UI loops while video is off.
                 should_probe = (
                     (
                         mqtt_stale
                         or mqtt_recovered
                         or probe_result is False
                         or pppp_went_dormant
-                        or stale_probe_success
                     )
                     and (now - last_probe_time) > next_interval
                 )
@@ -1853,7 +1854,6 @@ def pppp_state(sock):
                     reason = ("PPPP service stopped" if pppp_went_dormant
                               else "MQTT recovered" if mqtt_recovered
                               else "MQTT stale" if mqtt_stale
-                              else "cached probe stale" if stale_probe_success
                               else "retry after fail")
                     _maybe_start_pppp_probe(reason, printer_index=printer_index)
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -52,6 +52,7 @@ class _AccessLogNoiseFilter(logging.Filter):
         '"GET /api/printer/runtime-state',
         '"GET /api/camera/frame',
         '"GET /api/camera/stream',
+        '"GET /api/filaments/service/swap',
     )
 
     def filter(self, record):
@@ -1021,25 +1022,46 @@ def _resolve_filament_service_settings(cfg):
 
 FILAMENT_SERVICE_DEFAULT_LENGTH_MM = 40.0
 FILAMENT_SERVICE_SWAP_PRIME_DEFAULT_LENGTH_MM = 10.0
-FILAMENT_SERVICE_SWAP_UNLOAD_DEFAULT_LENGTH_MM = 50.0
+FILAMENT_SERVICE_SWAP_UNLOAD_DEFAULT_LENGTH_MM = 60.0
 FILAMENT_SERVICE_SWAP_LOAD_DEFAULT_LENGTH_MM = 120.0
 FILAMENT_SERVICE_MAX_LENGTH_MM = 300.0
 FILAMENT_SERVICE_FEEDRATE_MM_MIN = 240
 FILAMENT_SERVICE_EXTRUDE_FEEDRATE_MM_MIN = 900
 FILAMENT_SERVICE_RETRACT_FEEDRATE_MM_MIN = 2700
 FILAMENT_SERVICE_SWAP_PRIME_FEEDRATE_MM_MIN = 240
-FILAMENT_SERVICE_SWAP_UNLOAD_FEEDRATE_MM_MIN = 240
+FILAMENT_SERVICE_SWAP_UNLOAD_FEEDRATE_MM_MIN = FILAMENT_SERVICE_RETRACT_FEEDRATE_MM_MIN
 FILAMENT_SERVICE_SWAP_LOAD_FEEDRATE_MM_MIN = 240
 FILAMENT_SERVICE_SWAP_PARK_X_MM = 0.0
 FILAMENT_SERVICE_SWAP_PARK_Y_MM = 230.0
 FILAMENT_SERVICE_SWAP_Z_LIFT_MM = 50.0
-FILAMENT_SERVICE_SWAP_PARK_FEEDRATE_MM_MIN = 9000
+FILAMENT_SERVICE_SWAP_PARK_FEEDRATE_MM_MIN = 3000
 FILAMENT_SERVICE_SWAP_Z_FEEDRATE_MM_MIN = 600
+FILAMENT_SERVICE_SWAP_HOME_READY_TEMP_C = int(os.getenv("FILAMENT_SWAP_HOME_READY_TEMP_C", 180))
+FILAMENT_SERVICE_SWAP_HOME_SETTLE_S = float(os.getenv(
+    "FILAMENT_SWAP_HOME_PAUSE_S",
+    os.getenv("FILAMENT_SWAP_HOME_SETTLE_S", 55.0),
+))
+FILAMENT_SERVICE_SWAP_COOLDOWN_DELAY_S = float(os.getenv("FILAMENT_SWAP_COOLDOWN_DELAY_S", 0.75))
+FILAMENT_SERVICE_SWAP_MOTION_SETTLE_S = float(os.getenv("FILAMENT_SWAP_MOTION_SETTLE_S", 1.0))
+FILAMENT_SERVICE_SWAP_PARK_MIN_TRAVEL_MM = float(os.getenv("FILAMENT_SWAP_PARK_MIN_TRAVEL_MM", 250.0))
+FILAMENT_SERVICE_SWAP_MAX_WAIT_S = 180.0
+FILAMENT_SERVICE_TARGET_ACK_TIMEOUT_S = float(os.getenv("FILAMENT_SERVICE_TARGET_ACK_TIMEOUT_S", 3.0))
 FILAMENT_SERVICE_HEAT_TIMEOUT_S = 240.0
 FILAMENT_SERVICE_HEAT_POLL_S = 0.5
 FILAMENT_SERVICE_HEAT_TOLERANCE_C = 5
+FILAMENT_SERVICE_TEMP_MAX_AGE_S = float(os.getenv("FILAMENT_SERVICE_TEMP_MAX_AGE_S", 15.0))
+FILAMENT_SERVICE_MANUAL_SWAP_DEFAULT_TEMP_C = 180
 FILAMENT_SERVICE_MANUAL_SWAP_MIN_TEMP_C = 130
-FILAMENT_SERVICE_MANUAL_SWAP_MAX_TEMP_C = 150
+FILAMENT_SERVICE_MANUAL_SWAP_MAX_TEMP_C = 300
+_FILAMENT_SWAP_RUNNING_PHASES = frozenset({
+    "homing",
+    "heating_unload",
+    "priming_unload",
+    "unloading",
+    "heating_load",
+    "loading",
+    "cooling_down",
+})
 Z_OFFSET_STEP_MM = 0.01
 Z_OFFSET_REFRESH_TIMEOUT_S = 5.0
 Z_OFFSET_CONFIRM_TIMEOUT_S = 8.0
@@ -1089,6 +1111,28 @@ def _filament_service_setting_length(settings, key, default=FILAMENT_SERVICE_DEF
         return round(default, 2)
 
 
+def _filament_service_seconds(payload, key, default=FILAMENT_SERVICE_SWAP_HOME_SETTLE_S):
+    raw = payload.get(key, default)
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be a number")
+    if not math.isfinite(seconds):
+        raise ValueError(f"{key} must be a finite number")
+    if seconds < 0:
+        raise ValueError(f"{key} must be >= 0")
+    if seconds > FILAMENT_SERVICE_SWAP_MAX_WAIT_S:
+        raise ValueError(f"{key} must be <= {FILAMENT_SERVICE_SWAP_MAX_WAIT_S:g}")
+    return round(seconds, 2)
+
+
+def _filament_service_setting_seconds(settings, key, default=FILAMENT_SERVICE_SWAP_HOME_SETTLE_S):
+    try:
+        return _filament_service_seconds({key: settings.get(key, default)}, key, default=default)
+    except (AttributeError, ValueError):
+        return round(default, 2)
+
+
 def _normalize_filament_service_settings(settings):
     normalized = dict(settings or {})
     normalized["allow_legacy_swap"] = _filament_service_bool(normalized.get("allow_legacy_swap"))
@@ -1108,6 +1152,11 @@ def _normalize_filament_service_settings(settings):
         normalized,
         "swap_load_length_mm",
         FILAMENT_SERVICE_SWAP_LOAD_DEFAULT_LENGTH_MM,
+    )
+    normalized["swap_home_pause_s"] = _filament_service_setting_seconds(
+        normalized,
+        "swap_home_pause_s",
+        FILAMENT_SERVICE_SWAP_HOME_SETTLE_S,
     )
     return normalized
 
@@ -1144,14 +1193,9 @@ def _build_filament_swap_park_gcode(
     park_y_mm=FILAMENT_SERVICE_SWAP_PARK_Y_MM,
 ):
     return "\n".join([
-        "G28",
         "G91",
-        f"G1 Z{_format_extrusion_mm(z_lift_mm)} F{FILAMENT_SERVICE_SWAP_Z_FEEDRATE_MM_MIN}",
+        f"G0 Z{_format_extrusion_mm(z_lift_mm)} F{FILAMENT_SERVICE_SWAP_Z_FEEDRATE_MM_MIN}",
         "G90",
-        (
-            f"G1 X{_format_extrusion_mm(park_x_mm)} "
-            f"Y{_format_extrusion_mm(park_y_mm)} F{FILAMENT_SERVICE_SWAP_PARK_FEEDRATE_MM_MIN}"
-        ),
         "M400",
     ])
 
@@ -1181,6 +1225,7 @@ def _serialize_filament_swap_state(state):
             "z_lift_mm": state.get("z_lift_mm"),
             "park_x_mm": state.get("park_x_mm"),
             "park_y_mm": state.get("park_y_mm"),
+            "home_pause_s": state.get("home_pause_s"),
             "manual_swap_preheat_temp_c": state.get("manual_swap_preheat_temp_c"),
         },
     }
@@ -1311,22 +1356,86 @@ def _assert_filament_service_ready(mqtt):
         raise RuntimeError("Filament service commands are blocked while a print is active")
 
 
-def _wait_for_filament_service_nozzle(mqtt, target_temp_c):
+class _FilamentSwapCancelled(Exception):
+    pass
+
+
+def _wait_for_filament_swap_delay(delay_s, should_continue=None):
+    deadline = time.monotonic() + max(0.0, float(delay_s or 0.0))
+    while time.monotonic() < deadline:
+        if should_continue is not None and not should_continue():
+            raise _FilamentSwapCancelled()
+        time.sleep(min(0.25, max(0.0, deadline - time.monotonic())))
+
+
+def _wait_for_filament_swap_home(should_continue=None, pause_s=None):
+    delay_s = FILAMENT_SERVICE_SWAP_HOME_SETTLE_S if pause_s is None else pause_s
+    _wait_for_filament_swap_delay(delay_s, should_continue=should_continue)
+
+
+def _filament_swap_motion_wait_s(length_mm, feedrate_mm_min):
+    try:
+        length = abs(float(length_mm))
+        feedrate = max(1.0, float(feedrate_mm_min))
+    except (TypeError, ValueError):
+        return FILAMENT_SERVICE_SWAP_MOTION_SETTLE_S
+    return max(0.5, (length / feedrate * 60.0) + FILAMENT_SERVICE_SWAP_MOTION_SETTLE_S)
+
+
+def _wait_for_filament_swap_motion(length_mm, feedrate_mm_min, should_continue=None):
+    _wait_for_filament_swap_delay(
+        _filament_swap_motion_wait_s(length_mm, feedrate_mm_min),
+        should_continue=should_continue,
+    )
+
+
+def _wait_for_filament_swap_park(z_lift_mm, park_x_mm, park_y_mm, should_continue=None):
+    try:
+        z_seconds = abs(float(z_lift_mm)) / max(1.0, float(FILAMENT_SERVICE_SWAP_Z_FEEDRATE_MM_MIN)) * 60.0
+    except (TypeError, ValueError):
+        z_seconds = 0.0
+    _wait_for_filament_swap_delay(
+        z_seconds + FILAMENT_SERVICE_SWAP_MOTION_SETTLE_S,
+        should_continue=should_continue,
+    )
+
+
+def _send_filament_swap_home_all(mqtt, should_continue=None, pause_s=None):
+    send_home = getattr(mqtt, "send_home", None)
+    if callable(send_home):
+        send_home("all")
+    else:
+        mqtt.send_gcode("G28")
+    _wait_for_filament_swap_home(should_continue=should_continue, pause_s=pause_s)
+
+
+def _wait_for_filament_service_nozzle(mqtt, target_temp_c, should_continue=None, tolerance_c=FILAMENT_SERVICE_HEAT_TOLERANCE_C):
     deadline = time.monotonic() + FILAMENT_SERVICE_HEAT_TIMEOUT_S
     next_query = 0.0
     last_temp = mqtt.nozzle_temp
-    target_ready = int(target_temp_c) - FILAMENT_SERVICE_HEAT_TOLERANCE_C
+    target_ready = int(target_temp_c) - max(0, int(tolerance_c))
+    require_fresh_temp = hasattr(mqtt, "nozzle_temp_updated_at")
 
     while time.monotonic() < deadline:
+        if should_continue is not None and not should_continue():
+            raise _FilamentSwapCancelled()
         now = time.monotonic()
         if now >= next_query:
-            mqtt.request_status()
+            request_status = getattr(mqtt, "request_status", None)
+            if callable(request_status):
+                request_status()
             next_query = now + 2.0
 
         current_temp = mqtt.nozzle_temp
         if current_temp is not None:
             last_temp = current_temp
-            if current_temp >= target_ready:
+            temp_updated_at = getattr(mqtt, "nozzle_temp_updated_at", 0.0)
+            fresh_enough = (
+                not require_fresh_temp
+                or not temp_updated_at
+                or time.time() - temp_updated_at <= FILAMENT_SERVICE_TEMP_MAX_AGE_S
+            )
+            if current_temp >= target_ready and fresh_enough:
                 return current_temp
 
         time.sleep(FILAMENT_SERVICE_HEAT_POLL_S)
@@ -1337,12 +1446,83 @@ def _wait_for_filament_service_nozzle(mqtt, target_temp_c):
     )
 
 
+def _wait_for_filament_service_nozzle_target(mqtt, target_temp_c, should_continue=None):
+    if not hasattr(mqtt, "nozzle_temp_target"):
+        _wait_for_filament_swap_delay(0.25, should_continue=should_continue)
+        return None
+
+    target_temp_c = int(target_temp_c)
+    deadline = time.monotonic() + FILAMENT_SERVICE_TARGET_ACK_TIMEOUT_S
+    next_query = 0.0
+    last_target = getattr(mqtt, "nozzle_temp_target", None)
+
+    while time.monotonic() < deadline:
+        if should_continue is not None and not should_continue():
+            raise _FilamentSwapCancelled()
+
+        now = time.monotonic()
+        if now >= next_query:
+            request_status = getattr(mqtt, "request_status", None)
+            if callable(request_status):
+                request_status()
+            next_query = now + 0.5
+
+        current_target = getattr(mqtt, "nozzle_temp_target", None)
+        if current_target is not None:
+            last_target = current_target
+            try:
+                if int(round(float(current_target))) == target_temp_c:
+                    return current_target
+            except (TypeError, ValueError):
+                pass
+
+        time.sleep(0.25)
+
+    log.warning(
+        "Filament swap: nozzle target %sC was not observed before homing (last target: %s); continuing",
+        target_temp_c,
+        last_target if last_target is not None else "unknown",
+    )
+    return last_target
+
+
+def _filament_service_nozzle_target_matches(observed_target, target_temp_c):
+    if observed_target is None:
+        return False
+    try:
+        return int(round(float(observed_target))) == int(target_temp_c)
+    except (TypeError, ValueError):
+        return False
+
+
+def _send_filament_service_nozzle_target(mqtt, target_temp_c, should_continue=None, attempts=3):
+    target_temp_c = int(target_temp_c)
+    last_target = None
+    can_observe_target = hasattr(mqtt, "nozzle_temp_target")
+    for _ in range(max(1, int(attempts))):
+        if should_continue is not None and not should_continue():
+            raise _FilamentSwapCancelled()
+        mqtt.send_gcode(f"M104 S{target_temp_c}")
+        last_target = _wait_for_filament_service_nozzle_target(
+            mqtt,
+            target_temp_c,
+            should_continue=should_continue,
+        )
+        if (
+            not can_observe_target
+            or _filament_service_nozzle_target_matches(last_target, target_temp_c)
+        ):
+            return last_target
+        _wait_for_filament_swap_delay(0.75, should_continue=should_continue)
+    return last_target
+
+
 def _filament_service_manual_swap_temp(settings):
-    raw_temp = settings.get("manual_swap_preheat_temp_c", 140)
+    raw_temp = settings.get("manual_swap_preheat_temp_c", FILAMENT_SERVICE_MANUAL_SWAP_DEFAULT_TEMP_C)
     try:
         temp_c = int(raw_temp)
     except (TypeError, ValueError):
-        temp_c = 140
+        temp_c = FILAMENT_SERVICE_MANUAL_SWAP_DEFAULT_TEMP_C
     return max(FILAMENT_SERVICE_MANUAL_SWAP_MIN_TEMP_C, min(FILAMENT_SERVICE_MANUAL_SWAP_MAX_TEMP_C, temp_c))
 
 
@@ -1351,67 +1531,189 @@ def _run_legacy_swap_unload(token):
     if not state:
         return
 
+    printer_index = _service_printer_index(state.get("printer_index"))
+
+    def should_continue():
+        return _filament_swap_state_get(token, printer_index=printer_index) is not None
+
+    def ensure_continue():
+        if not should_continue():
+            raise _FilamentSwapCancelled()
+
     try:
         park_gcode = _build_filament_swap_park_gcode(
             state.get("z_lift_mm", FILAMENT_SERVICE_SWAP_Z_LIFT_MM),
             state.get("park_x_mm", FILAMENT_SERVICE_SWAP_PARK_X_MM),
             state.get("park_y_mm", FILAMENT_SERVICE_SWAP_PARK_Y_MM),
         )
+        prime_length_mm = state.get("prime_length_mm", FILAMENT_SERVICE_SWAP_PRIME_DEFAULT_LENGTH_MM)
+        unload_length_mm = state["unload_length_mm"]
+        prime_feedrate_mm_min = state.get(
+            "prime_feedrate_mm_min",
+            FILAMENT_SERVICE_SWAP_PRIME_FEEDRATE_MM_MIN,
+        )
+        unload_feedrate_mm_min = state.get(
+            "unload_feedrate_mm_min",
+            FILAMENT_SERVICE_SWAP_UNLOAD_FEEDRATE_MM_MIN,
+        )
+        home_pause_s = state.get("home_pause_s", FILAMENT_SERVICE_SWAP_HOME_SETTLE_S)
         prime_gcode = _build_filament_move_gcode(
-            state.get("prime_length_mm", FILAMENT_SERVICE_SWAP_PRIME_DEFAULT_LENGTH_MM),
-            feedrate_mm_min=state.get("prime_feedrate_mm_min", FILAMENT_SERVICE_SWAP_PRIME_FEEDRATE_MM_MIN),
+            prime_length_mm,
+            feedrate_mm_min=prime_feedrate_mm_min,
         )
         unload_gcode = _build_filament_move_gcode(
-            -state["unload_length_mm"],
-            feedrate_mm_min=state.get("unload_feedrate_mm_min", FILAMENT_SERVICE_FEEDRATE_MM_MIN),
+            -unload_length_mm,
+            feedrate_mm_min=unload_feedrate_mm_min,
         )
-        with borrow_mqtt(state.get("printer_index")) as mqtt:
+        home_preheat_temp_c = min(
+            int(state["unload_temp_c"]),
+            int(state.get("manual_swap_preheat_temp_c") or FILAMENT_SERVICE_SWAP_HOME_READY_TEMP_C),
+        )
+        home_ready_temp_c = home_preheat_temp_c
+        with borrow_mqtt(printer_index) as mqtt:
             _assert_filament_service_ready(mqtt)
 
             _filament_swap_state_update(
                 token,
+                printer_index=printer_index,
+                phase="heating_unload",
+                message=(
+                    f"Heating nozzle to {state['unload_temp_c']}°C; "
+                    f"waiting for {home_ready_temp_c}°C before homing..."
+                ),
+                error=None,
+            )
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
+                phase="heating_unload",
+                message=f"Heating nozzle to {home_preheat_temp_c}C before homing...",
+                error=None,
+            )
+            mqtt.send_gcode(f"M104 S{home_preheat_temp_c}")
+            _wait_for_filament_service_nozzle(
+                mqtt,
+                home_ready_temp_c,
+                should_continue=should_continue,
+                tolerance_c=0,
+            )
+            ensure_continue()
+
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
+                phase="heating_unload",
+                message=f"Setting nozzle target to {state['unload_temp_c']}C for unload...",
+                error=None,
+            )
+            _send_filament_service_nozzle_target(
+                mqtt,
+                state["unload_temp_c"],
+                should_continue=should_continue,
+            )
+            ensure_continue()
+
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
                 phase="homing",
                 message=(
-                    "Homing and parking before filament swap. Make sure the bed and toolhead path are clear."
+                    f"Homing all axes before filament swap. Waiting {home_pause_s:g}s before raising Z."
+                ),
+                error=None,
+            )
+            _send_filament_swap_home_all(mqtt, should_continue=should_continue, pause_s=home_pause_s)
+            ensure_continue()
+
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
+                phase="heating_unload",
+                message=f"Reapplying nozzle target {state['unload_temp_c']}C after homing...",
+                error=None,
+            )
+            _send_filament_service_nozzle_target(
+                mqtt,
+                state["unload_temp_c"],
+                should_continue=should_continue,
+            )
+            ensure_continue()
+
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
+                phase="homing",
+                message=(
+                    f"Raising Z {state.get('z_lift_mm', FILAMENT_SERVICE_SWAP_Z_LIFT_MM)} mm..."
                 ),
                 error=None,
             )
             mqtt.send_gcode(park_gcode)
+            _wait_for_filament_swap_park(
+                state.get("z_lift_mm", FILAMENT_SERVICE_SWAP_Z_LIFT_MM),
+                state.get("park_x_mm", FILAMENT_SERVICE_SWAP_PARK_X_MM),
+                state.get("park_y_mm", FILAMENT_SERVICE_SWAP_PARK_Y_MM),
+                should_continue=should_continue,
+            )
+            ensure_continue()
 
-            current_temp = mqtt.nozzle_temp
-            if current_temp is None or current_temp < (state["unload_temp_c"] - FILAMENT_SERVICE_HEAT_TOLERANCE_C):
-                _filament_swap_state_update(
-                    token,
-                    phase="heating_unload",
-                    message=f"Heating nozzle to {state['unload_temp_c']}°C for unload...",
-                    error=None,
-                )
-                mqtt.send_gcode(f"M104 S{state['unload_temp_c']}")
-                _wait_for_filament_service_nozzle(mqtt, state["unload_temp_c"])
+            _send_filament_service_nozzle_target(
+                mqtt,
+                state["unload_temp_c"],
+                should_continue=should_continue,
+            )
+            ensure_continue()
 
             _filament_swap_state_update(
                 token,
+                printer_index=printer_index,
+                phase="heating_unload",
+                message=f"Waiting for nozzle to reach {state['unload_temp_c']}°C for unload...",
+                error=None,
+            )
+            _wait_for_filament_service_nozzle(
+                mqtt,
+                state["unload_temp_c"],
+                should_continue=should_continue,
+            )
+            ensure_continue()
+
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
                 phase="priming_unload",
                 message=(
-                    f"Extruding {state.get('prime_length_mm', FILAMENT_SERVICE_SWAP_PRIME_DEFAULT_LENGTH_MM)} mm "
-                    f"to soften {state['unload_profile_name']} before unload..."
+                    f"Extruding {prime_length_mm} mm before unloading "
+                    f"{state['unload_profile_name']}..."
                 ),
                 error=None,
             )
             mqtt.send_gcode(prime_gcode)
+            _wait_for_filament_swap_motion(
+                prime_length_mm,
+                prime_feedrate_mm_min,
+                should_continue=should_continue,
+            )
+            ensure_continue()
 
             _filament_swap_state_update(
                 token,
+                printer_index=printer_index,
                 phase="unloading",
-                message=(
-                    f"Retracting {state['unload_length_mm']} mm for {state['unload_profile_name']}..."
-                ),
+                message=f"Retracting {unload_length_mm} mm for {state['unload_profile_name']}...",
                 error=None,
             )
             mqtt.send_gcode(unload_gcode)
+            _wait_for_filament_swap_motion(
+                unload_length_mm,
+                unload_feedrate_mm_min,
+                should_continue=should_continue,
+            )
+            ensure_continue()
 
         _filament_swap_state_update(
             token,
+            printer_index=printer_index,
             phase="await_manual_swap",
             message=(
                 "Unload finished. Replace the filament, feed the new filament into the extruder, "
@@ -1419,9 +1721,12 @@ def _run_legacy_swap_unload(token):
             ),
             error=None,
         )
+    except _FilamentSwapCancelled:
+        _filament_swap_state_clear(token, printer_index=printer_index)
     except (RuntimeError, TimeoutError, ConnectionError) as exc:
         _filament_swap_state_update(
             token,
+            printer_index=printer_index,
             phase="error",
             message=f"Automatic unload failed: {exc}",
             error=str(exc),
@@ -1433,40 +1738,81 @@ def _run_legacy_swap_load(token):
     if not state:
         return
 
+    printer_index = _service_printer_index(state.get("printer_index"))
+
+    def should_continue():
+        return _filament_swap_state_get(token, printer_index=printer_index) is not None
+
+    def ensure_continue():
+        if not should_continue():
+            raise _FilamentSwapCancelled()
+
     try:
-        gcode = _build_filament_move_gcode(
-            state["load_length_mm"],
-            feedrate_mm_min=state.get("load_feedrate_mm_min", FILAMENT_SERVICE_FEEDRATE_MM_MIN),
+        load_length_mm = state["load_length_mm"]
+        load_feedrate_mm_min = state.get("load_feedrate_mm_min", FILAMENT_SERVICE_FEEDRATE_MM_MIN)
+        load_gcode = _build_filament_move_gcode(
+            load_length_mm,
+            feedrate_mm_min=load_feedrate_mm_min,
         )
-        with borrow_mqtt(state.get("printer_index")) as mqtt:
+        purge_started = False
+        with borrow_mqtt(printer_index) as mqtt:
             _assert_filament_service_ready(mqtt)
-            current_temp = mqtt.nozzle_temp
-            if current_temp is None or current_temp < (state["load_temp_c"] - FILAMENT_SERVICE_HEAT_TOLERANCE_C):
-                _filament_swap_state_update(
-                    token,
-                    phase="heating_load",
-                    message=f"Heating nozzle to {state['load_temp_c']}°C for load / purge...",
-                    error=None,
-                )
-                mqtt.send_gcode(f"M104 S{state['load_temp_c']}")
-                _wait_for_filament_service_nozzle(mqtt, state["load_temp_c"])
+            _filament_swap_state_update(
+                token,
+                printer_index=printer_index,
+                phase="heating_load",
+                message=f"Heating nozzle to {state['load_temp_c']}°C for load / purge...",
+                error=None,
+            )
+            mqtt.send_gcode(f"M104 S{state['load_temp_c']}")
+            _wait_for_filament_service_nozzle(
+                mqtt,
+                state["load_temp_c"],
+                should_continue=should_continue,
+            )
+            ensure_continue()
 
             _filament_swap_state_update(
                 token,
+                printer_index=printer_index,
                 phase="loading",
                 message=(
                     f"Loading / purging {state['load_profile_name']} "
-                    f"({state['load_length_mm']} mm)..."
+                    f"({load_length_mm} mm)..."
                 ),
                 error=None,
             )
-            mqtt.send_gcode(gcode)
-            mqtt.send_gcode("M104 S0")
+            try:
+                mqtt.send_gcode(load_gcode)
+                purge_started = True
+                _wait_for_filament_swap_motion(
+                    load_length_mm,
+                    load_feedrate_mm_min,
+                    should_continue=should_continue,
+                )
+                ensure_continue()
+            finally:
+                if purge_started:
+                    _filament_swap_state_update(
+                        token,
+                        printer_index=printer_index,
+                        phase="cooling_down",
+                        message="Load / purge finished. Sending nozzle cooldown...",
+                        error=None,
+                    )
+                    _wait_for_filament_swap_delay(
+                        FILAMENT_SERVICE_SWAP_COOLDOWN_DELAY_S,
+                        should_continue=None,
+                    )
+                    mqtt.send_gcode("M104 S0")
 
-        _filament_swap_state_clear(token)
+        _filament_swap_state_clear(token, printer_index=printer_index)
+    except _FilamentSwapCancelled:
+        _filament_swap_state_clear(token, printer_index=printer_index)
     except (RuntimeError, TimeoutError, ConnectionError) as exc:
         _filament_swap_state_update(
             token,
+            printer_index=printer_index,
             phase="error",
             message=f"Automatic load / purge failed: {exc}",
             error=str(exc),
@@ -2834,6 +3180,11 @@ def app_api_settings_filament_service_update():
                 fs_payload[key] = _filament_service_length({key: fs_payload[key]}, key)
             except ValueError as exc:
                 return {"error": str(exc)}, 400
+    if "swap_home_pause_s" in fs_payload:
+        try:
+            fs_payload["swap_home_pause_s"] = _filament_service_seconds(fs_payload, "swap_home_pause_s")
+        except ValueError as exc:
+            return {"error": str(exc)}, 400
 
     with config.modify() as cfg:
         if not cfg:
@@ -4004,6 +4355,7 @@ def app_api_filament_service_swap_start():
     unload_feedrate_mm_min = FILAMENT_SERVICE_FEEDRATE_MM_MIN
     load_feedrate_mm_min = FILAMENT_SERVICE_FEEDRATE_MM_MIN
     prime_feedrate_mm_min = FILAMENT_SERVICE_SWAP_PRIME_FEEDRATE_MM_MIN
+    home_pause_s = filament_settings.get("swap_home_pause_s", FILAMENT_SERVICE_SWAP_HOME_SETTLE_S)
 
     if allow_legacy_swap:
         try:
@@ -4022,6 +4374,11 @@ def app_api_filament_service_swap_start():
             load_length_mm = _filament_service_length(
                 {"load_length_mm": payload.get("load_length_mm", filament_settings["swap_load_length_mm"])},
                 "load_length_mm",
+            )
+            home_pause_s = _filament_service_seconds(
+                {"home_pause_s": payload.get("home_pause_s", home_pause_s)},
+                "home_pause_s",
+                default=home_pause_s,
             )
         except ValueError as exc:
             return {"error": str(exc)}, 400
@@ -4054,6 +4411,7 @@ def app_api_filament_service_swap_start():
         "z_lift_mm": FILAMENT_SERVICE_SWAP_Z_LIFT_MM,
         "park_x_mm": FILAMENT_SERVICE_SWAP_PARK_X_MM,
         "park_y_mm": FILAMENT_SERVICE_SWAP_PARK_Y_MM,
+        "home_pause_s": home_pause_s,
         "manual_swap_preheat_temp_c": manual_swap_preheat_temp_c,
         "prime_feedrate_mm_min": prime_feedrate_mm_min,
         "unload_feedrate_mm_min": unload_feedrate_mm_min,
@@ -4062,8 +4420,8 @@ def app_api_filament_service_swap_start():
 
     if allow_legacy_swap:
         swap_state["message"] = (
-            "Guided automatic swap will home and park first. Make sure the bed is clear. "
-            f"Then it will heat {unload_profile['name']} to {unload_temp_c}°C, "
+            f"Guided automatic swap will start heating {unload_profile['name']} to {unload_temp_c}°C, "
+            f"then home, wait {home_pause_s:g}s, raise Z, "
             f"extrude {prime_length_mm} mm, and retract {unload_length_mm} mm."
         )
     else:
@@ -4071,6 +4429,14 @@ def app_api_filament_service_swap_start():
             f"Recommended method enabled: preheating nozzle to {manual_swap_preheat_temp_c}°C. "
             "Release the extruder lever, remove the filament manually, insert the new filament, "
             "then confirm. Use Quick Extrude afterward if you need to purge."
+        )
+
+    if allow_legacy_swap:
+        swap_state["message"] = (
+            f"Guided automatic swap will preheat to {manual_swap_preheat_temp_c}C, "
+            f"set {unload_profile['name']} to {unload_temp_c}C, then home, "
+            f"wait {home_pause_s:g}s, raise Z, "
+            f"extrude {prime_length_mm} mm, and retract {unload_length_mm} mm."
         )
 
     if _filament_swap_state_set_if_absent(swap_state) is None:
@@ -4111,7 +4477,7 @@ def app_api_filament_service_swap_confirm():
     provided_token = payload.get("token")
     if provided_token and provided_token != swap_state["token"]:
         return {"error": "Swap token mismatch"}, 409
-    if swap_state.get("phase") in {"homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"}:
+    if swap_state.get("phase") in _FILAMENT_SWAP_RUNNING_PHASES:
         return {"error": "Swap stage is still running; wait for it to finish first"}, 409
     printer_index = _service_printer_index(swap_state.get("printer_index", printer_index))
 
@@ -4186,14 +4552,20 @@ def app_api_filament_service_swap_cancel():
     provided_token = payload.get("token")
     if provided_token and provided_token != swap_state["token"]:
         return {"error": "Swap token mismatch"}, 409
-    if swap_state.get("phase") in {"homing", "heating_unload", "priming_unload", "unloading", "heating_load", "loading"}:
-        return {"error": "Cannot cancel while an automatic swap stage is running"}, 409
+    printer_index = _service_printer_index(swap_state.get("printer_index", printer_index))
     cancelled_swap = _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
+    try:
+        with borrow_mqtt(printer_index) as mqtt:
+            if mqtt:
+                mqtt.send_gcode("M104 S0")
+    except Exception as exc:
+        log.warning("Filament swap cancel: could not send nozzle cooldown: %s", exc)
 
     return {
         "status": "ok",
         "message": "Filament swap cancelled.",
         "cancelled_swap": cancelled_swap,
+        "gcode": "M104 S0",
         "pending": False,
         "swap": None,
     }

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4617,6 +4617,7 @@ _PROTECTED_GET_PATHS = {
     "/api/debug/logs",
     "/api/debug/services",
     "/api/camera/frame",
+    "/api/camera/stream",
     "/api/snapshot",
     # Sensitive credential exposure: HA MQTT password, Apprise URLs/keys
     "/api/settings/mqtt",

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1769,6 +1769,7 @@ def pppp_state(sock):
     log.info("Starting PPPP state websocket handler for printer_index=%s", printer_index)
 
     last_status = None
+    last_source = None
     last_keepalive = 0.0
     pppp_was_connected = False  # True once we see "connected"; resets on dormant
     mqtt_was_stale = False      # tracks previous stale state to detect recovery
@@ -1776,6 +1777,7 @@ def pppp_state(sock):
     # Scheduling constants
     PROBE_INTERVAL = 60.0    # back-off interval after MAX_RETRIES failures
     RETRY_INTERVAL = 15.0    # interval between retries after a failure
+    PROBE_SUCCESS_FRESH_SEC = 5.0  # only trust cached probe success briefly
     MQTT_STALE_AFTER = 30.0  # MQTT considered stale after 30s silence
     MAX_RETRIES = 2          # retries after first failure before switching to PROBE_INTERVAL
 
@@ -1795,9 +1797,11 @@ def pppp_state(sock):
             # Passive read — no ref-count increment, never starts the service.
             probe = _get_pppp_probe_state(printer_index)
             pppp = get_pppp_service(printer_index)
+            current_source = "none"
 
             if pppp is not None and bool(getattr(pppp, "connected", False)):
                 current_status = "connected"
+                current_source = "service"
                 pppp_was_connected = True
                 with app.pppp_probe_lock:
                     probe["result"] = None
@@ -1828,34 +1832,55 @@ def pppp_state(sock):
                 # Also probe when PPPP was recently connected but service stopped
                 # (e.g. last video client disconnected) so the badge refreshes.
                 pppp_went_dormant = pppp_was_connected and probe_result is None
+                probe_success_fresh = (
+                    probe_result is True
+                    and last_probe_time > 0
+                    and (now - last_probe_time) <= PROBE_SUCCESS_FRESH_SEC
+                )
+                stale_probe_success = probe_result is True and not probe_success_fresh
 
                 should_probe = (
-                    (mqtt_stale or mqtt_recovered or probe_result is False or pppp_went_dormant)
+                    (
+                        mqtt_stale
+                        or mqtt_recovered
+                        or probe_result is False
+                        or pppp_went_dormant
+                        or stale_probe_success
+                    )
                     and (now - last_probe_time) > next_interval
                 )
                 if should_probe:
                     reason = ("PPPP service stopped" if pppp_went_dormant
                               else "MQTT recovered" if mqtt_recovered
                               else "MQTT stale" if mqtt_stale
+                              else "cached probe stale" if stale_probe_success
                               else "retry after fail")
                     _maybe_start_pppp_probe(reason, printer_index=printer_index)
 
-                if probe_result is True:
+                if probe_success_fresh:
                     current_status = "connected"
+                    current_source = "probe"
                 elif probe_result is False:
                     current_status = "disconnected"
+                    current_source = "probe"
                 elif pppp is not None and getattr(pppp, "wanted", False) and pppp_was_connected:
                     # Service is still wanted but lost its PPPP connection.
                     current_status = "disconnected"
+                    current_source = "service"
                 else:
                     # Service not running or connecting for the first time → dormant.
                     current_status = "dormant"
                     if pppp is None or not getattr(pppp, "wanted", False):
                         pppp_was_connected = False
 
-            if current_status != last_status or (current_status == "connected" and now - last_keepalive >= 10.0):
-                sock.send(json.dumps({"status": current_status}))
+            if (
+                current_status != last_status
+                or current_source != last_source
+                or (current_status == "connected" and now - last_keepalive >= 10.0)
+            ):
+                sock.send(json.dumps({"status": current_status, "source": current_source}))
                 last_status = current_status
+                last_source = current_source
                 if current_status == "connected":
                     last_keepalive = now
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -2008,14 +2008,23 @@ def app_root():
     config = app.config["config"]
     with config.open() as cfg:
         printers_list = []
+        active_printer_index = _service_printer_index(app.config.get("printer_index", 0))
         if cfg:
             anker_config = str(web.config.config_show(cfg))
             config_existing_email = cfg.account.email if cfg.account else ""
-            printer = cfg.printers[app.config["printer_index"]]
+            printers = getattr(cfg, "printers", []) or []
+            if printers and not (0 <= active_printer_index < len(printers)):
+                active_printer_index = 0
+            printer = printers[active_printer_index] if printers else None
+            if not printers:
+                anker_config = (
+                    "No printers are configured for this account. "
+                    "Import from eufyMake Studio or log in again from Setup."
+                )
             upload_rate_mbps, upload_rate_source = cli.util.resolve_upload_rate_mbps_with_source(cfg)
             upload_rate_config = getattr(cfg, "upload_rate_mbps", None)
             country = cfg.account.country if cfg.account else ""
-            for i, p in enumerate(cfg.printers):
+            for i, p in enumerate(printers):
                 printers_list.append({
                     "index": i,
                     "name": p.name,
@@ -2032,8 +2041,8 @@ def app_root():
             upload_rate_source = None
             country = ""
 
-        active_camera = _resolve_camera_settings(cfg, printer_index=app.config.get("printer_index", 0)) if cfg else _resolve_camera_settings(None)
-        printer_video_supported = bool(app.config.get("video_supported", False))
+        active_camera = _resolve_camera_settings(cfg, printer_index=active_printer_index) if cfg else _resolve_camera_settings(None)
+        printer_video_supported = bool(app.config.get("video_supported", False) and printer is not None)
         show_camera_ffmpeg_warning = bool(
             printer_video_supported
             or (active_camera.get("external") or {}).get("configured")
@@ -2049,13 +2058,13 @@ def app_root():
             "index.html",
             request_host=request_host,
             request_port=request_port,
-            configure=app.config["login"],
+            configure=bool(app.config["login"] and printer is not None),
             login_file_path=web.platform.login_path(web.platform.current_platform()),
             anker_config=anker_config,
             config_existing_email=config_existing_email,
             country_codes=json.dumps(cli.countrycodes.country_codes),
             current_country=country,
-            video_supported=app.config.get("video_supported", False),
+            video_supported=printer_video_supported,
             printer_video_supported=printer_video_supported,
             camera_features_available=bool(active_camera.get("feature_available")),
             active_camera=active_camera,
@@ -2070,7 +2079,7 @@ def app_root():
             video_profiles=web.service.video.VIDEO_PROFILES,
             video_profile_default=web.service.video.VIDEO_PROFILE_DEFAULT_ID,
             printers=printers_list,
-            active_printer_index=app.config["printer_index"],
+            active_printer_index=active_printer_index,
             printer_index_locked=app.config.get("printer_index_locked", False),
             unsupported_device=app.config.get("unsupported_device", False),
             ankerctl_root=os.path.realpath(ROOT_DIR),

--- a/web/camera.py
+++ b/web/camera.py
@@ -1,6 +1,8 @@
 import os
+import queue
 import subprocess
 import tempfile
+import threading
 from urllib.parse import quote
 
 import cli.model
@@ -12,6 +14,9 @@ DEFAULT_EXTERNAL_REFRESH_SEC = 3
 PRINTERS_WITHOUT_CAMERA = {"V8110"}
 RTSP_LOW_LATENCY_INPUT_ARGS = ["-fflags", "nobuffer", "-probesize", "32768", "-analyzeduration", "0"]
 _ALLOWED_CAMERA_URL_SCHEMES = {"http", "https", "rtsp", "rtmp"}
+_MJPEG_STALE_READ_TIMEOUT_SEC = 10.0
+_MJPEG_READER_QUEUE_SIZE = 4
+_MJPEG_READ_DONE = object()
 
 
 class CameraCaptureError(RuntimeError):
@@ -307,14 +312,53 @@ def open_external_mjpeg_stream(ffmpeg_path, input_url, *, scale=None):
         raise CameraCaptureError(f"External camera stream could not start ffmpeg: {exc}") from exc
 
 
-def iter_mjpeg_frames(proc, *, chunk_size=8192, max_buffer=4 * 1024 * 1024):
+def iter_mjpeg_frames(proc, *, chunk_size=8192, max_buffer=4 * 1024 * 1024, stale_timeout=_MJPEG_STALE_READ_TIMEOUT_SEC):
     stdout = getattr(proc, "stdout", None)
     if stdout is None:
         return
 
+    chunks = queue.Queue(maxsize=_MJPEG_READER_QUEUE_SIZE)
+
+    def _reader():
+        try:
+            while True:
+                chunk = stdout.read(chunk_size)
+                while True:
+                    try:
+                        chunks.put(chunk, timeout=0.5)
+                        break
+                    except queue.Full:
+                        if getattr(proc, "poll", lambda: None)() is not None:
+                            return
+                if not chunk:
+                    break
+        except Exception as exc:
+            try:
+                chunks.put(exc, timeout=0.5)
+            except queue.Full:
+                pass
+        finally:
+            try:
+                chunks.put(_MJPEG_READ_DONE, timeout=0.5)
+            except queue.Full:
+                pass
+
+    threading.Thread(target=_reader, daemon=True, name="external-mjpeg-reader").start()
+
     buffer = bytearray()
     while True:
-        chunk = stdout.read(chunk_size)
+        try:
+            read_timeout = max(0.001, float(stale_timeout))
+        except (TypeError, ValueError):
+            read_timeout = _MJPEG_STALE_READ_TIMEOUT_SEC
+        try:
+            chunk = chunks.get(timeout=read_timeout)
+        except queue.Empty:
+            break
+        if chunk is _MJPEG_READ_DONE:
+            break
+        if isinstance(chunk, Exception):
+            break
         if not chunk:
             break
         buffer.extend(chunk)

--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -4,13 +4,15 @@ import contextlib
 import time
 
 from enum import Enum
-from threading import Thread, Event
+from threading import Thread, Event, current_thread
 from datetime import datetime, timedelta
 import queue
 from queue import Queue
 
 _START_FAILURE_REPEAT_NOTICE_SECONDS = 10.0
 _START_FAILURE_REPEAT_NOTICE_COUNT = 5
+_REPLACE_SERVICE_STOP_TIMEOUT_SECONDS = 5.0
+_REPLACE_SERVICE_JOIN_TIMEOUT_SECONDS = 1.0
 
 
 class Holdoff:
@@ -285,7 +287,11 @@ class Service(Thread):
 
             self.idle(timeout=0.4)
 
-    def await_stopped(self):
+    def await_stopped(self, timeout=None):
+        deadline = None
+        if timeout is not None:
+            deadline = time.monotonic() + max(0.0, float(timeout))
+
         while True:
             if self.wanted:
                 log.warning(f"{self.name}: Service started while waiting for it to stop")
@@ -295,7 +301,15 @@ class Service(Thread):
                 log.debug(f"{self.name}: Stopped")
                 return True
 
-            self.idle(timeout=0.4)
+            wait_timeout = 0.4
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    log.warning(f"{self.name}: Timed out waiting for service to stop")
+                    return False
+                wait_timeout = min(wait_timeout, remaining)
+
+            self.idle(timeout=wait_timeout)
 
 
 class ServiceManager:
@@ -381,10 +395,20 @@ class ServiceManager:
             raise KeyError(f"Trying to replace unknown service {name!r}")
 
         old = self.svcs[name]
+        stopped = old.state == RunState.Stopped
+        replacing_current_thread = old is current_thread()
         try:
-            old.wanted = False
+            old.stop()
         except Exception:
-            pass
+            try:
+                old.wanted = False
+            except Exception:
+                pass
+        else:
+            try:
+                old.wanted = False
+            except Exception:
+                pass
         try:
             if hasattr(old, "_event"):
                 old._event.set()
@@ -395,9 +419,36 @@ class ServiceManager:
                 old._force_close_api()
         except Exception:
             pass
+
+        if not stopped and replacing_current_thread:
+            log.warning("%s: Replacement requested from the old service thread; skipping stop wait", name)
+        elif not stopped:
+            try:
+                stopped = old.await_stopped(timeout=_REPLACE_SERVICE_STOP_TIMEOUT_SECONDS)
+            except Exception as exc:
+                stopped = False
+                log.warning("%s: Failed waiting for old service %r to stop before replacement: %s", name, old, exc)
+
+        if not stopped:
+            log.warning(
+                "%s: Replacing service before old worker fully stopped after %.1fs",
+                name,
+                _REPLACE_SERVICE_STOP_TIMEOUT_SECONDS,
+            )
+
         try:
             old.running = False
         except Exception:
+            pass
+        try:
+            if hasattr(old, "_event"):
+                old._event.set()
+        except Exception:
+            pass
+        try:
+            if hasattr(old, "join") and not replacing_current_thread:
+                old.join(timeout=_REPLACE_SERVICE_JOIN_TIMEOUT_SECONDS)
+        except RuntimeError:
             pass
 
         self.svcs[name] = svc

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -147,6 +147,7 @@ class MqttQueue(Service):
         self._last_message_time = 0.0
         self._nozzle_temp = None
         self._nozzle_temp_target = None
+        self._nozzle_temp_updated_at = 0.0
         self._bed_temp = None
         self._bed_temp_target = None
         self._z_offset_steps = None
@@ -401,6 +402,10 @@ class MqttQueue(Service):
     @property
     def nozzle_temp(self):
         return self._nozzle_temp
+
+    @property
+    def nozzle_temp_updated_at(self):
+        return getattr(self, "_nozzle_temp_updated_at", 0.0)
 
     @property
     def nozzle_temp_target(self):
@@ -1159,6 +1164,7 @@ class MqttQueue(Service):
             if current is not None:
                 # Temps may come in 1/100th degree units
                 self._nozzle_temp = self._normalize_temp(current)
+                self._nozzle_temp_updated_at = time.time()
                 ha_updates["nozzle_temp"] = self._nozzle_temp
             if target is not None:
                 self._nozzle_temp_target = self._normalize_temp(target)

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -1259,7 +1259,14 @@ class TimelapseService:
             while len(videos) > self._max_videos:
                 oldest = videos.pop(0)
                 os.remove(os.path.join(self._captures_dir, oldest))
-                log.info(f"Timelapse: pruned old video {oldest}")
+                removed_collections = self._delete_snapshot_collections_for_video(oldest)
+                if removed_collections:
+                    log.info(
+                        f"Timelapse: pruned old video {oldest} and snapshot collection(s) "
+                        f"{', '.join(removed_collections)}"
+                    )
+                else:
+                    log.info(f"Timelapse: pruned old video {oldest}")
         except OSError as err:
             log.warning(f"Timelapse: prune failed: {err}")
 
@@ -1446,6 +1453,8 @@ class TimelapseService:
                 if not os.path.isdir(dir_path):
                     continue
                 meta = self._read_meta(dir_path) or {}
+                if not self._media_name_belongs_to_this_printer(name, meta):
+                    continue
                 meta_video = self._safe_path_component(meta.get("video_filename"))
                 if name == safe_stem or meta_video == safe_video:
                     real_path = os.path.realpath(dir_path)
@@ -1457,15 +1466,19 @@ class TimelapseService:
             return []
         return matches
 
+    def _delete_snapshot_collections_for_video(self, filename):
+        removed_collections = []
+        for collection_dir in self._snapshot_collection_dirs_for_video(filename):
+            shutil.rmtree(collection_dir, ignore_errors=True)
+            removed_collections.append(os.path.basename(collection_dir))
+        return removed_collections
+
     def delete_video(self, filename):
         """Delete a timelapse video."""
         path = self.get_video_path(filename)
         if path:
             os.remove(path)
-            removed_collections = []
-            for collection_dir in self._snapshot_collection_dirs_for_video(filename):
-                shutil.rmtree(collection_dir, ignore_errors=True)
-                removed_collections.append(os.path.basename(collection_dir))
+            removed_collections = self._delete_snapshot_collections_for_video(filename)
             if removed_collections:
                 log.info(
                     f"Timelapse: deleted {filename} and snapshot collection(s) "

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -48,6 +48,7 @@ class TimelapseService:
         self._printer_index = 0 if printer_index is None else int(printer_index)
         default_captures = os.path.join(str(config_manager.config_root), "captures")
         self._captures_dir = captures_dir or os.getenv("TIMELAPSE_CAPTURES_DIR", default_captures)
+        self._printer_scope = self._resolve_printer_scope()
         os.makedirs(self._captures_dir, exist_ok=True)
 
         self._lock = threading.Lock()
@@ -86,6 +87,30 @@ class TimelapseService:
 
         self.reload_config()
         self._scan_in_progress_captures()
+
+    @staticmethod
+    def _safe_scope_component(value):
+        value = str(value or "").strip()
+        safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in value)
+        return safe.strip("._") or None
+
+    def _resolve_printer_scope(self):
+        identifier = None
+        try:
+            if hasattr(self._config_manager, "open"):
+                with self._config_manager.open() as cfg:
+                    printers = getattr(cfg, "printers", None) or []
+                    if 0 <= self._printer_index < len(printers):
+                        printer = printers[self._printer_index]
+                        for attr in ("sn", "id", "p2p_duid", "name"):
+                            candidate = getattr(printer, attr, None)
+                            if candidate:
+                                identifier = candidate
+                                break
+        except Exception as err:
+            log.debug(f"Timelapse: could not resolve printer scope: {err}")
+        safe = self._safe_scope_component(identifier) or f"index_{self._printer_index}"
+        return f"printer_{safe}"
 
     def reload_config(self, config=None):
         """Update configuration from Config object or ConfigManager."""
@@ -557,7 +582,10 @@ class TimelapseService:
                 self._current_filename = filename
                 ts = datetime.now().strftime("%Y%m%d_%H%M%S")
                 safe_name = "".join(c if c.isalnum() or c in "-_." else "_" for c in filename)
-                self._current_dir = os.path.join(self._in_progress_base(), f"{safe_name}_{ts}")
+                self._current_dir = os.path.join(
+                    self._in_progress_base(),
+                    f"{self._printer_scope}_{safe_name}_{ts}",
+                )
                 os.makedirs(self._current_dir, exist_ok=True)
                 self._write_meta(self._current_dir, filename, 0)
                 self._frame_count = 0
@@ -833,7 +861,12 @@ class TimelapseService:
         """Write a small JSON sidecar so state survives container restarts."""
         try:
             payload = self._read_meta(dir_path) or {}
-            payload.update({"filename": filename, "frame_count": frame_count})
+            payload.update({
+                "filename": filename,
+                "frame_count": frame_count,
+                "printer_index": self._printer_index,
+                "printer_scope": self._printer_scope,
+            })
             for key, value in extra.items():
                 if value is not None:
                     payload[key] = value
@@ -850,16 +883,70 @@ class TimelapseService:
         except (OSError, ValueError):
             return None
 
+    def _capture_dir_belongs_to_this_printer(self, dir_name, meta):
+        """Return True when an in-progress capture belongs to this printer.
+
+        Legacy capture directories created before printer-scoped metadata are
+        only recovered by printer 0 because their owner cannot be known safely.
+        """
+        if isinstance(meta, dict):
+            meta_scope = meta.get("printer_scope")
+            if meta_scope:
+                return meta_scope == self._printer_scope
+            if "printer_index" in meta:
+                try:
+                    return int(meta.get("printer_index")) == self._printer_index
+                except (TypeError, ValueError):
+                    return False
+
+        if dir_name.startswith(f"{self._printer_scope}_"):
+            return True
+        if dir_name.startswith("printer_"):
+            return False
+        return self._printer_index == 0
+
+    def _media_name_belongs_to_this_printer(self, name, meta=None):
+        """Return True when an archived video/snapshot collection is ours.
+
+        Unscoped legacy media is exposed only through printer 0 because older
+        files have no reliable owner metadata.
+        """
+        if isinstance(meta, dict):
+            meta_scope = meta.get("printer_scope")
+            if meta_scope:
+                return meta_scope == self._printer_scope
+            if "printer_index" in meta:
+                try:
+                    return int(meta.get("printer_index")) == self._printer_index
+                except (TypeError, ValueError):
+                    return False
+        if str(name or "").startswith(f"{self._printer_scope}_"):
+            return True
+        if str(name or "").startswith("printer_"):
+            return False
+        return self._printer_index == 0
+
     def _resolve_snapshot_collection_dir(self, collection_id):
         safe_collection = self._safe_path_component(collection_id)
         if not safe_collection:
             return None, None
+        with self._lock:
+            for dir_path in (self._current_dir, self._resume_dir):
+                if (
+                    dir_path
+                    and os.path.isdir(dir_path)
+                    and os.path.basename(dir_path) == safe_collection
+                ):
+                    return dir_path, True
         for root, read_only in (
             (self._snapshot_archive_base(), False),
             (self._in_progress_base(), True),
         ):
             path = os.path.join(root, safe_collection)
             if os.path.isdir(path):
+                meta = self._read_meta(path)
+                if not self._media_name_belongs_to_this_printer(safe_collection, meta):
+                    continue
                 return path, read_only
         return None, None
 
@@ -917,7 +1004,7 @@ class TimelapseService:
             collection_id = os.path.splitext(os.path.basename(video_filename))[0]
         else:
             safe_name = "".join(c if c.isalnum() or c in "-_." else "_" for c in (filename or "print"))
-            collection_id = f"{safe_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            collection_id = f"{self._printer_scope}_{safe_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
         archive_dir = os.path.join(self._snapshot_archive_base(), collection_id)
         try:
@@ -952,6 +1039,10 @@ class TimelapseService:
                     os.path.join(base, name)
                     for name in os.listdir(base)
                     if os.path.isdir(os.path.join(base, name))
+                    and self._media_name_belongs_to_this_printer(
+                        name,
+                        self._read_meta(os.path.join(base, name)),
+                    )
                 ),
                 key=os.path.getmtime,
             )
@@ -969,7 +1060,7 @@ class TimelapseService:
 
         taken_at = taken_at or datetime.now()
         safe_timestamp = taken_at.strftime("%Y%m%d_%H%M%S")
-        collection_id = f"manual_snapshot_{taken_at.strftime('%Y%m%d_%H%M%S_%f')}"
+        collection_id = f"{self._printer_scope}_manual_snapshot_{taken_at.strftime('%Y%m%d_%H%M%S_%f')}"
         archive_dir = os.path.join(self._snapshot_archive_base(), collection_id)
         frame_name = f"ankerctl_snapshot_{safe_timestamp}.jpg"
         archive_path = os.path.join(archive_dir, frame_name)
@@ -1036,12 +1127,14 @@ class TimelapseService:
             dir_path = os.path.join(base, name)
             if not os.path.isdir(dir_path):
                 continue
+            meta = self._read_meta(dir_path)
+            if not self._capture_dir_belongs_to_this_printer(name, meta):
+                continue
             frames = [f for f in os.listdir(dir_path) if f.startswith("frame_") and f.endswith(".jpg")]
             frame_count = len(frames)
             if frame_count == 0:
                 shutil.rmtree(dir_path, ignore_errors=True)
                 continue
-            meta = self._read_meta(dir_path)
             filename = (meta or {}).get("filename", "unknown")
             age = now - os.path.getmtime(dir_path)
             candidates.append((age, dir_path, filename, frame_count))
@@ -1090,7 +1183,7 @@ class TimelapseService:
 
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         safe_name = "".join(c if c.isalnum() or c in "-_." else "_" for c in (filename or "print"))
-        output_name = f"{safe_name}_{ts}{suffix}.mp4"
+        output_name = f"{self._printer_scope}_{safe_name}_{ts}{suffix}.mp4"
         output_path = os.path.join(self._captures_dir, output_name)
 
         # Calculate fps to make ~30s videos, min 1fps max 30fps
@@ -1156,7 +1249,11 @@ class TimelapseService:
             return
         try:
             videos = sorted(
-                [f for f in os.listdir(self._captures_dir) if f.endswith(".mp4")],
+                [
+                    f for f in os.listdir(self._captures_dir)
+                    if f.endswith(".mp4")
+                    and self._media_name_belongs_to_this_printer(f)
+                ],
                 key=lambda f: os.path.getmtime(os.path.join(self._captures_dir, f)),
             )
             while len(videos) > self._max_videos:
@@ -1172,6 +1269,8 @@ class TimelapseService:
         try:
             for f in sorted(os.listdir(self._captures_dir), reverse=True):
                 if not f.endswith(".mp4"):
+                    continue
+                if not self._media_name_belongs_to_this_printer(f):
                     continue
                 path = os.path.join(self._captures_dir, f)
                 stat = os.stat(path)
@@ -1228,6 +1327,9 @@ class TimelapseService:
             collection_id = os.path.basename(dir_path)
             if collection_id in seen:
                 continue
+            meta = self._read_meta(dir_path) or {}
+            if not self._media_name_belongs_to_this_printer(collection_id, meta):
+                continue
             record = self._snapshot_collection_record(dir_path)
             if record:
                 collections.append(record)
@@ -1238,7 +1340,11 @@ class TimelapseService:
     def get_video_path(self, filename):
         """Return full path to a video file, or None if not found."""
         path = os.path.join(self._captures_dir, filename)
-        if os.path.isfile(path) and filename.endswith(".mp4"):
+        if (
+            os.path.isfile(path)
+            and filename.endswith(".mp4")
+            and self._media_name_belongs_to_this_printer(filename)
+        ):
             return path
         return None
 

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -47,7 +47,11 @@ class TimelapseService:
         self._config_manager = config_manager
         self._printer_index = 0 if printer_index is None else int(printer_index)
         default_captures = os.path.join(str(config_manager.config_root), "captures")
-        self._captures_dir = captures_dir or os.getenv("TIMELAPSE_CAPTURES_DIR", default_captures)
+        self._captures_dir_explicit = captures_dir is not None
+        initial_captures_dir = captures_dir or os.getenv("TIMELAPSE_CAPTURES_DIR", default_captures) or default_captures
+        self._captures_dir = self._normalize_captures_dir(
+            initial_captures_dir
+        )
         self._printer_scope = self._resolve_printer_scope()
         os.makedirs(self._captures_dir, exist_ok=True)
 
@@ -87,6 +91,27 @@ class TimelapseService:
 
         self.reload_config()
         self._scan_in_progress_captures()
+
+    @staticmethod
+    def _normalize_captures_dir(path):
+        raw_path = str(path or "").strip()
+        if not raw_path:
+            return None
+        return os.path.abspath(os.path.expanduser(raw_path))
+
+    def _apply_captures_dir(self, path):
+        target = self._normalize_captures_dir(path)
+        if not target:
+            return False
+        try:
+            os.makedirs(target, exist_ok=True)
+        except OSError as err:
+            log.warning(f"Timelapse: could not use output directory {target!r}: {err}")
+            return False
+        if target != self._captures_dir:
+            log.info(f"Timelapse: output directory set to {target}")
+        self._captures_dir = target
+        return True
 
     @staticmethod
     def _safe_scope_component(value):
@@ -131,6 +156,8 @@ class TimelapseService:
         self._interval = max(1, int(cfg.get("interval", _DEFAULT_INTERVAL_SEC)))
         self._max_videos = int(cfg.get("max_videos", _DEFAULT_MAX_VIDEOS))
         self._save_persistent = cfg.get("save_persistent", True)
+        if not self._captures_dir_explicit:
+            self._apply_captures_dir(cfg.get("output_dir"))
         raw_light = cfg.get("light", None)
         if raw_light == "snapshot":
             self._light_mode = "snapshot"


### PR DESCRIPTION
High: External camera live stream appears to bypass API-key GET protection.
/api/camera/frame and /api/snapshot are protected, but /api/camera/stream is not listed in _PROTECTED_GET_PATHS. With API-key auth enabled, this likely allows unauthenticated access to the MJPEG external camera stream. See web/init.py:3448 and web/init.py:4613.

High: Timelapse recovery/storage is still risky for multiple printers.
Production TimelapseService instances share the same default capture directory, and startup recovery scans all in-progress capture folders without printer scoping. That means one printer service could resume/finalize another printer’s orphaned capture after restart. See web/service/timelapse.py:46, web/service/mqtt.py:113, and web/service/timelapse.py:1024.

Medium: Automatic timelapse pruning can orphan snapshot collections.
Manual video deletion removes related snapshots, but retention pruning deletes old .mp4 files without removing their matching snapshot folders. This could bring back “video gone but snapshots remain” over time. See web/service/timelapse.py:1153 and web/service/timelapse.py:1354.

Medium: Filament swap state is global, not per-printer.
The swap state stores printer_index, but the active state slot is one global app.filament_swap_state. A swap on Thing 1 can block Thing 2, and polling from another printer can see the wrong operation unless the UI filters perfectly. See web/init.py:291 and web/init.py:3927.

Medium: Service replacement can race with old PPPP/video workers.
replace_service swaps the service reference immediately after requesting the old service stop; it does not wait for the old worker to fully stop. This can create confusing recovery states if PPPP/video is already unstable. See web/lib/service.py:379.

Medium: Homepage can crash if config exists but has no printers.
app_root assumes cfg.printers[printer_index] exists whenever config exists. A valid login/import with zero discovered printers could cause an IndexError instead of a friendly setup state. See web/init.py:1936.

Medium: Timelapse output_dir setting appears ignored after service construction.
Settings preserve output_dir, and README documents the env/config behavior, but TimelapseService.reload_config() does not apply cfg["output_dir"]. The env var at startup works; changing the saved setting likely won’t. See cli/model.py:48, web/timelapse_settings.py:48, and web/service/timelapse.py:104.

Low/Medium: External MJPEG stream can block without a stale-read timeout.
The ffmpeg reader uses blocking stdout.read(). If ffmpeg stays alive but stops producing bytes, the Flask stream may hang until teardown. This is worth hardening for bad RTSP/Wi-Fi drops. See web/camera.py:280 and web/camera.py:310.

Low/Medium: PPPP/CTRL badges can stay green briefly from cached probe state.
The PPPP websocket can report connected from cached probe success until stale/retry logic catches up. This matches the “printer off but PPPP/CTRL still green” behavior, though it may only be a delay. See web/init.py:1703 and static/ankersrv.js:1852.

Low: Security tests include placeholder pass tests.
Several security tests currently pass without assertions, which weakens confidence around protected endpoints and would not catch the external stream auth gap. See tests/test_security_validation.py:250.

Ran through and fixed a bumch of random bugs and issues.