### PR TITLE
Add Home Assistant Supervisor addon (closes #65)

### DIFF
--- a/hassio-addon/Dockerfile
+++ b/hassio-addon/Dockerfile
@@ -1,0 +1,9 @@
+ARG BUILD_FROM=ghcr.io/django1982/ankermake-m5-protocol:latest
+FROM ${BUILD_FROM}
+
+# HA Supervisor passes addon options via /data/options.json.
+# run.sh reads them, exports env vars, then launches the app.
+COPY run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+ENTRYPOINT ["/app/run.sh"]

--- a/hassio-addon/README.md
+++ b/hassio-addon/README.md
@@ -1,0 +1,56 @@
+# ankerctl Home Assistant Addon
+
+ankerctl is a web UI and CLI for monitoring and controlling AnkerMake M5 3D printers over your local network — without relying on the proprietary AnkerMake cloud app. This addon runs the ankerctl web interface as a Home Assistant Supervisor addon, giving you print control, live camera, timelapse, print history, and optional Home Assistant MQTT Discovery integration, all from your HA dashboard.
+
+## Prerequisites
+
+- An AnkerMake M5 printer on the same LAN as your Home Assistant host.
+- Either a `login.json` exported from the AnkerMake slicer, or your AnkerMake account email and password (used once to generate a local config — no ongoing cloud dependency).
+- Home Assistant OS or Supervised installation (Supervisor required).
+
+## Installation
+
+1. In Home Assistant, go to **Settings → Add-ons → Add-on Store**.
+2. Click the three-dot menu (top right) and select **Repositories**.
+3. Add the repository URL: `https://github.com/Django1982/ankermake-m5-protocol`
+4. Click **Add**, then close the dialog. The **ankerctl** addon will appear in the store.
+5. Click **ankerctl**, then **Install**.
+6. Configure the addon options (see table below). At minimum, leave defaults — you can configure credentials after first start via the web UI.
+7. Click **Start**.
+8. Open the web UI on port **4470** (click **OPEN WEB UI** in the addon panel).
+9. On first run, upload your `login.json` or log in with email/password via the Setup tab.
+
+## Configuration Options
+
+| Option | Description | Default |
+|---|---|---|
+| `flask_host` | IP address the web server binds to | `0.0.0.0` |
+| `flask_port` | TCP port for the web UI | `4470` |
+| `flask_secret_key` | Session cookie secret. Set a fixed value if you want sessions to survive restarts. Auto-generated if blank. | _(blank)_ |
+| `ankerctl_api_key` | API key required for all write operations (GCode, print control, uploads). Leave blank to disable auth. | _(blank)_ |
+| `printer_index` | Zero-based index of the printer to control when multiple are configured. | `0` |
+| `upload_rate_mbps` | GCode upload speed to the printer in Mbit/s. Choices: 5, 10, 25, 50, 100. | `10` |
+| `timelapse_enabled` | Enable automatic timelapse capture during prints (requires ffmpeg, included in image). | `false` |
+| `timelapse_interval_sec` | Seconds between timelapse snapshots. | `30` |
+| `apprise_enabled` | Enable Apprise push notifications (print started/finished/failed, progress). | `false` |
+| `apprise_server_url` | URL of your Apprise API server (e.g. `http://192.168.1.10:8000`). | _(blank)_ |
+| `apprise_key` | Apprise notification key. | _(blank)_ |
+| `ha_mqtt_enabled` | Enable Home Assistant MQTT Discovery — publishes printer sensors, binary sensors, and light control to your HA MQTT broker. | `false` |
+| `ha_mqtt_host` | Hostname or IP of your HA MQTT broker. | `localhost` |
+| `ha_mqtt_port` | Port of your HA MQTT broker. | `1883` |
+| `ha_mqtt_user` | MQTT broker username (optional). | _(blank)_ |
+| `ha_mqtt_password` | MQTT broker password (optional, stored as HA secret). | _(blank)_ |
+
+All persistent data (printer config, print history, timelapse videos, logs) is stored in the addon's `/data` volume and survives addon restarts and updates.
+
+## Network Note
+
+This addon runs with `host_network: true`. This is not optional — the PPPP protocol used for LAN communication with the printer uses asymmetric UDP (the printer replies to a different port than the one it receives on). Docker bridge networking breaks this handshake. Host networking is the only reliable solution, and is the same requirement as the standalone Docker deployment.
+
+## HA Sidebar Access
+
+To add ankerctl to your Home Assistant sidebar, go to **Settings → Dashboard** and add an **iframe_panel** card pointing to `http://<your-ha-ip>:4470`. Alternatively, use the **Webpage** dashboard card type.
+
+## Ingress
+
+Ingress (the built-in HA reverse proxy that serves addons under the `/api/hassio_ingress/` path) is not currently supported. Use direct port access on `4470` instead.

--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -1,0 +1,68 @@
+name: ankerctl
+version: "1.0.1"
+slug: ankerctl
+description: Web UI and control interface for AnkerMake M5 3D printers
+url: https://github.com/Django1982/ankermake-m5-protocol
+arch:
+  - aarch64
+  - amd64
+  - armv7
+
+# PPPP uses asymmetric UDP — bridge networking breaks it
+host_network: true
+
+# Pull the pre-built multi-arch image from GHCR
+image: ghcr.io/django1982/ankermake-m5-protocol
+
+# Persistent config storage (maps to /data inside the addon container)
+map:
+  - data
+
+# Port declaration enables the "OPEN WEB UI" button in the addon panel
+ports:
+  4470/tcp: 4470
+ports_description:
+  4470/tcp: ankerctl Web UI
+
+# Watchdog — Supervisor auto-restarts the addon if health fails
+watchdog: http://[HOST]:4470/api/health
+
+startup: application
+boot: auto
+
+# User-configurable options exposed in the HA addon UI
+options:
+  flask_host: "0.0.0.0"
+  flask_port: 4470
+  flask_secret_key: ""
+  ankerctl_api_key: ""
+  printer_index: 0
+  upload_rate_mbps: 10
+  timelapse_enabled: false
+  timelapse_interval_sec: 30
+  apprise_enabled: false
+  apprise_server_url: ""
+  apprise_key: ""
+  ha_mqtt_enabled: false
+  ha_mqtt_host: "localhost"
+  ha_mqtt_port: 1883
+  ha_mqtt_user: ""
+  ha_mqtt_password: ""
+
+schema:
+  flask_host: str
+  flask_port: port
+  flask_secret_key: str?
+  ankerctl_api_key: str?
+  printer_index: int
+  upload_rate_mbps: "list(5|10|25|50|100)"
+  timelapse_enabled: bool
+  timelapse_interval_sec: int
+  apprise_enabled: bool
+  apprise_server_url: str?
+  apprise_key: str?
+  ha_mqtt_enabled: bool
+  ha_mqtt_host: str
+  ha_mqtt_port: port
+  ha_mqtt_user: str?
+  ha_mqtt_password: password?

--- a/hassio-addon/run.sh
+++ b/hassio-addon/run.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+set -eu
+
+OPTIONS_FILE="/data/options.json"
+
+# Helper: read a string field from options.json
+# Usage: json_get FIELD DEFAULT_QUOTED
+# DEFAULT_QUOTED must be a valid Python expression (e.g., '"0.0.0.0"' or '4470')
+json_get() {
+    python3 -c "
+import json, sys
+try:
+    data = json.load(open('${OPTIONS_FILE}'))
+except Exception:
+    data = {}
+val = data.get('${1}', ${2})
+if val is None:
+    sys.exit(0)
+print(val)
+" 2>/dev/null || true
+}
+
+# Helper: read a boolean field from options.json, output 'true' or 'false'
+json_bool() {
+    python3 -c "
+import json
+try:
+    data = json.load(open('${OPTIONS_FILE}'))
+except Exception:
+    data = {}
+val = data.get('${1}', False)
+print('true' if val else 'false')
+" 2>/dev/null || echo "false"
+}
+
+# ------------------------------------------------------------------
+# Ensure persistent storage directories exist and are writable
+# ------------------------------------------------------------------
+mkdir -p /data/.config/ankerctl
+mkdir -p /data/captures
+mkdir -p /data/logs
+chown -R ankerctl:ankerctl /data
+
+# ------------------------------------------------------------------
+# Map HA addon options → ankerctl environment variables
+# ------------------------------------------------------------------
+
+# Config path: redirect platformdirs to the Supervisor-managed /data volume
+export HOME=/data
+
+# Server
+export FLASK_HOST="$(json_get flask_host '"0.0.0.0"')"
+export FLASK_PORT="$(json_get flask_port 4470)"
+
+SECRET="$(json_get flask_secret_key '""')"
+if [ -n "$SECRET" ]; then
+    export FLASK_SECRET_KEY="$SECRET"
+fi
+
+# Security
+API_KEY="$(json_get ankerctl_api_key '""')"
+if [ -n "$API_KEY" ]; then
+    export ANKERCTL_API_KEY="$API_KEY"
+fi
+
+# Printer
+export PRINTER_INDEX="$(json_get printer_index 0)"
+
+# Upload
+export UPLOAD_RATE_MBPS="$(json_get upload_rate_mbps 10)"
+
+# Timelapse — captures stored in persistent /data volume
+export TIMELAPSE_ENABLED="$(json_bool timelapse_enabled)"
+export TIMELAPSE_INTERVAL_SEC="$(json_get timelapse_interval_sec 30)"
+export TIMELAPSE_CAPTURES_DIR="/data/captures"
+
+# Logs — persistent and accessible from HA log viewer
+export ANKERCTL_LOG_DIR="/data/logs"
+
+# Apprise notifications
+export APPRISE_ENABLED="$(json_bool apprise_enabled)"
+APPRISE_URL="$(json_get apprise_server_url '""')"
+if [ -n "$APPRISE_URL" ]; then
+    export APPRISE_SERVER_URL="$APPRISE_URL"
+fi
+APPRISE_K="$(json_get apprise_key '""')"
+if [ -n "$APPRISE_K" ]; then
+    export APPRISE_KEY="$APPRISE_K"
+fi
+
+# Home Assistant MQTT Discovery
+export HA_MQTT_ENABLED="$(json_bool ha_mqtt_enabled)"
+export HA_MQTT_HOST="$(json_get ha_mqtt_host '"localhost"')"
+export HA_MQTT_PORT="$(json_get ha_mqtt_port 1883)"
+MQTT_USER="$(json_get ha_mqtt_user '""')"
+if [ -n "$MQTT_USER" ]; then
+    export HA_MQTT_USER="$MQTT_USER"
+fi
+MQTT_PASS="$(json_get ha_mqtt_password '""')"
+if [ -n "$MQTT_PASS" ]; then
+    export HA_MQTT_PASSWORD="$MQTT_PASS"
+fi
+
+# ------------------------------------------------------------------
+# Hand off to the existing entrypoint (handles gosu privilege drop)
+# ------------------------------------------------------------------
+exec /app/entrypoint.sh /app/ankerctl.py webserver run

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: ankerctl
+url: https://github.com/Django1982/ankermake-m5-protocol
+maintainer: Django1982


### PR DESCRIPTION
Adds hassio-addon/ directory with config.yaml, Dockerfile, run.sh, and README.md, plus repository.yaml at the repo root so the project can be added as a custom HA addon repository.

- host_network: true required for PPPP asymmetric UDP
- run.sh maps /data/options.json options to env vars; sets HOME=/data so platformdirs resolves config to the Supervisor-managed /data volume
- watchdog points to /api/health (unauthenticated liveness endpoint)
- No CI changes needed: uses existing multi-arch GHCR manifest