### PR TITLE
Implemented the dedicated printer-camera integration stream and wired…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The `ankerctl` program uses [`libflagship`](documentation/developer-docs/libflag
 - Automatic timelapse capture during prints, including pause, resume, stop, partial-save-on-failure behavior, per-printer camera source selection (`follow`, printer, or external), and MP4 assembly at print end. Requires `ffmpeg`.
 - Dedicated **Snapshots** page for timelapse frames and manual snapshots, including preview, download, and delete actions.
 - Stream the built-in printer camera to your computer, with support for optional external camera feeds and a camera setup page.
+- Optional printer camera integration endpoint that remuxes the built-in camera feed to H.264 / fragmented MP4 with `ffmpeg` for Frigate and other FFmpeg-based consumers.
 - Manual snapshot capture from the Home page, with snapshots saved into the Snapshots gallery.
 - Live ankerctl console viewer on the Home page, with recent history and live updates.
 - Filament status indicators and filament-change awareness in printer status.

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -3238,7 +3238,7 @@ $(function () {
         $("#camera-integration-enabled").prop("checked", !!(camera && camera.integration && camera.integration.enabled));
 
         const integration = camera && camera.integration ? camera.integration : {};
-        const endpointUrl = integration.endpoint_url_with_api_key || integration.endpoint_url || integration.endpoint_path || "";
+        const endpointUrl = integration.endpoint_url || integration.endpoint_path || "";
         $("#camera-integration-endpoint").val(endpointUrl);
 
         const statusEl = $("#camera-integration-status");
@@ -3253,6 +3253,9 @@ $(function () {
                 statusText += " Install ffmpeg to use this stream.";
             } else if (endpointUrl) {
                 statusText += " Use the URL above in Frigate or another FFmpeg-based consumer.";
+            }
+            if (integration.api_key_required) {
+                statusText += " API-key auth is enabled, so add your API key in the consumer manually.";
             }
             statusEl.text(statusText);
         }

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1097,19 +1097,25 @@ $(function () {
         return 0;
     }
 
-    function withActivePrinterQuery(url) {
-        const activePrinterIndex = String(getActivePrinterIndex());
+    function withPrinterQuery(url, printerIndex) {
+        const resolvedPrinterIndex = String(
+            Number.isFinite(Number(printerIndex)) ? Number(printerIndex) : getActivePrinterIndex()
+        );
         try {
             const resolved = new URL(url, window.location.origin);
-            resolved.searchParams.set("printer_index", activePrinterIndex);
+            resolved.searchParams.set("printer_index", resolvedPrinterIndex);
             if (resolved.origin === window.location.origin) {
                 return `${resolved.pathname}${resolved.search}${resolved.hash}`;
             }
             return resolved.toString();
         } catch (_err) {
             const separator = String(url).includes("?") ? "&" : "?";
-            return `${url}${separator}printer_index=${encodeURIComponent(activePrinterIndex)}`;
+            return `${url}${separator}printer_index=${encodeURIComponent(resolvedPrinterIndex)}`;
         }
+    }
+
+    function withActivePrinterQuery(url) {
+        return withPrinterQuery(url, getActivePrinterIndex());
     }
 
     function processPrinterAlertEntries(entries, notifyUser) {
@@ -4006,6 +4012,7 @@ $(function () {
     let historyOffset = 0;
     const HISTORY_LIMIT = 25;
     const selectedHistoryIds = new Set();
+    let historyAllPrinters = false;
 
     function formatDuration(sec) {
         if (!sec) return "-";
@@ -4031,6 +4038,11 @@ $(function () {
             .prop("disabled", count === 0)
             .html(`<i class="bi bi-trash3"></i> Delete Selected${count > 0 ? ` (${count})` : ""}`);
 
+        const clearButton = $("#history-clear");
+        clearButton
+            .html(`<i class="bi bi-trash"></i> ${historyAllPrinters ? "Clear All Printers" : "Clear"}`)
+            .attr("title", historyAllPrinters ? "Clear history across all printers" : "Clear history for the selected printer");
+
         const checkboxes = $(".history-select-checkbox").filter(function () {
             return !$(this).prop("disabled");
         });
@@ -4047,8 +4059,26 @@ $(function () {
         }
     }
 
+    function withHistoryScopeQuery(url, printerIndex = null) {
+        const base = withPrinterQuery(url, printerIndex);
+        if (!historyAllPrinters) {
+            return base;
+        }
+        try {
+            const resolved = new URL(base, window.location.origin);
+            resolved.searchParams.set("all_printers", "1");
+            if (resolved.origin === window.location.origin) {
+                return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+            }
+            return resolved.toString();
+        } catch (_err) {
+            const separator = String(base).includes("?") ? "&" : "?";
+            return `${base}${separator}all_printers=1`;
+        }
+    }
+
     function loadHistory(append) {
-        fetch(withActivePrinterQuery(`/api/history?limit=${HISTORY_LIMIT}&offset=${historyOffset}`))
+        fetch(withHistoryScopeQuery(`/api/history?limit=${HISTORY_LIMIT}&offset=${historyOffset}`))
             .then(r => r.json())
             .then(data => {
                 const tbody = $("#history-tbody");
@@ -4057,7 +4087,8 @@ $(function () {
                     selectedHistoryIds.clear();
                 }
                 if (data.entries.length === 0 && !append) {
-                    tbody.html('<tr><td colspan="6" class="text-center text-muted py-4">No history yet</td></tr>');
+                    const emptyLabel = historyAllPrinters ? "No history yet across all printers" : "No history yet";
+                    tbody.html(`<tr><td colspan="6" class="text-center text-muted py-4">${emptyLabel}</td></tr>`);
                 }
                 data.entries.forEach(e => {
                     const started = e.started_at ? new Date(e.started_at + "Z").toLocaleString() : "-";
@@ -4068,15 +4099,27 @@ $(function () {
                     const checkboxCell = canDelete
                         ? `<input type="checkbox" class="form-check-input history-select-checkbox" data-history-id="${e.id}" ${isChecked ? "checked" : ""} aria-label="Select ${safeFilename}">`
                         : '<input type="checkbox" class="form-check-input" disabled aria-label="Cannot delete in-progress history entry">';
+                    const safePrinterName = escapeHtml(
+                        String(e.printer_name || `Printer ${Number.isFinite(Number(e.printer_index)) ? Number(e.printer_index) + 1 : "?"}`)
+                    );
+                    const printerMeta = historyAllPrinters
+                        ? `<div class="text-muted small">${safePrinterName}</div>`
+                        : "";
+                    const reprintPrinterAttr = Number.isFinite(Number(e.printer_index))
+                        ? ` data-history-printer-index="${Number(e.printer_index)}"`
+                        : "";
                     const actionCell = e.can_reprint
-                        ? `<button class="btn btn-sm btn-outline-primary history-reprint-btn" data-history-id="${e.id}" data-history-name="${safeFilename}">Reprint</button>`
+                        ? `<button class="btn btn-sm btn-outline-primary history-reprint-btn" data-history-id="${e.id}" data-history-name="${safeFilename}"${reprintPrinterAttr}>Reprint</button>`
                         : '<span class="text-muted small">-</span>';
                     const row = `<tr>
                         <td class="text-center align-middle">${checkboxCell}</td>
                         <td class="history-file-cell" title="${safeFilename}">
                             <div class="d-flex align-items-center gap-2">
                                 ${thumbnail}
-                                <div class="text-truncate" style="max-width:200px;">${safeFilename}</div>
+                                <div class="text-truncate" style="max-width:200px;">
+                                    <div>${safeFilename}</div>
+                                    ${printerMeta}
+                                </div>
                             </div>
                         </td>
                         <td>${statusBadge(e.status)}</td>
@@ -4086,7 +4129,8 @@ $(function () {
                     </tr>`;
                     tbody.append(row);
                 });
-                $("#history-count").text(`${Math.min(historyOffset + data.entries.length, data.total)} / ${data.total} entries`);
+                const scopeSuffix = historyAllPrinters ? " across all printers" : "";
+                $("#history-count").text(`${Math.min(historyOffset + data.entries.length, data.total)} / ${data.total} entries${scopeSuffix}`);
                 if (historyOffset + data.entries.length < data.total) {
                     $("#history-load-more").show();
                 } else {
@@ -4107,6 +4151,14 @@ $(function () {
             loadHistory(false);
         });
     }
+
+    $("#history-all-printers").on("change", function () {
+        historyAllPrinters = $(this).prop("checked");
+        selectedHistoryIds.clear();
+        historyOffset = 0;
+        updateHistorySelectionUi();
+        loadHistory(false);
+    });
 
     $("#history-load-more").on("click", function () {
         historyOffset += HISTORY_LIMIT;
@@ -4150,13 +4202,14 @@ $(function () {
             flash_message("Select one or more history entries first.", "warning");
             return;
         }
-        if (!confirm(`Delete ${ids.length} selected history entr${ids.length === 1 ? "y" : "ies"}?`)) {
+        const scopeLabel = historyAllPrinters ? "all printers" : "the selected printer";
+        if (!confirm(`Delete ${ids.length} selected history entr${ids.length === 1 ? "y" : "ies"} from ${scopeLabel}?`)) {
             return;
         }
         const btn = $(this);
         btn.prop("disabled", true);
         try {
-            const resp = await fetch(withActivePrinterQuery("/api/history/delete"), {
+            const resp = await fetch(withHistoryScopeQuery("/api/history/delete"), {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ ids }),
@@ -4178,8 +4231,11 @@ $(function () {
     });
 
     $("#history-clear").on("click", function () {
-        if (!confirm("Clear all print history?")) return;
-        fetch(withActivePrinterQuery("/api/history"), { method: "DELETE" })
+        const message = historyAllPrinters
+            ? "Clear all print history across all printers?"
+            : "Clear all print history for the selected printer?";
+        if (!confirm(message)) return;
+        fetch(withHistoryScopeQuery("/api/history"), { method: "DELETE" })
             .then(() => {
                 selectedHistoryIds.clear();
                 historyOffset = 0;
@@ -4192,6 +4248,8 @@ $(function () {
         const btn = $(this);
         const entryId = btn.attr("data-history-id");
         const entryName = btn.attr("data-history-name") || "selected file";
+        const printerAttr = btn.attr("data-history-printer-index");
+        const targetPrinterIndex = Number.isFinite(Number(printerAttr)) ? Number(printerAttr) : null;
         if (!entryId) {
             return;
         }
@@ -4200,7 +4258,7 @@ $(function () {
         }
         btn.prop("disabled", true);
         try {
-            const resp = await fetch(withActivePrinterQuery(`/api/history/${encodeURIComponent(entryId)}/reprint`), {
+            const resp = await fetch(withHistoryScopeQuery(`/api/history/${encodeURIComponent(entryId)}/reprint`, targetPrinterIndex), {
                 method: "POST",
             });
             const data = await resp.json().catch(() => ({}));

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -3235,6 +3235,27 @@ $(function () {
         $("#camera-external-name").val(camera && camera.external ? camera.external.name || "" : "");
         $("#camera-external-stream-url").val(camera && camera.external ? camera.external.stream_url || "" : "");
         $("#camera-external-snapshot-url").val(camera && camera.external ? camera.external.snapshot_url || "" : "");
+        $("#camera-integration-enabled").prop("checked", !!(camera && camera.integration && camera.integration.enabled));
+
+        const integration = camera && camera.integration ? camera.integration : {};
+        const endpointUrl = integration.endpoint_url_with_api_key || integration.endpoint_url || integration.endpoint_path || "";
+        $("#camera-integration-endpoint").val(endpointUrl);
+
+        const statusEl = $("#camera-integration-status");
+        if (statusEl.length) {
+            let statusText = integration.enabled
+                ? "Integration endpoint is enabled for this printer."
+                : "Integration endpoint is disabled for this printer.";
+            if (integration.stream_format) {
+                statusText += ` ${integration.stream_format}.`;
+            }
+            if (integration.ffmpeg_available === false) {
+                statusText += " Install ffmpeg to use this stream.";
+            } else if (endpointUrl) {
+                statusText += " Use the URL above in Frigate or another FFmpeg-based consumer.";
+            }
+            statusEl.text(statusText);
+        }
     }
 
     async function loadCameraSettings() {
@@ -3291,6 +3312,22 @@ $(function () {
             }, "External camera settings saved");
         } catch (err) {
             flash_message(`Failed to save camera settings: ${err.message || err}`, "danger");
+        } finally {
+            btn.prop("disabled", false);
+        }
+    });
+
+    $("#camera-integration-save").on("click", async function () {
+        const btn = $(this);
+        btn.prop("disabled", true);
+        try {
+            await saveCameraSettings({
+                integration: {
+                    enabled: !!$("#camera-integration-enabled").prop("checked"),
+                },
+            }, "Printer integration stream settings saved");
+        } catch (err) {
+            flash_message(`Failed to save printer integration stream settings: ${err.message || err}`, "danger");
         } finally {
             btn.prop("disabled", false);
         }

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -4282,13 +4282,64 @@ $(function () {
         return mb >= 1 ? `${mb.toFixed(1)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
     }
 
+    let _timelapseVideos = [];
+    let _timelapseSelectedVideoKey = null;
     let _timelapseSnapshotCollections = [];
     let _timelapseSelectedCollectionId = null;
     let _timelapseSelectedFrameName = null;
     const selectedTimelapseFiles = new Set();
+    let timelapseAllPrinters = false;
+    let snapshotsAllPrinters = false;
 
-    function getTimelapseSnapshotCollection(id) {
-        return _timelapseSnapshotCollections.find(collection => collection.id === id) || null;
+    function normalizeMediaPrinterIndex(value) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : getActivePrinterIndex();
+    }
+
+    function withOptionalAllPrintersQuery(url, enabled, printerIndex = null) {
+        const base = withPrinterQuery(url, printerIndex);
+        if (!enabled) {
+            return base;
+        }
+        try {
+            const resolved = new URL(base, window.location.origin);
+            resolved.searchParams.set("all_printers", "1");
+            if (resolved.origin === window.location.origin) {
+                return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+            }
+            return resolved.toString();
+        } catch (_err) {
+            const separator = String(base).includes("?") ? "&" : "?";
+            return `${base}${separator}all_printers=1`;
+        }
+    }
+
+    function timelapseVideoKey(video) {
+        if (!video) {
+            return "";
+        }
+        return `${normalizeMediaPrinterIndex(video.printer_index)}::${String(video.filename || "")}`;
+    }
+
+    function getTimelapseVideo(key) {
+        return _timelapseVideos.find(video => timelapseVideoKey(video) === key) || null;
+    }
+
+    function timelapseCollectionKey(collection) {
+        if (!collection) {
+            return "";
+        }
+        return `${normalizeMediaPrinterIndex(collection.printer_index)}::${String(collection.id || "")}`;
+    }
+
+    function getTimelapseSnapshotCollection(key) {
+        return _timelapseSnapshotCollections.find(collection => timelapseCollectionKey(collection) === key) || null;
+    }
+
+    function getPrinterScopedLabel(printerIndex, printerName) {
+        const resolvedIndex = normalizeMediaPrinterIndex(printerIndex);
+        const fallback = `Printer ${resolvedIndex + 1}`;
+        return String(printerName || fallback);
     }
 
     function configureTimelapseSnapshotDeleteButton(mode, options = {}) {
@@ -4306,6 +4357,12 @@ $(function () {
             deleteBtn.dataset.collection = options.collectionId;
         } else {
             deleteBtn.removeAttribute("data-collection");
+        }
+
+        if (options.printerIndex !== undefined && options.printerIndex !== null) {
+            deleteBtn.dataset.printerIndex = String(normalizeMediaPrinterIndex(options.printerIndex));
+        } else {
+            deleteBtn.removeAttribute("data-printer-index");
         }
 
         if (options.filename) {
@@ -4404,21 +4461,32 @@ $(function () {
             return;
         }
 
-        _timelapseSelectedCollectionId = collection.id;
+        const collectionKey = timelapseCollectionKey(collection);
+        const printerIndex = normalizeMediaPrinterIndex(collection.printer_index);
+        const printerName = getPrinterScopedLabel(printerIndex, collection.printer_name);
+
+        _timelapseSelectedCollectionId = collectionKey;
         _timelapseSelectedFrameName = frame.filename;
 
-        if (collectionSelect) collectionSelect.value = collection.id;
+        if (collectionSelect) collectionSelect.value = collectionKey;
         if (frameSelect) frameSelect.value = frame.filename;
 
-        if (titleEl) titleEl.textContent = collection.label || collection.id;
+        if (titleEl) {
+            const baseTitle = collection.label || collection.id;
+            titleEl.textContent = snapshotsAllPrinters ? `${baseTitle} - ${printerName}` : baseTitle;
+        }
         if (subtitleEl) {
-            const subtitle = getSnapshotCollectionSubtitle(collection);
+            let subtitle = getSnapshotCollectionSubtitle(collection);
+            if (snapshotsAllPrinters && subtitle) {
+                subtitle = `${printerName}. ${subtitle}`;
+            }
             subtitleEl.textContent = subtitle;
             subtitleEl.style.display = subtitle ? "" : "none";
         }
         if (metaEl) {
             const created = frame.created_at ? new Date(frame.created_at).toLocaleString() : "-";
-            metaEl.textContent = `${frame.filename} · ${created} · ${formatSize(frame.size_bytes)}`;
+            const prefix = snapshotsAllPrinters ? `${printerName} · ` : "";
+            metaEl.textContent = `${prefix}${frame.filename} · ${created} · ${formatSize(frame.size_bytes)}`;
             metaEl.style.display = "";
         }
         if (statusEl) {
@@ -4446,14 +4514,16 @@ $(function () {
             imageEl.onerror = function () {
                 clearTimelapseSnapshotPreview("Unable to load snapshot preview");
             };
-            imageEl.src = withActivePrinterQuery(
-                `/api/timelapse-snapshot/${encodeURIComponent(collection.id)}/${encodeURIComponent(frame.filename)}`
+            imageEl.src = withPrinterQuery(
+                `/api/timelapse-snapshot/${encodeURIComponent(collection.id)}/${encodeURIComponent(frame.filename)}`,
+                printerIndex
             );
         }
         if (downloadEl) {
             downloadEl.classList.remove("disabled");
-            downloadEl.href = withActivePrinterQuery(
-                `/api/timelapse-snapshot/${encodeURIComponent(collection.id)}/${encodeURIComponent(frame.filename)}?download=1`
+            downloadEl.href = withPrinterQuery(
+                `/api/timelapse-snapshot/${encodeURIComponent(collection.id)}/${encodeURIComponent(frame.filename)}?download=1`,
+                printerIndex
             );
             downloadEl.setAttribute("download", frame.filename);
         }
@@ -4461,12 +4531,14 @@ $(function () {
             configureTimelapseSnapshotDeleteButton("collection", {
                 enabled: true,
                 collectionId: collection.id,
+                printerIndex: printerIndex,
             });
         } else {
             configureTimelapseSnapshotDeleteButton("frame", {
                 enabled: !!collection.allow_delete,
                 collectionId: collection.id,
                 filename: frame.filename,
+                printerIndex: printerIndex,
             });
         }
     }
@@ -4496,18 +4568,24 @@ $(function () {
         collectionSelect.disabled = false;
         _timelapseSnapshotCollections.forEach(collection => {
             const option = document.createElement("option");
-            option.value = collection.id;
+            option.value = timelapseCollectionKey(collection);
             const stateSuffix = getSnapshotCollectionStateSuffix(collection);
+            const printerPrefix = snapshotsAllPrinters
+                ? `${getPrinterScopedLabel(collection.printer_index, collection.printer_name)} - `
+                : "";
             option.textContent = `${collection.label || collection.id} · ${collection.frame_count} frame(s)${stateSuffix}`;
+            if (printerPrefix) {
+                option.textContent = `${printerPrefix}${collection.label || collection.id} - ${collection.frame_count} frame(s)${stateSuffix}`;
+            }
             collectionSelect.appendChild(option);
         });
 
         let selectedCollection = getTimelapseSnapshotCollection(_timelapseSelectedCollectionId);
         if (!selectedCollection) {
             selectedCollection = _timelapseSnapshotCollections[0];
-            _timelapseSelectedCollectionId = selectedCollection.id;
+            _timelapseSelectedCollectionId = timelapseCollectionKey(selectedCollection);
         }
-        collectionSelect.value = selectedCollection.id;
+        collectionSelect.value = timelapseCollectionKey(selectedCollection);
 
         const frames = Array.isArray(selectedCollection.frames) ? selectedCollection.frames : [];
         if (!frames.length) {
@@ -4527,11 +4605,11 @@ $(function () {
         });
 
         const selectedFrame = frames.find(frame => frame.filename === _timelapseSelectedFrameName) || frames[frames.length - 1];
-        timelapseSelectSnapshot(selectedCollection.id, selectedFrame.filename);
+        timelapseSelectSnapshot(timelapseCollectionKey(selectedCollection), selectedFrame.filename);
     }
 
     function loadTimelapseSnapshots() {
-        return fetch(withActivePrinterQuery("/api/timelapse-snapshots"))
+        return fetch(withOptionalAllPrintersQuery("/api/timelapse-snapshots", snapshotsAllPrinters))
             .then(r => r.json())
             .then(data => {
                 _timelapseSnapshotCollections = Array.isArray(data.collections) ? data.collections : [];
@@ -4555,6 +4633,8 @@ $(function () {
             } catch (_err) {}
             videoEl.removeAttribute("src");
             videoEl.removeAttribute("data-file");
+            videoEl.removeAttribute("data-key");
+            videoEl.removeAttribute("data-printer-index");
             videoEl.style.display = "none";
             videoEl.load();
         }
@@ -4568,7 +4648,11 @@ $(function () {
             placeholderTextEl.textContent = message || "Select a video to play";
         }
         if (placeholderEl) placeholderEl.style.display = "";
-        if (deleteBtn) deleteBtn.removeAttribute("data-file");
+        if (deleteBtn) {
+            deleteBtn.removeAttribute("data-file");
+            deleteBtn.removeAttribute("data-key");
+            deleteBtn.removeAttribute("data-printer-index");
+        }
 
         document.querySelectorAll("#timelapse-list .list-group-item").forEach(el => {
             el.classList.remove("active");
@@ -4582,21 +4666,32 @@ $(function () {
         const titleEl = document.getElementById("timelapse-player-title");
         const metaEl = document.getElementById("timelapse-player-meta");
         const deleteBtn = document.getElementById("timelapse-player-delete");
+        const videoKey = timelapseVideoKey(v);
+        const printerIndex = normalizeMediaPrinterIndex(v.printer_index);
+        const printerName = getPrinterScopedLabel(printerIndex, v.printer_name);
         if (!videoEl) return;
 
         document.querySelectorAll("#timelapse-list .list-group-item").forEach(el => {
-            el.classList.toggle("active", el.dataset.file === v.filename);
+            el.classList.toggle("active", el.dataset.key === videoKey);
         });
 
-        if (titleEl) titleEl.textContent = v.filename;
+        _timelapseSelectedVideoKey = videoKey;
+
+        if (titleEl) titleEl.textContent = timelapseAllPrinters ? `${v.filename} - ${printerName}` : v.filename;
         if (metaEl) {
             metaEl.textContent = `${v.created_at ? new Date(v.created_at).toLocaleString() : "-"} · ${formatSize(v.size_bytes)}`;
             metaEl.style.display = "";
         }
 
-        if (deleteBtn) deleteBtn.dataset.file = v.filename;
+        if (deleteBtn) {
+            deleteBtn.dataset.file = v.filename;
+            deleteBtn.dataset.key = videoKey;
+            deleteBtn.dataset.printerIndex = String(printerIndex);
+        }
         videoEl.dataset.file = v.filename;
-        videoEl.src = withActivePrinterQuery(`/api/timelapse/${encodeURIComponent(v.filename)}`);
+        videoEl.dataset.key = videoKey;
+        videoEl.dataset.printerIndex = String(printerIndex);
+        videoEl.src = withPrinterQuery(`/api/timelapse/${encodeURIComponent(v.filename)}`, printerIndex);
         videoEl.style.display = "";
         videoEl.load();
 
@@ -4626,35 +4721,38 @@ $(function () {
         }
     }
 
-    async function deleteTimelapseFile(file) {
-        const resp = await fetch(withActivePrinterQuery(`/api/timelapse/${encodeURIComponent(file)}`), { method: "DELETE" });
+    async function deleteTimelapseFile(file, printerIndex = null) {
+        const resolvedPrinterIndex = normalizeMediaPrinterIndex(printerIndex);
+        const fileKey = `${resolvedPrinterIndex}::${String(file || "")}`;
+        const resp = await fetch(withPrinterQuery(`/api/timelapse/${encodeURIComponent(file)}`, resolvedPrinterIndex), { method: "DELETE" });
         const data = await resp.json().catch(() => ({}));
         if (!resp.ok) {
             throw new Error(data.error || `HTTP ${resp.status}`);
         }
-        selectedTimelapseFiles.delete(file);
+        selectedTimelapseFiles.delete(fileKey);
         const videoEl = document.getElementById("timelapse-player");
-        if (videoEl && (videoEl.dataset.file || "") === file) {
+        if (videoEl && (videoEl.dataset.key || "") === fileKey) {
             clearTimelapseVideoPreview("Select a video to play");
         }
         return data;
     }
 
     function loadTimelapses() {
-        fetch(withActivePrinterQuery("/api/timelapses"))
+        fetch(withOptionalAllPrintersQuery("/api/timelapses", timelapseAllPrinters))
             .then(r => r.json())
             .then(data => {
                 const banner = document.getElementById("timelapse-disabled-banner");
                 const list = document.getElementById("timelapse-list");
                 const videoEl = document.getElementById("timelapse-player");
-                const currentFile = videoEl ? (videoEl.dataset.file || "") : "";
+                const currentVideoKey = videoEl ? (videoEl.dataset.key || "") : "";
+                _timelapseVideos = Array.isArray(data.videos) ? data.videos : [];
 
                 if (banner) banner.style.display = data.enabled ? "none" : "";
                 if (!list) return;
 
                 list.innerHTML = "";
 
-                if (!Array.isArray(data.videos) || data.videos.length === 0) {
+                if (!_timelapseVideos.length) {
                     selectedTimelapseFiles.clear();
                     list.innerHTML = '<div class="text-center text-muted py-4">No timelapse videos yet</div>';
                     clearTimelapseVideoPreview("Select a video to play");
@@ -4663,30 +4761,40 @@ $(function () {
                 }
 
                 let currentFileStillExists = false;
-                const visibleFiles = new Set(data.videos.map(v => v.filename));
+                const visibleFiles = new Set(_timelapseVideos.map(v => timelapseVideoKey(v)));
                 selectedTimelapseFiles.forEach(file => {
                     if (!visibleFiles.has(file)) {
                         selectedTimelapseFiles.delete(file);
                     }
                 });
 
-                data.videos.forEach(v => {
+                _timelapseVideos.forEach(v => {
+                    const videoKey = timelapseVideoKey(v);
+                    const printerIndex = normalizeMediaPrinterIndex(v.printer_index);
+                    const printerName = getPrinterScopedLabel(printerIndex, v.printer_name);
                     const created = v.created_at ? new Date(v.created_at).toLocaleString() : "-";
                     const safeFilename = escapeHtml(v.filename);
-                    const isChecked = selectedTimelapseFiles.has(v.filename);
+                    const safePrinterName = escapeHtml(printerName);
+                    const isChecked = selectedTimelapseFiles.has(videoKey);
+                    const printerMeta = timelapseAllPrinters
+                        ? `<div class="text-muted" style="font-size:0.75em;">${safePrinterName}</div>`
+                        : "";
                     const item = document.createElement("div");
                     item.className = "list-group-item list-group-item-action d-flex align-items-center py-2 px-3";
                     item.dataset.file = v.filename;
+                    item.dataset.key = videoKey;
+                    item.dataset.printerIndex = String(printerIndex);
                     item.innerHTML = `
                         <div class="form-check me-2 flex-shrink-0">
                             <input type="checkbox" class="form-check-input timelapse-select-checkbox">
                         </div>
                         <div class="overflow-hidden me-2" style="cursor:pointer; flex:1; min-width:0;">
                             <div class="text-truncate fw-semibold small">${safeFilename}</div>
+                            ${printerMeta}
                             <div class="text-muted" style="font-size:0.75em;">${created} · ${formatSize(v.size_bytes)}</div>
                         </div>
                         <div class="d-flex gap-1 flex-shrink-0">
-                            <a href="${withActivePrinterQuery(`/api/timelapse/${encodeURIComponent(v.filename)}`)}" class="btn btn-sm btn-outline-secondary" download title="Download">
+                            <a href="${withPrinterQuery(`/api/timelapse/${encodeURIComponent(v.filename)}`, printerIndex)}" class="btn btn-sm btn-outline-secondary" download title="Download">
                                 <i class="bi bi-download"></i>
                             </a>
                             <button type="button" class="btn btn-sm btn-outline-danger timelapse-delete" title="Delete">
@@ -4695,15 +4803,19 @@ $(function () {
                         </div>`;
 
                     item.querySelector(".timelapse-delete").dataset.file = v.filename;
+                    item.querySelector(".timelapse-delete").dataset.key = videoKey;
+                    item.querySelector(".timelapse-delete").dataset.printerIndex = String(printerIndex);
                     const checkbox = item.querySelector(".timelapse-select-checkbox");
                     if (checkbox) {
+                        checkbox.dataset.key = videoKey;
                         checkbox.dataset.file = v.filename;
+                        checkbox.dataset.printerIndex = String(printerIndex);
                         checkbox.checked = isChecked;
                         checkbox.setAttribute("aria-label", `Select ${v.filename}`);
                         checkbox.addEventListener("click", event => event.stopPropagation());
                     }
 
-                    if (currentFile && currentFile === v.filename) {
+                    if (currentVideoKey && currentVideoKey === videoKey) {
                         item.classList.add("active");
                         currentFileStillExists = true;
                     }
@@ -4712,8 +4824,13 @@ $(function () {
                     list.appendChild(item);
                 });
 
-                if (currentFile && !currentFileStillExists) {
+                if (currentVideoKey && !currentFileStillExists) {
                     clearTimelapseVideoPreview("Select a video to play");
+                } else if (_timelapseSelectedVideoKey && !currentVideoKey) {
+                    const selectedVideo = getTimelapseVideo(_timelapseSelectedVideoKey);
+                    if (selectedVideo) {
+                        timelapseSelectVideo(selectedVideo);
+                    }
                 }
                 updateTimelapseSelectionUi();
             })
@@ -4764,6 +4881,22 @@ $(function () {
             }
         });
     }
+
+    $("#timelapse-all-printers").on("change", function () {
+        timelapseAllPrinters = $(this).prop("checked");
+        selectedTimelapseFiles.clear();
+        _timelapseSelectedVideoKey = null;
+        clearTimelapseVideoPreview("Select a video to play");
+        loadTimelapses();
+    });
+
+    $("#snapshots-all-printers").on("change", function () {
+        snapshotsAllPrinters = $(this).prop("checked");
+        _timelapseSelectedCollectionId = null;
+        _timelapseSelectedFrameName = null;
+        clearTimelapseSnapshotPreview("Select a saved snapshot to preview");
+        loadTimelapseSnapshots();
+    });
 
     $("#timelapse-action-start").on("click", async function () {
         const btn = $(this);
@@ -4859,9 +4992,11 @@ $(function () {
     $("#timelapse-snapshot-delete").on("click", async function () {
         const btn = $(this);
         const mode = String(btn.data("mode") || "frame");
-        const collectionId = btn.data("collection");
-        const filename = btn.data("file");
-        const collection = getTimelapseSnapshotCollection(collectionId);
+        const collectionId = btn.attr("data-collection") || btn.data("collection");
+        const filename = btn.attr("data-file") || btn.data("file");
+        const printerIndex = normalizeMediaPrinterIndex(btn.attr("data-printer-index") || btn.data("printerIndex"));
+        const collectionKey = `${printerIndex}::${String(collectionId || "")}`;
+        const collection = getTimelapseSnapshotCollection(collectionKey);
         if (!collectionId || !collection) return;
 
         let requestUrl = null;
@@ -4870,8 +5005,9 @@ $(function () {
 
         if (mode === "collection") {
             confirmMessage = `Discard paused capture ${collection.label || collection.id}?`;
-            requestUrl = withActivePrinterQuery(
-                `/api/timelapse-snapshot/${encodeURIComponent(collectionId)}`
+            requestUrl = withPrinterQuery(
+                `/api/timelapse-snapshot/${encodeURIComponent(collectionId)}`,
+                printerIndex
             );
             successMessage = `Discarded paused capture ${collection.label || collection.id}.`;
         } else {
@@ -4879,8 +5015,9 @@ $(function () {
                 return;
             }
             confirmMessage = `Delete snapshot ${filename}?`;
-            requestUrl = withActivePrinterQuery(
-                `/api/timelapse-snapshot/${encodeURIComponent(collectionId)}/${encodeURIComponent(filename)}`
+            requestUrl = withPrinterQuery(
+                `/api/timelapse-snapshot/${encodeURIComponent(collectionId)}/${encodeURIComponent(filename)}`,
+                printerIndex
             );
             successMessage = `Deleted snapshot ${filename}.`;
         }
@@ -4903,14 +5040,14 @@ $(function () {
     });
 
     $(document).on("change", ".timelapse-select-checkbox", function () {
-        const file = $(this).attr("data-file") || $(this).data("file");
-        if (!file) {
+        const fileKey = $(this).attr("data-key") || $(this).data("key");
+        if (!fileKey) {
             return;
         }
         if ($(this).prop("checked")) {
-            selectedTimelapseFiles.add(file);
+            selectedTimelapseFiles.add(fileKey);
         } else {
-            selectedTimelapseFiles.delete(file);
+            selectedTimelapseFiles.delete(fileKey);
         }
         updateTimelapseSelectionUi();
     });
@@ -4919,22 +5056,24 @@ $(function () {
         const checked = $(this).prop("checked");
         $(".timelapse-select-checkbox").each(function () {
             const checkbox = $(this);
-            const file = checkbox.attr("data-file") || checkbox.data("file");
-            if (!file) {
+            const fileKey = checkbox.attr("data-key") || checkbox.data("key");
+            if (!fileKey) {
                 return;
             }
             checkbox.prop("checked", checked);
             if (checked) {
-                selectedTimelapseFiles.add(file);
+                selectedTimelapseFiles.add(fileKey);
             } else {
-                selectedTimelapseFiles.delete(file);
+                selectedTimelapseFiles.delete(fileKey);
             }
         });
         updateTimelapseSelectionUi();
     });
 
     $("#timelapse-delete-selected").on("click", async function () {
-        const files = Array.from(selectedTimelapseFiles);
+        const files = Array.from(selectedTimelapseFiles)
+            .map(key => ({ key: key, video: getTimelapseVideo(key) }))
+            .filter(item => item.video);
         if (!files.length) {
             flash_message("Select one or more timelapse videos first.", "warning");
             return;
@@ -4947,12 +5086,12 @@ $(function () {
         const failures = [];
         let deleted = 0;
         try {
-            for (const file of files) {
+            for (const item of files) {
                 try {
-                    await deleteTimelapseFile(file);
+                    await deleteTimelapseFile(item.video.filename, item.video.printer_index);
                     deleted += 1;
                 } catch (err) {
-                    failures.push(`${file}: ${err.message || err}`);
+                    failures.push(`${item.video.filename}: ${err.message || err}`);
                 }
             }
             await loadTimelapses();
@@ -4973,10 +5112,11 @@ $(function () {
     $(document).on("click", ".timelapse-delete", async function () {
         const btn = $(this);
         const file = btn.attr("data-file") || btn.data("file");
+        const printerIndex = btn.attr("data-printer-index") || btn.data("printerIndex");
         if (!file || !confirm(`Delete timelapse ${file}?`)) return;
         btn.prop("disabled", true);
         try {
-            await deleteTimelapseFile(file);
+            await deleteTimelapseFile(file, printerIndex);
             flash_message(`Deleted timelapse ${file}.`, "success", 4000);
             await loadTimelapses();
             await loadTimelapseSnapshots();

--- a/static/tabs/history.html
+++ b/static/tabs/history.html
@@ -6,6 +6,10 @@
                     <div class="card-header fs-5 d-flex justify-content-between align-items-center">
                         <span>{{ macro.bi_icon("clock-history") }} Print History</span>
                         <div class="d-flex gap-2">
+                            <div class="form-check form-switch d-flex align-items-center mb-0 me-2">
+                                <input class="form-check-input me-2" type="checkbox" id="history-all-printers" aria-label="Show history from all printers">
+                                <label class="form-check-label small text-nowrap" for="history-all-printers">All printers</label>
+                            </div>
                             <button class="btn btn-sm btn-outline-danger" id="history-delete-selected" disabled>
                                 {{ macro.bi_icon("trash3") }} Delete Selected
                             </button>

--- a/static/tabs/instructions.html
+++ b/static/tabs/instructions.html
@@ -13,12 +13,13 @@
                             </li>
                             <li class="mb-2">
                                 Confirm your printer list in the <strong>AnkerMake M5 Config</strong> preview on the
-                                right side of the Account tab.
+                                right side of the Account tab. If more than one printer is detected, use the printer
+                                selector in the top navbar to switch between them.
                             </li>
                             <li class="mb-2">
                                 If needed, switch to each printer from the navbar and save that printer's
-                                <strong>External Camera</strong> and <strong>Timelapse</strong> settings. Then review
-                                notification settings if you use alerts.
+                                <strong>External Camera</strong>, <strong>Printer Integration Stream</strong>, and
+                                <strong>Timelapse</strong> settings. Then review notification settings if you use alerts.
                             </li>
                             <li class="mb-2">
                                 Connect your slicer with the OctoPrint-compatible upload settings below, then use
@@ -151,6 +152,67 @@
                                 Manual snapshots follow the selected camera source. Timelapse has its own source setting
                                 in <strong>Setup -&gt; Timelapse</strong>, so Home page viewing does not have to interrupt
                                 captures.
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row g-3 mb-3">
+            <div class="col-lg-6">
+                <div class="card h-100">
+                    <div class="card-header fs-4">{{ macro.bi_icon("printer") }} Printer Selection</div>
+                    <div class="card-body">
+                        <ol class="mb-0">
+                            <li class="mb-2">
+                                If you have more than one printer, use the printer dropdown in the top navbar to pick
+                                the printer you want to work with first.
+                            </li>
+                            <li class="mb-2">
+                                The dropdown shows the printer name plus the last five characters of the serial number
+                                so you can confirm you picked the right one.
+                            </li>
+                            <li class="mb-2">
+                                After switching, the page reloads onto that printer. The <strong>Home</strong>,
+                                <strong>G-code</strong>, <strong>History</strong>, <strong>Filaments</strong>,
+                                <strong>Timelapse</strong>, and <strong>Snapshots</strong> pages will then show that
+                                printer's data.
+                            </li>
+                            <li class="mb-2">
+                                Camera setup and timelapse setup are saved per printer. Configure each printer
+                                separately if Thing 1 and Thing 2 should use different camera feeds or timelapse
+                                behavior.
+                            </li>
+                            <li class="mb-0">
+                                If the selector is locked or disabled, an environment setting is forcing a fixed
+                                printer index for this ankerctl session.
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="card h-100">
+                    <div class="card-header fs-4">{{ macro.bi_icon("broadcast") }} Printer Integration Stream</div>
+                    <div class="card-body">
+                        <ol class="mb-0">
+                            <li class="mb-2">Switch to the printer you want to expose first.</li>
+                            <li class="mb-2">Open <strong>Setup -&gt; Camera</strong>.</li>
+                            <li class="mb-2">
+                                In <strong>Printer Integration Stream</strong>, enable the printer camera integration
+                                endpoint and click <strong>Save Integration Stream</strong>.
+                            </li>
+                            <li class="mb-2">
+                                Copy the generated endpoint URL and use it in Frigate or another FFmpeg-based consumer.
+                            </li>
+                            <li class="mb-2">
+                                This endpoint is separate from the Home page camera source, so changing the Home view
+                                between printer and external camera does not change the integration stream.
+                            </li>
+                            <li class="mb-0">
+                                It requires <code>ffmpeg</code> and a printer model with a built-in camera. If API key
+                                protection is enabled in ankerctl, use the protected endpoint URL shown on the page.
                             </li>
                         </ol>
                     </div>

--- a/static/tabs/setup.html
+++ b/static/tabs/setup.html
@@ -358,23 +358,54 @@
                                 </div>
                             </div>
                             <div class="col-lg-5">
-                                <div class="card h-100">
-                                    <div class="card-header fs-4">Setup Notes</div>
-                                    <div class="card-body small">
-                                        <p class="mb-2">
-                                            External camera support is meant for simple FFmpeg-friendly feeds.
-                                        </p>
-                                        <ul class="mb-3">
-                                            <li>RTSP example: <code>rtsp://user:pass@camera-ip:554/stream1</code></li>
-                                            <li>MJPEG example: <code>http://camera-ip/mjpeg</code></li>
-                                            <li>Snapshot example: <code>http://camera-ip/snapshot.jpg</code></li>
-                                        </ul>
-                                        <p class="mb-2">
-                                            Use the <strong>Home</strong> page to switch between the printer camera and the external feed. Manual snapshots follow the Home source; timelapse can be pinned in <strong>Setup -&gt; Timelapse</strong>.
-                                        </p>
-                                        <p class="mb-0">
-                                            External preview uses the stream URL for live view when configured. Snapshot URLs are optional fallback sources for still captures.
-                                        </p>
+                                <div class="vstack gap-3">
+                                    <div class="card">
+                                        <div class="card-header fs-4">Printer Integration Stream</div>
+                                        <div class="card-body">
+                                            <form id="camera-integration-form" class="vstack gap-3">
+                                                <div class="form-check form-switch">
+                                                    <input class="form-check-input" type="checkbox" id="camera-integration-enabled">
+                                                    <label class="form-check-label" for="camera-integration-enabled">
+                                                        Enable printer camera integration endpoint
+                                                    </label>
+                                                </div>
+                                                <div class="form-text">
+                                                    Creates a dedicated printer-camera stream endpoint for Frigate and other FFmpeg-based consumers. It is independent from the Home page camera source selection.
+                                                </div>
+                                                <div>
+                                                    <label class="form-label" for="camera-integration-endpoint">Endpoint URL</label>
+                                                    <input class="form-control" type="text" id="camera-integration-endpoint" readonly />
+                                                    <div class="form-text" id="camera-integration-status">
+                                                        Loading integration endpoint details...
+                                                    </div>
+                                                </div>
+                                                <div class="d-flex flex-wrap gap-2">
+                                                    <button class="btn btn-primary" type="button" id="camera-integration-save">Save Integration Stream</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                    <div class="card h-100">
+                                        <div class="card-header fs-4">Setup Notes</div>
+                                        <div class="card-body small">
+                                            <p class="mb-2">
+                                                External camera support is meant for simple FFmpeg-friendly feeds.
+                                            </p>
+                                            <ul class="mb-3">
+                                                <li>RTSP example: <code>rtsp://user:pass@camera-ip:554/stream1</code></li>
+                                                <li>MJPEG example: <code>http://camera-ip/mjpeg</code></li>
+                                                <li>Snapshot example: <code>http://camera-ip/snapshot.jpg</code></li>
+                                            </ul>
+                                            <p class="mb-2">
+                                                Use the <strong>Home</strong> page to switch between the printer camera and the external feed. Manual snapshots follow the Home source; timelapse can be pinned in <strong>Setup -&gt; Timelapse</strong>.
+                                            </p>
+                                            <p class="mb-2">
+                                                The printer integration endpoint remuxes the raw printer stream into H.264 / fragmented MP4 with <code>ffmpeg</code> so consumers like Frigate have a more standard stream to pull from.
+                                            </p>
+                                            <p class="mb-0">
+                                                External preview uses the stream URL for live view when configured. Snapshot URLs are optional fallback sources for still captures.
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/static/tabs/snapshots.html
+++ b/static/tabs/snapshots.html
@@ -36,8 +36,12 @@
             </div>
             <div class="col-lg-4">
                 <div class="card">
-                    <div class="card-header fs-5">
-                        {{ macro.bi_icon("images") }} Saved Snapshots
+                    <div class="card-header fs-5 d-flex flex-column flex-sm-row justify-content-between align-items-sm-center gap-2">
+                        <span>{{ macro.bi_icon("images") }} Saved Snapshots</span>
+                        <div class="form-check form-switch m-0">
+                            <input class="form-check-input" type="checkbox" id="snapshots-all-printers" aria-label="Show snapshots from all printers">
+                            <label class="form-check-label small text-nowrap" for="snapshots-all-printers">All printers</label>
+                        </div>
                     </div>
                     <div class="card-body">
                         <div class="vstack gap-3">

--- a/static/tabs/timelapse.html
+++ b/static/tabs/timelapse.html
@@ -79,6 +79,10 @@
                     <div class="card-header fs-5 d-flex flex-column flex-sm-row justify-content-between align-items-sm-center gap-2">
                         <span>{{ macro.bi_icon("camera-reels") }} Timelapse Videos</span>
                         <div class="d-flex align-items-center gap-2">
+                            <div class="form-check form-switch m-0">
+                                <input class="form-check-input" type="checkbox" id="timelapse-all-printers" aria-label="Show timelapses from all printers">
+                                <label class="form-check-label small text-nowrap" for="timelapse-all-printers">All printers</label>
+                            </div>
                             <div class="form-check m-0">
                                 <input class="form-check-input" type="checkbox" id="timelapse-select-all" aria-label="Select all timelapse videos" disabled>
                                 <label class="form-check-label small" for="timelapse-select-all">Select all</label>

--- a/tests/test_camera_helpers.py
+++ b/tests/test_camera_helpers.py
@@ -3,9 +3,12 @@ import threading
 
 from web.camera import (
     CameraCaptureError,
+    build_printer_integration_stream_url,
     capture_camera_snapshot_to_file,
+    iter_process_chunks,
     iter_mjpeg_frames,
     open_external_mjpeg_stream,
+    open_printer_fmp4_stream,
 )
 
 
@@ -102,6 +105,41 @@ def test_open_external_mjpeg_stream_supports_ffmpeg_readable_non_rtsp_stream(mon
     assert cmd[-7:] == ["-f", "image2pipe", "-vcodec", "mjpeg", "-q:v", "5", "pipe:1"]
 
 
+def test_open_printer_fmp4_stream_uses_fragmented_mp4_remux_command(monkeypatch):
+    captured = {}
+
+    class FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            self.stdin = None
+            self.stdout = None
+
+    monkeypatch.setattr("subprocess.Popen", FakePopen)
+
+    proc = open_printer_fmp4_stream("ffmpeg", input_fps=15)
+
+    cmd = captured["cmd"]
+    assert proc.stdin is None
+    assert proc.stdout is None
+    assert cmd[:7] == ["ffmpeg", "-loglevel", "error", "-nostdin", "-fflags", "+genpts", "-r"]
+    assert "15" in cmd
+    assert cmd[cmd.index("-f"):cmd.index("-i") + 2] == ["-f", "h264", "-i", "pipe:0"]
+    assert "-movflags" in cmd
+    assert "+frag_keyframe+empty_moov+default_base_moof" in cmd
+    assert cmd[-5:] == ["-frag_duration", "1000000", "-f", "mp4", "pipe:1"]
+
+
+def test_build_printer_integration_stream_url_includes_printer_and_api_key():
+    url = build_printer_integration_stream_url(
+        "http://127.0.0.1:4470",
+        "secret key",
+        printer_index=1,
+    )
+
+    assert url == "http://127.0.0.1:4470/api/camera/printer-stream?printer_index=1&apikey=secret%20key"
+
+
 def test_iter_mjpeg_frames_extracts_jpegs_from_chunked_stream():
     class FakeStdout:
         def __init__(self):
@@ -145,3 +183,20 @@ def test_iter_mjpeg_frames_stops_when_ffmpeg_stdout_stalls():
         assert read_started.wait(timeout=0.5)
     finally:
         release_read.set()
+
+
+def test_iter_process_chunks_yields_binary_output():
+    class FakeStdout:
+        def __init__(self):
+            self.chunks = [b"one", b"two", b""]
+
+        def read(self, _size):
+            return self.chunks.pop(0)
+
+    class FakeProc:
+        stdout = FakeStdout()
+
+        def poll(self):
+            return None
+
+    assert list(iter_process_chunks(FakeProc(), chunk_size=4, stale_timeout=0.1)) == [b"one", b"two"]

--- a/tests/test_filament_api.py
+++ b/tests/test_filament_api.py
@@ -448,7 +448,7 @@ def test_filament_swap_routes_cover_legacy_start_confirm_and_cancel(tmp_path, mo
     assert confirmed.get_json()["pending"] is True
     assert cancelled.status_code == 200
     assert cancelled.get_json()["pending"] is False
-    assert home_calls == ["all"]
+    assert home_calls == ["z"]
     assert home_waits == [42.0]
     assert sent[0] == "M104 S180"
     assert sent[1] == "M104 S220"
@@ -540,7 +540,7 @@ def test_legacy_swap_sends_heat_before_homing_when_nozzle_is_cold(tmp_path, monk
     assert sent[0] == "M104 S180"
     assert sent[1] == "M104 S220"
     assert sent[2] == "M104 S220"
-    assert home_calls == ["all"]
+    assert home_calls == ["z"]
     assert home_waits == [70.0]
     assert sent[3] == "G91"
     assert sent[4] == "G1 Z50 F600"
@@ -576,6 +576,23 @@ def test_filament_swap_command_config_overrides_templates(tmp_path):
 
     assert nozzle_command == "M109 S220"
     assert lift_command == "G1 Z50 F1234"
+
+
+def test_filament_swap_command_config_migrates_legacy_native_home_all(tmp_path):
+    mqtt = SimpleNamespace(is_printing=False, nozzle_temp=25, send_gcode=lambda gcode: None)
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+    command_config = tmp_path / "filament_swap_commands.json"
+    command_config.write_text(
+        '{"commands":{"home_all":"native:home_all"}}',
+        encoding="utf-8",
+    )
+
+    try:
+        config = web_module._load_filament_swap_commands()
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert config["commands"]["home_all"] == "native:home_z"
 
 
 def test_legacy_swap_cancel_is_allowed_while_stage_is_running(tmp_path, monkeypatch):

--- a/tests/test_print_history.py
+++ b/tests/test_print_history.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 from datetime import datetime, timezone
 
 from web.service.history import PrintHistory
@@ -65,6 +66,57 @@ def test_printer_scoped_history_claims_legacy_active_task_row(tmp_path):
     assert resumed_id == row_id
     assert entry["status"] == "finished"
     assert entry["printer_index"] == 1
+
+
+def test_legacy_null_rows_are_claimed_only_when_printer_is_unambiguous(tmp_path):
+    db_path = tmp_path / "history.db"
+    PrintHistory(db_path=db_path)
+    started_at = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, task_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("thing2-known.gcode", 1, "finished", started_at, "task-identified"),
+        )
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, task_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy-task.gcode", None, "finished", started_at, "task-identified"),
+        )
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, archive_relpath) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("thing1-archive.gcode", 0, "finished", started_at, "shared-archive.gcode"),
+        )
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, archive_relpath) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy-archive.gcode", None, "finished", started_at, "shared-archive.gcode"),
+        )
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, task_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("thing1-ambiguous.gcode", 0, "finished", started_at, "task-ambiguous"),
+        )
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, task_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("thing2-ambiguous.gcode", 1, "finished", started_at, "task-ambiguous"),
+        )
+        conn.execute(
+            "INSERT INTO print_history (filename, printer_index, status, started_at, task_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy-ambiguous.gcode", None, "finished", started_at, "task-ambiguous"),
+        )
+        conn.commit()
+
+    history = PrintHistory(db_path=db_path)
+    rows = {entry["filename"]: entry for entry in history.get_history(limit=20)}
+
+    assert rows["legacy-task.gcode"]["printer_index"] == 1
+    assert rows["legacy-archive.gcode"]["printer_index"] == 0
+    assert rows["legacy-ambiguous.gcode"]["printer_index"] is None
 
 
 def test_record_finish_and_fail_update_active_entries(tmp_path):

--- a/tests/test_print_history.py
+++ b/tests/test_print_history.py
@@ -36,13 +36,19 @@ def test_record_start_does_not_interrupt_active_jobs_from_other_printers(tmp_pat
     first_id = history0.record_start("thing1-part.gcode", task_id="thing1-task")
     second_id = history1.record_start("thing2-part.gcode", task_id="thing2-task")
 
-    entries = history0.get_history(limit=10)
-    by_id = {entry["id"]: entry for entry in entries}
+    entries0 = history0.get_history(limit=10)
+    entries1 = history1.get_history(limit=10)
+    all_entries = PrintHistory(db_path=db_path).get_history(limit=10)
 
-    assert by_id[first_id]["status"] == "started"
-    assert by_id[first_id]["printer_index"] == 0
-    assert by_id[second_id]["status"] == "started"
-    assert by_id[second_id]["printer_index"] == 1
+    assert [entry["id"] for entry in entries0] == [first_id]
+    assert [entry["id"] for entry in entries1] == [second_id]
+    assert history0.get_count() == 1
+    assert history1.get_count() == 1
+    assert history0.get_entry(first_id)["printer_index"] == 0
+    assert history1.get_entry(second_id)["printer_index"] == 1
+    assert history0.get_entry(second_id) is None
+    assert history1.get_entry(first_id) is None
+    assert {entry["id"] for entry in all_entries} == {first_id, second_id}
 
 
 def test_printer_scoped_history_claims_legacy_active_task_row(tmp_path):
@@ -246,6 +252,44 @@ def test_history_clear_removes_archived_gcode_files(tmp_path):
     assert history.get_archive_path(row_id) is None
 
 
+def test_printer_scoped_clear_only_removes_current_printer_entries_and_archives(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    archive0 = history0.archive_upload("thing1.gcode", b"G28\n")
+    archive1 = history1.archive_upload("thing2.gcode", b"G28\n")
+
+    row0_id = history0.record_start(
+        "thing1.gcode",
+        task_id="thing1-task",
+        archive_relpath=archive0["archive_relpath"],
+        archive_size=archive0["archive_size"],
+    )
+    history0.record_finish(task_id="thing1-task", progress=100)
+    row1_id = history1.record_start(
+        "thing2.gcode",
+        task_id="thing2-task",
+        archive_relpath=archive1["archive_relpath"],
+        archive_size=archive1["archive_size"],
+    )
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    archive0_path = history0.get_archive_path(row0_id)
+    archive1_path = history1.get_archive_path(row1_id)
+    assert archive0_path is not None and os.path.exists(archive0_path)
+    assert archive1_path is not None and os.path.exists(archive1_path)
+
+    history0.clear()
+
+    assert history0.get_count() == 0
+    assert history1.get_count() == 1
+    assert history0.get_entry(row0_id) is None
+    assert history1.get_entry(row1_id) is not None
+    assert not os.path.exists(archive0_path)
+    assert os.path.exists(archive1_path)
+
+
 def test_history_preview_url_marks_entry_thumbnail_available(tmp_path):
     history = PrintHistory(db_path=tmp_path / "history.db")
 
@@ -286,3 +330,42 @@ def test_delete_entries_removes_selected_rows_and_unreferenced_archives(tmp_path
     assert history.get_entry(second_id) is not None
     assert first_archive_path is not None and not os.path.exists(first_archive_path)
     assert second_archive_path is not None and os.path.exists(second_archive_path)
+
+
+def test_printer_scoped_delete_entries_only_removes_matching_printer_rows(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    archive0 = history0.archive_upload("thing1.gcode", b"G28\n")
+    archive1 = history1.archive_upload("thing2.gcode", b"G28\n")
+
+    row0_id = history0.record_start(
+        "thing1.gcode",
+        task_id="thing1-task",
+        archive_relpath=archive0["archive_relpath"],
+        archive_size=archive0["archive_size"],
+    )
+    history0.record_finish(task_id="thing1-task", progress=100)
+    row1_id = history1.record_start(
+        "thing2.gcode",
+        task_id="thing2-task",
+        archive_relpath=archive1["archive_relpath"],
+        archive_size=archive1["archive_size"],
+    )
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    archive0_path = history0.get_archive_path(row0_id)
+    archive1_path = history1.get_archive_path(row1_id)
+    assert archive0_path is not None and os.path.exists(archive0_path)
+    assert archive1_path is not None and os.path.exists(archive1_path)
+
+    assert history0.delete_entries([row1_id]) == 0
+    assert history1.get_entry(row1_id) is not None
+    assert os.path.exists(archive1_path)
+
+    assert history0.delete_entries([row0_id]) == 1
+    assert history0.get_entry(row0_id) is None
+    assert history1.get_entry(row1_id) is not None
+    assert not os.path.exists(archive0_path)
+    assert os.path.exists(archive1_path)

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -1097,6 +1097,82 @@ def test_timelapse_media_routes_honor_requested_printer_index(tmp_path):
     assert snapshot_deleted.status_code == 200
 
 
+def test_timelapse_media_routes_support_all_printers(tmp_path):
+    cfg = _base_config()
+    cfg.printers.append(_printer("SN2", "Printer 2"))
+
+    zero_dir = tmp_path / "captures-zero"
+    zero_dir.mkdir()
+    one_dir = tmp_path / "captures-one"
+    one_dir.mkdir()
+
+    timelapse_zero = SimpleNamespace(
+        enabled=False,
+        _captures_dir=str(zero_dir),
+        list_videos=lambda: [{
+            "filename": "zero.mp4",
+            "size_bytes": 8,
+            "created_at": "2026-04-17T10:00:00",
+        }],
+        list_snapshots=lambda: [{
+            "id": "zero_capture",
+            "label": "zero.gcode",
+            "frame_count": 1,
+            "created_at": "2026-04-17T10:00:00",
+            "allow_delete": True,
+            "frames": [{"filename": "frame_00000.jpg", "size_bytes": 8}],
+        }],
+    )
+    timelapse_one = SimpleNamespace(
+        enabled=True,
+        _captures_dir=str(one_dir),
+        list_videos=lambda: [{
+            "filename": "one.mp4",
+            "size_bytes": 7,
+            "created_at": "2026-04-17T11:00:00",
+        }],
+        list_snapshots=lambda: [{
+            "id": "one_capture",
+            "label": "one.gcode",
+            "frame_count": 2,
+            "created_at": "2026-04-17T11:00:00",
+            "allow_delete": True,
+            "frames": [{"filename": "frame_00001.jpg", "size_bytes": 7}],
+        }],
+    )
+
+    mqtt_zero = SimpleNamespace(timelapse=timelapse_zero)
+    mqtt_one = SimpleNamespace(timelapse=timelapse_one)
+
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.svc = FakeServices(**{"mqttqueue:0": mqtt_zero, "mqttqueue:1": mqtt_one})
+
+    try:
+        listed = client.get("/api/timelapses?all_printers=1", headers={"X-Api-Key": API_KEY})
+        listed_snapshots = client.get("/api/timelapse-snapshots?all_printers=1", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert listed.status_code == 200
+    listed_payload = listed.get_json()
+    assert listed_payload["enabled"] is True
+    assert [video["filename"] for video in listed_payload["videos"]] == ["one.mp4", "zero.mp4"]
+    assert listed_payload["videos"][0]["printer_index"] == 1
+    assert listed_payload["videos"][0]["printer_name"] == "Printer 2"
+    assert listed_payload["videos"][1]["printer_index"] == 0
+    assert listed_payload["videos"][1]["printer_name"] == "Printer"
+
+    assert listed_snapshots.status_code == 200
+    snapshots_payload = listed_snapshots.get_json()
+    assert snapshots_payload["enabled"] is True
+    assert [collection["id"] for collection in snapshots_payload["collections"]] == ["one_capture", "zero_capture"]
+    assert snapshots_payload["collections"][0]["printer_index"] == 1
+    assert snapshots_payload["collections"][0]["printer_name"] == "Printer 2"
+    assert snapshots_payload["collections"][1]["printer_index"] == 0
+    assert snapshots_payload["collections"][1]["printer_name"] == "Printer"
+
+
 def test_timelapse_current_routes_honor_requested_printer_index():
     cfg = _base_config()
     cfg.printers.append(_printer("SN2", "Printer 2"))

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -492,6 +492,157 @@ def test_history_route_uses_requested_or_active_indexed_mqtt_service():
     assert requested.get_json()["entries"][0]["filename"] == "thing1.gcode"
 
 
+def test_history_route_supports_all_printers_admin_view(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    history0.record_start("thing1.gcode", task_id="thing1-task")
+    history0.record_finish(task_id="thing1-task", progress=100)
+    history1.record_start("thing2.gcode", task_id="thing2-task")
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    cfg = _base_config()
+    cfg.printers = [
+        _printer(sn="SN0", name="Thing 1"),
+        _printer(sn="SN1", name="Thing 2"),
+    ]
+    services = FakeServices()
+    services._services = {
+        "mqttqueue": SimpleNamespace(history=history0),
+        "mqttqueue:0": SimpleNamespace(history=history0),
+        "mqttqueue:1": SimpleNamespace(history=history1),
+    }
+    services.svcs = dict(services._services)
+
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.config["config"].config_root = tmp_path
+    app.config["printer_index"] = 0
+    app.svc = services
+
+    try:
+        response = client.get("/api/history?all_printers=1", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["total"] == 2
+    by_filename = {entry["filename"]: entry for entry in payload["entries"]}
+    assert by_filename["thing1.gcode"]["printer_name"] == "Thing 1"
+    assert by_filename["thing2.gcode"]["printer_name"] == "Thing 2"
+
+
+def test_history_delete_selected_route_supports_all_printers_admin_view(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    row0_id = history0.record_start("thing1.gcode", task_id="thing1-task")
+    history0.record_finish(task_id="thing1-task", progress=100)
+    row1_id = history1.record_start("thing2.gcode", task_id="thing2-task")
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    cfg = _base_config()
+    cfg.printers = [
+        _printer(sn="SN0", name="Thing 1"),
+        _printer(sn="SN1", name="Thing 2"),
+    ]
+    services = FakeServices()
+    services._services = {
+        "mqttqueue": SimpleNamespace(history=history0),
+        "mqttqueue:0": SimpleNamespace(history=history0),
+        "mqttqueue:1": SimpleNamespace(history=history1),
+    }
+    services.svcs = dict(services._services)
+
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.config["config"].config_root = tmp_path
+    app.config["printer_index"] = 0
+    app.svc = services
+
+    try:
+        response = client.post(
+            "/api/history/delete?all_printers=1",
+            json={"ids": [row1_id]},
+            headers={"X-Api-Key": API_KEY},
+        )
+        listed = client.get("/api/history?all_printers=1", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    assert response.get_json()["deleted"] == 1
+    assert history0.get_entry(row0_id) is not None
+    assert history1.get_entry(row1_id) is None
+    assert [entry["filename"] for entry in listed.get_json()["entries"]] == ["thing1.gcode"]
+
+
+def test_history_reprint_route_uses_entry_printer_in_all_printers_mode(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    archive = history1.archive_upload("thing2.gcode", b"G28\nM104 S210\n")
+    row1_id = history1.record_start(
+        "thing2.gcode",
+        task_id="thing2-task",
+        archive_relpath=archive["archive_relpath"],
+        archive_size=archive["archive_size"],
+    )
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    cfg = _base_config()
+    cfg.printers = [
+        _printer(sn="SN0", name="Thing 1"),
+        _printer(sn="SN1", name="Thing 2"),
+    ]
+    sent = []
+    filetransfer = SimpleNamespace(
+        send_bytes=lambda archive_bytes, filename, user_name, rate_limit_mbps=None, start_print=True, printer_index=None, archive_info=None: sent.append({
+            "filename": filename,
+            "printer_index": printer_index,
+            "archive_info": archive_info,
+            "size": len(archive_bytes),
+        })
+    )
+    services = FakeServices()
+    services._services = {
+        "mqttqueue": SimpleNamespace(history=history0, is_printing=False, has_pending_print_start=False, is_preparing_print=False),
+        "mqttqueue:0": SimpleNamespace(history=history0, is_printing=False, has_pending_print_start=False, is_preparing_print=False),
+        "mqttqueue:1": SimpleNamespace(history=history1, is_printing=False, has_pending_print_start=False, is_preparing_print=False),
+        "filetransfer": filetransfer,
+    }
+    services.svcs = dict(services._services)
+
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.config["config"].config_root = tmp_path
+    app.config["printer_index"] = 0
+    app.svc = services
+
+    try:
+        response = client.post(
+            f"/api/history/{row1_id}/reprint?all_printers=1",
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    assert sent == [{
+        "filename": "thing2.gcode",
+        "printer_index": 1,
+        "archive_info": {
+            "archive_relpath": archive["archive_relpath"],
+            "archive_size": archive["archive_size"],
+        },
+        "size": archive["archive_size"],
+    }]
+
+
 def test_history_delete_selected_route_deletes_finished_entries(tmp_path):
     history = PrintHistory(db_path=tmp_path / "history.db")
     first_id = history.record_start("one.gcode")

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -536,6 +536,53 @@ def test_history_delete_selected_route_rejects_active_entries(tmp_path):
     assert "in-progress" in response.get_json()["error"]
 
 
+def test_history_delete_selected_route_respects_requested_printer_index(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    row0_id = history0.record_start("thing1.gcode", task_id="thing1-task")
+    history0.record_finish(task_id="thing1-task", progress=100)
+    row1_id = history1.record_start("thing2.gcode", task_id="thing2-task")
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    cfg = _base_config()
+    cfg.printers = [
+        _printer(sn="SN0", name="Thing 1"),
+        _printer(sn="SN1", name="Thing 2"),
+    ]
+    services = FakeServices()
+    services._services = {
+        "mqttqueue": SimpleNamespace(history=history0),
+        "mqttqueue:0": SimpleNamespace(history=history0),
+        "mqttqueue:1": SimpleNamespace(history=history1),
+    }
+    services.svcs = dict(services._services)
+
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.config["printer_index"] = 0
+    app.svc = services
+
+    try:
+        response = client.post(
+            "/api/history/delete?printer_index=0",
+            json={"ids": [row1_id]},
+            headers={"X-Api-Key": API_KEY},
+        )
+        listed0 = client.get("/api/history?printer_index=0", headers={"X-Api-Key": API_KEY})
+        listed1 = client.get("/api/history?printer_index=1", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    assert response.get_json()["deleted"] == 0
+    assert history0.get_entry(row0_id) is not None
+    assert history1.get_entry(row1_id) is not None
+    assert listed0.get_json()["entries"][0]["filename"] == "thing1.gcode"
+    assert listed1.get_json()["entries"][0]["filename"] == "thing2.gcode"
+
+
 def test_history_thumbnail_route_serves_local_archive_thumbnail(tmp_path):
     history = PrintHistory(db_path=tmp_path / "history.db")
     archive_info = history.archive_upload(

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 import subprocess
 from types import SimpleNamespace
+import pytest
 
 from cli.model import Account, Config, Printer
 from web import app
@@ -708,6 +709,64 @@ def test_history_reprint_route_requires_archived_file(tmp_path):
 
     assert response.status_code == 404
     assert "No archived GCode" in response.get_json()["error"]
+
+
+def test_fetch_remote_image_rejects_untrusted_preview_host(monkeypatch):
+    import web
+
+    cfg = _base_config()
+    cfg.printers[0].api_hosts = ["make-app.ankermake.com"]
+    old_values, old_svc = _install_app_state(config=cfg)
+    opener_calls = []
+    monkeypatch.setattr("urllib.request.build_opener", lambda *args, **kwargs: opener_calls.append((args, kwargs)))
+
+    try:
+        with pytest.raises(ValueError, match="host is not allowed"):
+            web._fetch_remote_image("https://evil.example/preview.png")
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert opener_calls == []
+
+
+def test_fetch_remote_image_rejects_oversized_remote_payload(monkeypatch):
+    from email.message import Message
+    import web
+
+    cfg = _base_config()
+    cfg.printers[0].api_hosts = ["example.test"]
+    old_values, old_svc = _install_app_state(config=cfg)
+
+    class FakeRemote:
+        def __init__(self):
+            self.headers = Message()
+            self.headers["Content-Type"] = "image/png"
+            self.headers["Content-Length"] = "6"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, _size=-1):
+            return b""
+
+        def geturl(self):
+            return "https://example.test/preview.png"
+
+    class FakeOpener:
+        def open(self, request_obj, timeout=10.0):
+            return FakeRemote()
+
+    monkeypatch.setattr("urllib.request.build_opener", lambda *args, **kwargs: FakeOpener())
+    monkeypatch.setattr("web._PREVIEW_IMAGE_MAX_BYTES", 5)
+
+    try:
+        with pytest.raises(RuntimeError, match="exceeded"):
+            web._fetch_remote_image("https://example.test/preview.png")
+    finally:
+        _restore_app_state(old_values, old_svc)
 
 
 def test_timelapse_routes_list_download_delete_and_reject_traversal(tmp_path):

--- a/tests/test_reports_video_and_webserver.py
+++ b/tests/test_reports_video_and_webserver.py
@@ -312,6 +312,121 @@ def test_video_download_requires_auth_and_streams_when_enabled():
     assert videoqueue.await_ready_calls == 1
 
 
+def test_printer_integration_stream_requires_auth_and_enable_flag(monkeypatch):
+    cfg = _base_config()
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(
+        api_key=API_KEY,
+        login=True,
+        video_supported=True,
+        config=FakeConfigManager(cfg),
+        svc=FakeVideoServices(None, []),
+    )
+
+    monkeypatch.setattr("web._ffmpeg_path", lambda: "/usr/bin/ffmpeg")
+
+    try:
+        unauthorized = client.get("/api/camera/printer-stream")
+        authorized = client.get("/api/camera/printer-stream", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert unauthorized.status_code == 401
+    assert authorized.status_code == 400
+    assert authorized.get_json()["error"] == "Printer integration stream is disabled in Setup -> Camera."
+
+
+def test_printer_integration_stream_remuxes_when_enabled(monkeypatch):
+    class FakeProc:
+        class _In:
+            def write(self, _payload):
+                return None
+
+            def flush(self):
+                return None
+
+            def close(self):
+                return None
+
+        stdin = _In()
+        stdout = None
+
+        def poll(self):
+            return None
+
+    class FakeVideoQueue:
+        def __init__(self):
+            self.state = RunState.Stopped
+            self.wanted = False
+            self.start_calls = 0
+            self.await_ready_calls = 0
+            self.integration_connects = 0
+            self.integration_disconnects = 0
+
+        def start(self):
+            self.start_calls += 1
+            self.state = RunState.Running
+            self.wanted = True
+
+        def await_ready(self):
+            self.await_ready_calls += 1
+
+        def integration_client_connected(self):
+            self.integration_connects += 1
+            self.start()
+            return self.integration_connects
+
+        def integration_client_disconnected(self):
+            self.integration_disconnects += 1
+            self.wanted = False
+            self.state = RunState.Stopped
+            return self.integration_disconnects
+
+    cfg = _base_config()
+    cfg.camera = {
+        "per_printer": {
+            "SN1": {
+                "source": "printer",
+                "external": {
+                    "name": "",
+                    "stream_url": "",
+                    "snapshot_url": "",
+                    "refresh_sec": 3,
+                },
+                "integration": {
+                    "enabled": True,
+                },
+            }
+        }
+    }
+    videoqueue = FakeVideoQueue()
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(
+        api_key=API_KEY,
+        login=True,
+        video_supported=True,
+        config=FakeConfigManager(cfg),
+        svc=FakeVideoServices(videoqueue, [b"raw-frame-1", b"raw-frame-2"]),
+    )
+
+    monkeypatch.setattr("web._ffmpeg_path", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr("web.camera.open_printer_fmp4_stream", lambda *_args, **_kwargs: FakeProc())
+    monkeypatch.setattr("web.camera.iter_process_chunks", lambda *_args, **_kwargs: iter([b"fmp4a", b"fmp4b"]))
+    monkeypatch.setattr("web.camera.stop_subprocess", lambda _proc: None)
+
+    try:
+        authorized = client.get("/api/camera/printer-stream", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert authorized.status_code == 200
+    assert authorized.data == b"fmp4afmp4b"
+    assert videoqueue.start_calls == 1
+    assert videoqueue.await_ready_calls == 1
+    assert videoqueue.integration_connects == 1
+    assert videoqueue.integration_disconnects == 1
+
+
 def test_webserver_bootstraps_secret_key_and_skips_services_for_unsupported_device(tmp_path, monkeypatch):
     run_calls = []
     register_calls = []

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -391,6 +391,7 @@ class TestSecurityIntegration:
             ("get", "/api/ankerctl/server/reload", None),
             ("get", "/api/camera/frame", None),
             ("get", "/api/camera/stream", None),
+            ("get", "/api/camera/printer-stream", None),
             ("get", "/api/snapshot", None),
         ]
 

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -393,6 +393,9 @@ class TestSecurityIntegration:
             ("get", "/api/camera/stream", None),
             ("get", "/api/camera/printer-stream", None),
             ("get", "/api/snapshot", None),
+            ("get", "/api/files/printer", None),
+            ("get", "/api/files/printer/thumbnail?path=/tmp/udisk/udisk1/file.gcode", None),
+            ("get", "/api/history/1/thumbnail", None),
         ]
 
         client = app.test_client()
@@ -408,6 +411,47 @@ class TestSecurityIntegration:
 
         assert responses
         assert all(status == 401 for _, status in responses), responses
+
+    def test_anonymous_user_is_blocked_before_dynamic_history_and_storage_logic(self, tmp_path, monkeypatch):
+        """Sensitive dynamic GET routes must 401 before hitting printer/history logic."""
+        storage_probe_calls = []
+        mqtt_borrow_calls = []
+
+        def fake_probe(*args, **kwargs):
+            storage_probe_calls.append((args, kwargs))
+            return {"source_value": 1, "reply_count": 1, "files": []}, None
+
+        @contextmanager
+        def fake_borrow_mqtt(printer_index):
+            mqtt_borrow_calls.append(printer_index)
+            yield SimpleNamespace(
+                is_printing=False,
+                has_pending_print_start=False,
+                is_preparing_print=False,
+                get_cached_stored_file_preview_url=lambda *args, **kwargs: "https://example.test/thumb.png",
+                get_stored_file_preview_url=lambda *args, **kwargs: "https://example.test/thumb.png",
+                history=SimpleNamespace(
+                    get_entry=lambda entry_id: {"preview_url": "https://example.test/thumb.png"},
+                    get_thumbnail_path=lambda entry_id: None,
+                ),
+            )
+
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        monkeypatch.setattr("web._probe_printer_storage_files", fake_probe)
+        monkeypatch.setattr("web.borrow_mqtt", fake_borrow_mqtt)
+        try:
+            printer_files = client.get("/api/files/printer")
+            printer_thumbnail = client.get("/api/files/printer/thumbnail?path=/tmp/udisk/udisk1/file.gcode")
+            history_thumbnail = client.get("/api/history/1/thumbnail")
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert printer_files.status_code == 401
+        assert printer_thumbnail.status_code == 401
+        assert history_thumbnail.status_code == 401
+        assert storage_probe_calls == []
+        assert mqtt_borrow_calls == []
 
     def test_authenticated_user_can_access_allowed_endpoints(self, tmp_path):
         """Authenticated user can access non-restricted endpoints"""

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -10,12 +10,47 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import web
 from cli.model import Account, Config, Printer
 from web import app
 from web.service.filament import FilamentStore
 
 
 API_KEY = "secret-key-123456"
+
+_PROTECTED_SECURITY_REQUESTS = [
+    ("post", "/api/printer/gcode", {"gcode": "G28"}),
+    ("post", "/api/printer/control", {"value": 1}),
+    ("get", "/api/filaments", None),
+    ("get", "/api/debug/state", None),
+    ("get", "/api/ankerctl/server/reload", None),
+    ("get", "/api/camera/frame", None),
+    ("get", "/api/camera/stream", None),
+    ("get", "/api/camera/printer-stream", None),
+    ("get", "/api/snapshot", None),
+    ("get", "/api/files/printer", None),
+    ("get", "/api/files/printer/thumbnail?path=/tmp/udisk/udisk1/file.gcode", None),
+    ("get", "/api/history/1/thumbnail", None),
+]
+
+_EXPECTED_PROTECTED_GET_PATHS = {
+    "/api/ankerctl/server/reload",
+    "/api/camera/frame",
+    "/api/camera/stream",
+    "/api/camera/printer-stream",
+    "/api/debug/state",
+    "/api/filaments",
+    "/api/history",
+    "/api/snapshot",
+}
+
+_EXPECTED_PROTECTED_GET_PREFIXES = {
+    "/api/debug/",
+    "/api/files/printer",
+    "/api/history/",
+    "/api/timelapse/",
+    "/api/timelapse-snapshot/",
+}
 
 
 def _pending_security_coverage(reason):
@@ -153,13 +188,42 @@ class TestSQLInjectionProtection:
 class TestPathTraversalProtection:
     """Test path traversal attack prevention"""
 
-    def test_log_viewer_path_traversal_blocked(self):
+    def test_log_viewer_path_traversal_blocked(self, tmp_path, monkeypatch):
         """GET /api/debug/logs/../../../etc/passwd is blocked"""
-        _pending_security_coverage("debug log file path traversal")
+        if not hasattr(web, "app_api_debug_logs_content"):
+            pytest.skip("Debug log content route is only registered in dev mode")
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        old_log_dir = getattr(web, "_log_dir", None)
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        monkeypatch.setattr(web, "_log_dir", str(log_dir), raising=False)
+        try:
+            response = client.get(
+                "/api/debug/logs/..%5C..%5Cpasswd",
+                headers=_auth_headers(),
+            )
+        finally:
+            monkeypatch.setattr(web, "_log_dir", old_log_dir, raising=False)
+            _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_timelapse_filename_path_traversal(self):
+        assert response.status_code == 400
+        assert "Invalid filename" in response.get_json()["error"]
+
+    def test_timelapse_filename_path_traversal(self, tmp_path):
         """Timelapse download with ../ in filename is blocked"""
-        _pending_security_coverage("timelapse download path traversal")
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            response = client.get(
+                "/api/timelapse-snapshot/..%5Cbad/frame_00000.jpg",
+                headers=_auth_headers(),
+            )
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert response.status_code == 400
+        assert "invalid filename" in response.get_json()["error"]
 
     def test_file_upload_path_sanitization(self):
         """File upload with path separators is sanitized"""
@@ -204,9 +268,28 @@ class TestInputValidation:
         finally:
             _restore_security_state(old_values, old_svc, old_filaments)
 
-    def test_invalid_upload_rate_rejected(self):
+    def test_invalid_upload_rate_rejected(self, tmp_path):
         """Upload rate outside valid range (5,10,25,50,100) is rejected"""
-        _pending_security_coverage("upload rate validation in settings/update routes")
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            non_integer = client.post(
+                "/api/ankerctl/config/upload-rate",
+                data={"upload_rate_mbps": "fast"},
+                headers=_auth_headers(),
+            )
+            out_of_range = client.post(
+                "/api/ankerctl/config/upload-rate",
+                data={"upload_rate_mbps": "7"},
+                headers=_auth_headers(),
+            )
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert non_integer.status_code == 400
+        assert "must be an integer" in non_integer.get_json()["error"]
+        assert out_of_range.status_code == 400
+        assert "must be one of" in out_of_range.get_json()["error"]
 
     def test_negative_printer_index_rejected(self, tmp_path):
         """Negative printer index in POST /api/printers/active is rejected"""
@@ -363,6 +446,11 @@ class TestFileSystemSecurity:
 class TestSecurityIntegration:
     """Integration tests combining multiple attack vectors"""
 
+    def test_security_auth_manifest_includes_sensitive_dynamic_routes(self):
+        """The auth guard must keep sensitive exact paths and dynamic prefixes protected."""
+        assert _EXPECTED_PROTECTED_GET_PATHS <= set(web._PROTECTED_GET_PATHS)
+        assert _EXPECTED_PROTECTED_GET_PREFIXES <= set(web._PROTECTED_GET_PREFIXES)
+
     def test_full_attack_chain_blocked(self, tmp_path):
         """Combined SQL injection + XSS + path traversal is blocked"""
         client = app.test_client()
@@ -383,26 +471,11 @@ class TestSecurityIntegration:
 
     def test_anonymous_user_cannot_access_protected_endpoints(self, tmp_path):
         """All protected endpoints require authentication"""
-        protected_requests = [
-            ("post", "/api/printer/gcode", {"gcode": "G28"}),
-            ("post", "/api/printer/control", {"value": 1}),
-            ("get", "/api/filaments", None),
-            ("get", "/api/debug/state", None),
-            ("get", "/api/ankerctl/server/reload", None),
-            ("get", "/api/camera/frame", None),
-            ("get", "/api/camera/stream", None),
-            ("get", "/api/camera/printer-stream", None),
-            ("get", "/api/snapshot", None),
-            ("get", "/api/files/printer", None),
-            ("get", "/api/files/printer/thumbnail?path=/tmp/udisk/udisk1/file.gcode", None),
-            ("get", "/api/history/1/thumbnail", None),
-        ]
-
         client = app.test_client()
         old_values, old_svc, old_filaments = _install_security_state(tmp_path)
         try:
             responses = []
-            for method, path, payload in protected_requests:
+            for method, path, payload in _PROTECTED_SECURITY_REQUESTS:
                 request_method = getattr(client, method)
                 kwargs = {"json": payload} if payload is not None else {}
                 responses.append((path, request_method(path, **kwargs).status_code))

--- a/tests/test_settings_and_notifications_api.py
+++ b/tests/test_settings_and_notifications_api.py
@@ -240,11 +240,17 @@ def test_camera_settings_endpoints_persist_per_printer():
     assert got.status_code == 200
     assert got.get_json()["camera"]["source"] == "printer"
     assert got.get_json()["camera"]["integration"]["enabled"] is False
+    assert "endpoint_url_with_api_key" not in got.get_json()["camera"]["integration"]
+    assert got.get_json()["camera"]["integration"]["api_key_required"] is True
+    assert "apikey=" not in got.get_json()["camera"]["integration"]["endpoint_url"]
     assert updated.status_code == 200
     camera = updated.get_json()["camera"]
     assert camera["source"] == "external"
     assert camera["effective_source"] == "external"
     assert camera["integration"]["enabled"] is True
+    assert "endpoint_url_with_api_key" not in camera["integration"]
+    assert camera["integration"]["api_key_required"] is True
+    assert "apikey=" not in camera["integration"]["endpoint_url"]
     assert camera["external"]["name"] == "Workbench Cam"
     assert camera["external"]["snapshot_url"] == "http://cam.local/snapshot.jpg"
     assert cfg.camera["per_printer"]["SN1"]["source"] == "external"
@@ -292,8 +298,13 @@ def test_camera_settings_endpoints_honor_requested_printer_index():
     assert second_printer.status_code == 200
     assert first_printer.get_json()["camera"]["source"] == "printer"
     assert first_printer.get_json()["camera"]["integration"]["enabled"] is False
+    assert "endpoint_url_with_api_key" not in first_printer.get_json()["camera"]["integration"]
+    assert first_printer.get_json()["camera"]["integration"]["api_key_required"] is True
     assert second_printer.get_json()["camera"]["source"] == "external"
     assert second_printer.get_json()["camera"]["integration"]["enabled"] is True
+    assert "endpoint_url_with_api_key" not in second_printer.get_json()["camera"]["integration"]
+    assert second_printer.get_json()["camera"]["integration"]["api_key_required"] is True
+    assert "apikey=" not in second_printer.get_json()["camera"]["integration"]["endpoint_url"]
     assert second_printer.get_json()["camera"]["external"]["name"] == "Thing 2 Cam"
     assert "SN1" not in cfg.camera["per_printer"]
     assert cfg.camera["per_printer"]["SN2"]["source"] == "external"

--- a/tests/test_settings_and_notifications_api.py
+++ b/tests/test_settings_and_notifications_api.py
@@ -222,6 +222,9 @@ def test_camera_settings_endpoints_persist_per_printer():
             json={
                 "camera": {
                     "source": "external",
+                    "integration": {
+                        "enabled": True,
+                    },
                     "external": {
                         "name": "Workbench Cam",
                         "snapshot_url": "http://cam.local/snapshot.jpg",
@@ -236,13 +239,16 @@ def test_camera_settings_endpoints_persist_per_printer():
 
     assert got.status_code == 200
     assert got.get_json()["camera"]["source"] == "printer"
+    assert got.get_json()["camera"]["integration"]["enabled"] is False
     assert updated.status_code == 200
     camera = updated.get_json()["camera"]
     assert camera["source"] == "external"
     assert camera["effective_source"] == "external"
+    assert camera["integration"]["enabled"] is True
     assert camera["external"]["name"] == "Workbench Cam"
     assert camera["external"]["snapshot_url"] == "http://cam.local/snapshot.jpg"
     assert cfg.camera["per_printer"]["SN1"]["source"] == "external"
+    assert cfg.camera["per_printer"]["SN1"]["integration"]["enabled"] is True
     assert "SN2" not in cfg.camera["per_printer"]
 
 
@@ -258,6 +264,9 @@ def test_camera_settings_endpoints_honor_requested_printer_index():
             json={
                 "camera": {
                     "source": "external",
+                    "integration": {
+                        "enabled": True,
+                    },
                     "external": {
                         "name": "Thing 2 Cam",
                         "snapshot_url": "http://thing2.local/snapshot.jpg",
@@ -282,10 +291,13 @@ def test_camera_settings_endpoints_honor_requested_printer_index():
     assert first_printer.status_code == 200
     assert second_printer.status_code == 200
     assert first_printer.get_json()["camera"]["source"] == "printer"
+    assert first_printer.get_json()["camera"]["integration"]["enabled"] is False
     assert second_printer.get_json()["camera"]["source"] == "external"
+    assert second_printer.get_json()["camera"]["integration"]["enabled"] is True
     assert second_printer.get_json()["camera"]["external"]["name"] == "Thing 2 Cam"
     assert "SN1" not in cfg.camera["per_printer"]
     assert cfg.camera["per_printer"]["SN2"]["source"] == "external"
+    assert cfg.camera["per_printer"]["SN2"]["integration"]["enabled"] is True
 
 
 def test_timelapse_settings_endpoints_persist_per_printer():

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -5598,6 +5598,17 @@ _PROTECTED_GET_PATHS = {
     "/api/timelapse-snapshots",
 }
 
+# Dynamic GET route families that must also require auth. These cannot be
+# represented safely as exact-path matches because they contain per-item
+# segments such as history entry ids or storage thumbnail lookups.
+_PROTECTED_GET_PREFIXES = (
+    "/api/debug/",
+    "/api/timelapse/",
+    "/api/timelapse-snapshot/",
+    "/api/history/",
+    "/api/files/printer",
+)
+
 # POST endpoints needed for initial printer setup (config import / login)
 _SETUP_PATHS = {
     "/api/ankerctl/config/upload",
@@ -5706,14 +5717,16 @@ def _check_api_key():
     if header_key and secrets.compare_digest(header_key, api_key):
         return None
 
-    # Allow read-only (GET/HEAD/OPTIONS) unless the path is explicitly protected.
-    # Also protect any path under /api/debug/ (prefix match for dynamic segments).
-    is_debug_path = request.path.startswith("/api/debug/")
-    is_timelapse_path = (
-        request.path.startswith("/api/timelapse/")
-        or request.path.startswith("/api/timelapse-snapshot/")
+    # Allow read-only (GET/HEAD/OPTIONS) unless the path is explicitly protected
+    # or belongs to a protected dynamic route family.
+    is_protected_get_prefix = any(
+        request.path.startswith(prefix) for prefix in _PROTECTED_GET_PREFIXES
     )
-    if request.method in ("GET", "HEAD", "OPTIONS") and request.path not in _PROTECTED_GET_PATHS and not is_debug_path and not is_timelapse_path:
+    if (
+        request.method in ("GET", "HEAD", "OPTIONS")
+        and request.path not in _PROTECTED_GET_PATHS
+        and not is_protected_get_prefix
+    ):
         return None
 
     # Allow setup endpoints when no printer is configured yet

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -774,6 +774,53 @@ def _build_history_store(printer_index=None, all_printers=False):
     )
 
 
+def _configured_printer_name_map(cfg=None):
+    if cfg is None:
+        config = app.config.get("config")
+        if not config:
+            return {}
+        with config.open() as opened_cfg:
+            return _configured_printer_name_map(opened_cfg)
+
+    names = {}
+    for index, printer in enumerate(getattr(cfg, "printers", []) or []):
+        names[index] = getattr(printer, "name", None) or f"Printer {index + 1}"
+    return names
+
+
+def _collect_all_printer_timelapse_media(kind):
+    printer_names = _configured_printer_name_map()
+    items = []
+    enabled = False
+
+    for printer_index, printer_name in printer_names.items():
+        with borrow_mqtt(printer_index) as mqtt:
+            if not mqtt:
+                continue
+            timelapse = getattr(mqtt, "timelapse", None)
+            if not timelapse:
+                continue
+            enabled = enabled or bool(getattr(timelapse, "enabled", False))
+            if kind == "videos":
+                records = timelapse.list_videos()
+            else:
+                records = timelapse.list_snapshots()
+            for record in records or []:
+                item = dict(record)
+                item["printer_index"] = printer_index
+                item["printer_name"] = printer_name
+                items.append(item)
+
+    items.sort(
+        key=lambda item: (
+            str(item.get("created_at") or ""),
+            str(item.get("filename") or item.get("id") or ""),
+        ),
+        reverse=True,
+    )
+    return items, enabled
+
+
 @contextmanager
 def borrow_pppp(printer_index=None, ready=True):
     last_error = None
@@ -5279,6 +5326,9 @@ def app_api_filament_service_swap_cancel():
 @app.get("/api/timelapses")
 def app_api_timelapses():
     """List available timelapse videos."""
+    if _requested_all_printers():
+        videos, enabled = _collect_all_printer_timelapse_media("videos")
+        return {"videos": videos, "enabled": enabled}
     printer_index = _requested_printer_index()
     with borrow_mqtt(printer_index) as mqtt:
         if not mqtt:
@@ -5291,6 +5341,9 @@ def app_api_timelapses():
 @app.get("/api/timelapse-snapshots")
 def app_api_timelapse_snapshots():
     """List available timelapse snapshot collections and frames."""
+    if _requested_all_printers():
+        collections, enabled = _collect_all_printer_timelapse_media("snapshots")
+        return {"collections": collections, "enabled": enabled}
     printer_index = _requested_printer_index()
     with borrow_mqtt(printer_index) as mqtt:
         if not mqtt:

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3871,20 +3871,131 @@ def _validate_printer_storage_path(file_path, source=None):
     return normalized_path, inferred_source
 
 
-def _fetch_remote_image(preview_url, timeout=10.0):
-    from urllib.error import HTTPError, URLError
-    from urllib.request import Request, urlopen
+_PREVIEW_IMAGE_MAX_BYTES = 5 * 1024 * 1024
+_PREVIEW_IMAGE_READ_CHUNK_BYTES = 64 * 1024
+_PREVIEW_IMAGE_ALLOWED_HOST_SUFFIXES = (
+    "ankermake.com",
+    "eufymake.com",
+)
+
+
+def _allowed_preview_image_hosts():
+    allowed_hosts = set()
+    config_manager = app.config.get("config")
+    if not config_manager:
+        return allowed_hosts
+
+    try:
+        with config_manager.open() as cfg:
+            if not cfg:
+                return allowed_hosts
+            for printer in getattr(cfg, "printers", []) or []:
+                for host in getattr(printer, "api_hosts", []) or []:
+                    host = str(host or "").strip().lower().rstrip(".")
+                    if host:
+                        allowed_hosts.add(host)
+    except Exception as exc:
+        log.debug(f"Preview image allowlist unavailable: {exc}")
+
+    return allowed_hosts
+
+
+def _validate_preview_image_url(preview_url):
+    from urllib.parse import urlparse
 
     preview_url = str(preview_url or "").strip()
-    if not preview_url.startswith(("http://", "https://")):
+    if not preview_url:
         raise ValueError("Invalid preview URL")
 
-    request_obj = Request(preview_url, headers={"User-Agent": "ankerctl"})
+    parsed = urlparse(preview_url)
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+
+    if scheme != "https":
+        raise ValueError("Preview URL must use HTTPS")
+    if not hostname:
+        raise ValueError("Invalid preview URL")
+    if parsed.username or parsed.password:
+        raise ValueError("Preview URL credentials are not allowed")
+    if parsed.port not in (None, 443):
+        raise ValueError("Preview URL port is not allowed")
+
+    allowed_hosts = _allowed_preview_image_hosts()
+    if hostname in allowed_hosts:
+        return preview_url
+    if any(
+        hostname == suffix or hostname.endswith("." + suffix)
+        for suffix in _PREVIEW_IMAGE_ALLOWED_HOST_SUFFIXES
+    ):
+        return preview_url
+
+    raise ValueError("Preview URL host is not allowed")
+
+
+def _preview_image_content_type(headers):
+    raw_content_type = headers.get("Content-Type") if headers else None
+    if not raw_content_type:
+        return "image/jpeg"
+
+    content_type = raw_content_type.split(";", 1)[0].strip().lower()
+    if not content_type.startswith("image/"):
+        raise RuntimeError("Preview image response was not an image")
+    return content_type or "image/jpeg"
+
+
+def _read_bounded_remote_image(remote, *, max_bytes):
+    content_length = None
+    if getattr(remote, "headers", None):
+        content_length = remote.headers.get("Content-Length")
+    if content_length:
+        try:
+            if int(content_length) > max_bytes:
+                raise RuntimeError(
+                    f"Preview image exceeded the {max_bytes} byte limit"
+                )
+        except ValueError:
+            pass
+
+    chunks = []
+    total = 0
+    while True:
+        chunk = remote.read(min(_PREVIEW_IMAGE_READ_CHUNK_BYTES, max_bytes - total + 1))
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise RuntimeError(
+                f"Preview image exceeded the {max_bytes} byte limit"
+            )
+        chunks.append(chunk)
+
+    return b"".join(chunks)
+
+
+def _fetch_remote_image(preview_url, timeout=10.0):
+    from urllib.error import HTTPError, URLError
+    from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+    class _PreviewImageRedirectHandler(HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            _validate_preview_image_url(newurl)
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+    preview_url = _validate_preview_image_url(preview_url)
+    opener = build_opener(_PreviewImageRedirectHandler())
+    request_obj = Request(
+        preview_url,
+        headers={
+            "User-Agent": "ankerctl",
+            "Accept": "image/*",
+        },
+    )
     try:
-        with urlopen(request_obj, timeout=timeout) as remote:
-            data = remote.read()
-            content_type = remote.headers.get_content_type() if remote.headers else None
-            return data, (content_type or "image/jpeg")
+        with opener.open(request_obj, timeout=timeout) as remote:
+            _validate_preview_image_url(getattr(remote, "geturl", lambda: preview_url)())
+            data = _read_bounded_remote_image(remote, max_bytes=_PREVIEW_IMAGE_MAX_BYTES)
+            content_type = _preview_image_content_type(getattr(remote, "headers", None))
+            return data, content_type
     except HTTPError as exc:
         raise RuntimeError(f"Preview image request failed with HTTP {exc.code}") from exc
     except URLError as exc:

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -418,11 +418,7 @@ def _camera_settings_for_response(camera_config):
         base_url,
         printer_index=printer_index,
     )
-    integration["endpoint_url_with_api_key"] = web.camera.build_printer_integration_stream_url(
-        base_url,
-        api_key=app.config.get("api_key"),
-        printer_index=printer_index,
-    )
+    integration["api_key_required"] = bool(app.config.get("api_key"))
     integration["stream_format"] = "H.264 / fragmented MP4 (ffmpeg remux)"
     integration["ffmpeg_available"] = _ffmpeg_available()
     camera_payload["integration"] = integration

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -53,6 +53,7 @@ class _AccessLogNoiseFilter(logging.Filter):
         '"GET /api/printer/runtime-state',
         '"GET /api/camera/frame',
         '"GET /api/camera/stream',
+        '"GET /api/camera/printer-stream',
         '"GET /api/filaments/service/swap',
     )
 
@@ -404,6 +405,30 @@ def _resolve_camera_settings(cfg=None, printer_index=None):
     return web.camera.resolve_camera_settings(cfg, printer_index=printer_index)
 
 
+def _camera_settings_for_response(camera_config):
+    camera_payload = json.loads(json.dumps(camera_config or {}))
+    integration = dict(camera_payload.get("integration") or {})
+    printer_index = camera_payload.get("printer_index", app.config.get("printer_index", 0))
+    base_url = request.host_url.rstrip("/") if has_request_context() else ""
+    integration["endpoint_path"] = web.camera.build_printer_integration_stream_url(
+        "",
+        printer_index=printer_index,
+    )
+    integration["endpoint_url"] = web.camera.build_printer_integration_stream_url(
+        base_url,
+        printer_index=printer_index,
+    )
+    integration["endpoint_url_with_api_key"] = web.camera.build_printer_integration_stream_url(
+        base_url,
+        api_key=app.config.get("api_key"),
+        printer_index=printer_index,
+    )
+    integration["stream_format"] = "H.264 / fragmented MP4 (ffmpeg remux)"
+    integration["ffmpeg_available"] = _ffmpeg_available()
+    camera_payload["integration"] = integration
+    return camera_payload
+
+
 def _camera_feature_available(cfg=None, printer_index=None):
     camera_settings = _resolve_camera_settings(cfg, printer_index=printer_index)
     return bool(camera_settings.get("feature_available"))
@@ -411,6 +436,8 @@ def _camera_feature_available(cfg=None, printer_index=None):
 
 def _requested_printer_index(default=None):
     fallback = app.config.get("printer_index", 0) if default is None else default
+    if fallback is None:
+        fallback = 0
     if not has_request_context():
         return fallback
     raw = request.args.get("printer_index", default=fallback, type=int)
@@ -1094,7 +1121,7 @@ FILAMENT_SWAP_ADVANCED_CONFIG_DEFAULT = {
     "commands": {
         "set_nozzle_temp": "M104 S{temp_c}",
         "cooldown_nozzle": "M104 S0",
-        "home_all": "native:home_all",
+        "home_all": "native:home_z",
         "relative_mode": "G91",
         "z_lift": "G1 Z{z_lift_mm} F{z_feedrate}",
         "wait_for_moves": "M400",
@@ -1249,6 +1276,15 @@ def _coerce_filament_swap_command(value):
     return str(value or "")
 
 
+def _migrate_filament_swap_command(command_name, command_value):
+    command_name = str(command_name or "")
+    command_value = _coerce_filament_swap_command(command_value)
+    normalized = command_value.strip().lower()
+    if command_name == "home_all" and normalized in {"native:home_all", "native:all"}:
+        return "native:home_z"
+    return command_value
+
+
 def _coerce_filament_swap_setting(value, default):
     if isinstance(default, bool):
         return _filament_service_bool(value)
@@ -1275,7 +1311,11 @@ def _merge_filament_swap_advanced_config(loaded):
     user_commands = loaded.get("commands") or {}
     if isinstance(user_commands, dict):
         for key, value in user_commands.items():
-            commands[str(key)] = _coerce_filament_swap_command(value)
+            key = str(key)
+            migrated_command = _migrate_filament_swap_command(key, value)
+            if commands.get(key) != migrated_command:
+                changed = True
+            commands[key] = migrated_command
     else:
         changed = True
     if merged.get("commands") != commands:
@@ -1873,7 +1913,8 @@ def _run_legacy_swap_unload(token):
                 printer_index=printer_index,
                 phase="homing",
                 message=(
-                    f"Homing all axes before filament swap. Waiting {home_pause_s:g}s before raising Z."
+                    f"Running the native Home Z quick-home sequence before filament swap. "
+                    f"Waiting {home_pause_s:g}s before raising Z."
                 ),
                 home_pause_started_at=home_pause_started_at,
                 home_pause_until=home_pause_started_at + max(0.0, float(home_pause_s or 0.0)),
@@ -3273,7 +3314,7 @@ def app_api_settings_camera():
         if not cfg:
             return {"error": "No printers configured"}, 400
         camera_config = _resolve_camera_settings(cfg, printer_index=printer_index)
-    return {"camera": camera_config}
+    return {"camera": _camera_settings_for_response(camera_config)}
 
 
 @app.post("/api/settings/camera")
@@ -3296,7 +3337,7 @@ def app_api_settings_camera_update():
         except ValueError as exc:
             return {"error": str(exc)}, 400
 
-    return {"status": "ok", "camera": camera_config}
+    return {"status": "ok", "camera": _camera_settings_for_response(camera_config)}
 
 
 @app.post("/api/settings/launcher-bat")
@@ -4240,6 +4281,109 @@ def app_api_camera_stream():
 
     response = Response(generate(), mimetype="multipart/x-mixed-replace; boundary=frame")
     response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@app.get("/api/camera/printer-stream")
+def app_api_camera_printer_stream():
+    """Return a Frigate-friendly printer camera stream remuxed to fragmented MP4."""
+    printer_index = _requested_printer_index()
+
+    if not app.config["login"] or app.config.get("unsupported_device"):
+        return {"error": "Printer camera is not available for this printer."}, 400
+
+    camera_settings = _resolve_camera_settings(printer_index=printer_index)
+    if not _printer_video_supported(printer_index=printer_index):
+        return {"error": "This printer does not expose a built-in camera."}, 400
+
+    integration = (camera_settings or {}).get("integration") or {}
+    if not integration.get("enabled"):
+        return {"error": "Printer integration stream is disabled in Setup -> Camera."}, 400
+
+    ffmpeg_path = _ffmpeg_path()
+    if not ffmpeg_path:
+        return {"error": "ffmpeg not installed"}, 500
+
+    vq = get_video_service(printer_index)
+    if not vq:
+        return {"error": "Printer video service unavailable."}, 503
+
+    try:
+        vq.integration_client_connected()
+        vq.await_ready()
+        proc = web.camera.open_printer_fmp4_stream(ffmpeg_path)
+    except ServiceStoppedError:
+        try:
+            vq.integration_client_disconnected()
+        except Exception:
+            pass
+        return {"error": "Printer video service is unavailable."}, 503
+    except web.camera.CameraCaptureError as exc:
+        try:
+            vq.integration_client_disconnected()
+        except Exception:
+            pass
+        return {"error": str(exc)}, 502
+
+    def generate():
+        stop_event = threading.Event()
+
+        def _pump_video():
+            try:
+                for msg in stream_videoqueue(printer_index, maxsize=VIDEO_STREAM_QUEUE_MAX):
+                    if stop_event.is_set():
+                        break
+                    payload = getattr(msg, "data", None)
+                    if not payload:
+                        continue
+                    stdin = getattr(proc, "stdin", None)
+                    if stdin is None:
+                        break
+                    try:
+                        stdin.write(payload)
+                        stdin.flush()
+                    except (BrokenPipeError, OSError, ValueError):
+                        break
+            finally:
+                stdin = getattr(proc, "stdin", None)
+                if stdin is not None:
+                    try:
+                        stdin.close()
+                    except Exception:
+                        pass
+
+        writer = threading.Thread(
+            target=_pump_video,
+            daemon=True,
+            name=f"printer-stream-pump-{printer_index}",
+        )
+        writer.start()
+
+        try:
+            for chunk in web.camera.iter_process_chunks(proc):
+                if chunk:
+                    yield chunk
+        finally:
+            stop_event.set()
+            stdin = getattr(proc, "stdin", None)
+            if stdin is not None:
+                try:
+                    stdin.close()
+                except Exception:
+                    pass
+            web.camera.stop_subprocess(proc)
+            try:
+                writer.join(timeout=1.0)
+            except RuntimeError:
+                pass
+            try:
+                vq.integration_client_disconnected()
+            except Exception as exc:
+                log.debug("Printer integration stream cleanup failed: %s", exc)
+
+    response = Response(generate(), mimetype="video/mp4")
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["X-Accel-Buffering"] = "no"
     return response
 
 
@@ -5430,6 +5574,7 @@ _PROTECTED_GET_PATHS = {
     "/api/debug/services",
     "/api/camera/frame",
     "/api/camera/stream",
+    "/api/camera/printer-stream",
     "/api/snapshot",
     # Sensitive credential exposure: HA MQTT password, Apprise URLs/keys
     "/api/settings/mqtt",

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -456,6 +456,26 @@ def _requested_printer_index(default=None):
     return fallback
 
 
+def _requested_all_printers():
+    if not has_request_context():
+        return False
+    raw = str(request.args.get("all_printers", "") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _printer_name_for_index(printer_index, cfg=None):
+    if printer_index is None:
+        return None
+    try:
+        normalized = int(printer_index)
+    except (TypeError, ValueError):
+        return None
+    printer = _active_printer(cfg, printer_index=normalized)
+    if printer is None:
+        return f"Printer {normalized + 1}"
+    return getattr(printer, "name", None) or f"Printer {normalized + 1}"
+
+
 def _printer_video_supported(cfg=None, printer_index=None):
     active_index = app.config.get("printer_index", 0)
     if cfg is None and (printer_index is None or printer_index == active_index):
@@ -732,6 +752,26 @@ def borrow_mqtt(printer_index=None):
     if last_error is not None:
         raise last_error
     yield None
+
+
+def _build_history_store(printer_index=None, all_printers=False):
+    from web.service.history import PrintHistory
+
+    config_manager = app.config.get("config")
+    config_root = getattr(config_manager, "config_root", None)
+    db_path = None
+    if config_root:
+        db_path = os.path.join(str(config_root), "history.db")
+    if not db_path:
+        with borrow_mqtt(printer_index) as mqtt:
+            history = getattr(mqtt, "history", None) if mqtt else None
+            db_path = getattr(history, "_db_path", None)
+    if not db_path:
+        return None
+    return PrintHistory(
+        db_path=db_path,
+        printer_index=None if all_printers else _service_printer_index(printer_index),
+    )
 
 
 @contextmanager
@@ -4553,25 +4593,68 @@ def app_api_snapshot():
 def app_api_history():
     """Return print history as JSON with pagination."""
     printer_index = _requested_printer_index()
+    all_printers = _requested_all_printers()
     limit = request.args.get("limit", 50, type=int)
     offset = request.args.get("offset", 0, type=int)
     # Clamp parameters to safe ranges to prevent excessive queries or errors
     limit = max(1, min(limit, 500))
     offset = max(0, offset)
-    with borrow_mqtt(printer_index) as mqtt:
-        if not mqtt:
+    if all_printers:
+        history = _build_history_store(printer_index=printer_index, all_printers=True)
+        if not history:
             return {"entries": [], "total": 0}
-        entries = mqtt.history.get_history(limit=limit, offset=offset)
-        total = mqtt.history.get_count()
+        entries = history.get_history(limit=limit, offset=offset)
+        total = history.get_count()
+    else:
+        with borrow_mqtt(printer_index) as mqtt:
+            if not mqtt:
+                return {"entries": [], "total": 0}
+            entries = mqtt.history.get_history(limit=limit, offset=offset)
+            total = mqtt.history.get_count()
     serialized_entries = []
-    for entry in entries:
-        item = dict(entry)
-        item["thumbnail_url"] = (
-            url_for("app_api_history_thumbnail", entry_id=item["id"], printer_index=printer_index)
-            if item.get("thumbnail_available")
-            else None
-        )
-        serialized_entries.append(item)
+    config_manager = app.config.get("config")
+    if config_manager:
+        with config_manager.open() as cfg:
+            for entry in entries:
+                item = dict(entry)
+                item["printer_name"] = _printer_name_for_index(item.get("printer_index"), cfg=cfg)
+                if all_printers and item.get("printer_index") is None:
+                    item["can_reprint"] = False
+                item_id = item.get("id")
+                thumbnail_params = {"entry_id": item_id} if item_id is not None else None
+                if thumbnail_params is not None:
+                    if all_printers:
+                        thumbnail_params["all_printers"] = 1
+                        if item.get("printer_index") is not None:
+                            thumbnail_params["printer_index"] = item["printer_index"]
+                    else:
+                        thumbnail_params["printer_index"] = printer_index
+                item["thumbnail_url"] = (
+                    url_for("app_api_history_thumbnail", **thumbnail_params)
+                    if item.get("thumbnail_available") and thumbnail_params is not None
+                    else None
+                )
+                serialized_entries.append(item)
+    else:
+        for entry in entries:
+            item = dict(entry)
+            if all_printers and item.get("printer_index") is None:
+                item["can_reprint"] = False
+            item_id = item.get("id")
+            thumbnail_params = {"entry_id": item_id} if item_id is not None else None
+            if thumbnail_params is not None:
+                if all_printers:
+                    thumbnail_params["all_printers"] = 1
+                    if item.get("printer_index") is not None:
+                        thumbnail_params["printer_index"] = item["printer_index"]
+                else:
+                    thumbnail_params["printer_index"] = printer_index
+            item["thumbnail_url"] = (
+                url_for("app_api_history_thumbnail", **thumbnail_params)
+                if item.get("thumbnail_available") and thumbnail_params is not None
+                else None
+            )
+            serialized_entries.append(item)
     return {"entries": serialized_entries, "total": total}
 
 
@@ -4579,14 +4662,23 @@ def app_api_history():
 def app_api_history_clear():
     """Clear all print history."""
     printer_index = _requested_printer_index()
-    with borrow_mqtt(printer_index) as mqtt:
-        mqtt.history.clear()
+    if _requested_all_printers():
+        history = _build_history_store(printer_index=printer_index, all_printers=True)
+        if not history:
+            return {"error": "Service unavailable"}, 503
+        history.clear()
+    else:
+        with borrow_mqtt(printer_index) as mqtt:
+            if not mqtt:
+                return {"error": "Service unavailable"}, 503
+            mqtt.history.clear()
     return {"status": "ok"}
 
 
 @app.post("/api/history/delete")
 def app_api_history_delete_selected():
     printer_index = _requested_printer_index()
+    all_printers = _requested_all_printers()
     payload = request.get_json(silent=True) or {}
     raw_ids = payload.get("ids")
     if not isinstance(raw_ids, list):
@@ -4604,14 +4696,24 @@ def app_api_history_delete_selected():
     if not entry_ids:
         return {"error": "No history entries were selected"}, 400
 
-    with borrow_mqtt(printer_index) as mqtt:
-        if not mqtt:
+    if all_printers:
+        history = _build_history_store(printer_index=printer_index, all_printers=True)
+        if not history:
             return {"error": "Service unavailable"}, 503
-        entries = [mqtt.history.get_entry(entry_id) for entry_id in entry_ids]
+        entries = [history.get_entry(entry_id) for entry_id in entry_ids]
         active = [entry for entry in entries if entry and entry.get("status") == "started"]
         if active:
             return {"error": "Cannot delete an in-progress history entry"}, 409
-        deleted = mqtt.history.delete_entries(entry_ids)
+        deleted = history.delete_entries(entry_ids)
+    else:
+        with borrow_mqtt(printer_index) as mqtt:
+            if not mqtt:
+                return {"error": "Service unavailable"}, 503
+            entries = [mqtt.history.get_entry(entry_id) for entry_id in entry_ids]
+            active = [entry for entry in entries if entry and entry.get("status") == "started"]
+            if active:
+                return {"error": "Cannot delete an in-progress history entry"}, 409
+            deleted = mqtt.history.delete_entries(entry_ids)
 
     return {
         "status": "ok",
@@ -4625,14 +4727,24 @@ def app_api_history_thumbnail(entry_id):
     from flask import send_file
 
     printer_index = _requested_printer_index()
-    with borrow_mqtt(printer_index) as mqtt:
-        if not mqtt:
+    if _requested_all_printers():
+        history = _build_history_store(printer_index=printer_index, all_printers=True)
+        if not history:
             return {"error": "Service unavailable"}, 503
-        entry = mqtt.history.get_entry(entry_id)
+        entry = history.get_entry(entry_id)
         if not entry:
             return {"error": "History entry not found"}, 404
-        thumbnail_path = mqtt.history.get_thumbnail_path(entry_id)
+        thumbnail_path = history.get_thumbnail_path(entry_id)
         preview_url = entry.get("preview_url")
+    else:
+        with borrow_mqtt(printer_index) as mqtt:
+            if not mqtt:
+                return {"error": "Service unavailable"}, 503
+            entry = mqtt.history.get_entry(entry_id)
+            if not entry:
+                return {"error": "History entry not found"}, 404
+            thumbnail_path = mqtt.history.get_thumbnail_path(entry_id)
+            preview_url = entry.get("preview_url")
 
     if thumbnail_path:
         response = send_file(
@@ -4653,19 +4765,39 @@ def app_api_history_thumbnail(entry_id):
 @app.post("/api/history/<int:entry_id>/reprint")
 def app_api_history_reprint(entry_id):
     user_name = request.headers.get("User-Agent", "ankerctl").split(url_for('app_root'))[0]
-    printer_index = _requested_printer_index()
+    requested_printer_index = _requested_printer_index()
+    all_printers = _requested_all_printers()
+
+    if all_printers:
+        history = _build_history_store(printer_index=requested_printer_index, all_printers=True)
+        if not history:
+            return {"error": "Service unavailable"}, 503
+        entry = history.get_entry(entry_id)
+        if not entry:
+            return {"error": "History entry not found"}, 404
+        printer_index = entry.get("printer_index")
+        if printer_index is None:
+            return {"error": "This history entry is missing a printer assignment and cannot be reprinted"}, 409
+        archive_path = history.get_archive_path(entry_id)
+        if not archive_path:
+            return {"error": "No archived GCode is available for this history entry"}, 404
+    else:
+        printer_index = requested_printer_index
+        with borrow_mqtt(printer_index) as mqtt:
+            if not mqtt:
+                return {"error": "Service unavailable"}, 503
+            entry = mqtt.history.get_entry(entry_id)
+            if not entry:
+                return {"error": "History entry not found"}, 404
+            archive_path = mqtt.history.get_archive_path(entry_id)
+            if not archive_path:
+                return {"error": "No archived GCode is available for this history entry"}, 404
 
     with borrow_mqtt(printer_index) as mqtt:
         if not mqtt:
             return {"error": "Service unavailable"}, 503
         if mqtt.is_printing or mqtt.has_pending_print_start or mqtt.is_preparing_print:
             return {"error": "Printer is already busy with another print job"}, 409
-        entry = mqtt.history.get_entry(entry_id)
-        if not entry:
-            return {"error": "History entry not found"}, 404
-        archive_path = mqtt.history.get_archive_path(entry_id)
-        if not archive_path:
-            return {"error": "No archived GCode is available for this history entry"}, 404
 
     with app.config["config"].open() as cfg:
         rate_limit_mbps, rate_limit_source = cli.util.resolve_upload_rate_mbps_with_source(cfg)

--- a/web/camera.py
+++ b/web/camera.py
@@ -17,12 +17,18 @@ def _scrub_url_credentials(text):
 CAMERA_SOURCE_PRINTER = "printer"
 CAMERA_SOURCE_EXTERNAL = "external"
 DEFAULT_EXTERNAL_REFRESH_SEC = 3
+DEFAULT_PRINTER_INTEGRATION_ENABLED = False
+PRINTER_INTEGRATION_STREAM_PATH = "/api/camera/printer-stream"
+PRINTER_STREAM_INPUT_FPS = 15
 PRINTERS_WITHOUT_CAMERA = {"V8110"}
 RTSP_LOW_LATENCY_INPUT_ARGS = ["-fflags", "nobuffer", "-probesize", "32768", "-analyzeduration", "0"]
 _ALLOWED_CAMERA_URL_SCHEMES = {"http", "https", "rtsp", "rtmp"}
 _MJPEG_STALE_READ_TIMEOUT_SEC = 10.0
 _MJPEG_READER_QUEUE_SIZE = 4
 _MJPEG_READ_DONE = object()
+_PROCESS_STREAM_STALE_READ_TIMEOUT_SEC = 15.0
+_PROCESS_STREAM_READER_QUEUE_SIZE = 8
+_PROCESS_STREAM_READ_DONE = object()
 
 
 class CameraCaptureError(RuntimeError):
@@ -49,6 +55,9 @@ def default_camera_settings():
             "stream_url": "",
             "snapshot_url": "",
             "refresh_sec": DEFAULT_EXTERNAL_REFRESH_SEC,
+        },
+        "integration": {
+            "enabled": DEFAULT_PRINTER_INTEGRATION_ENABLED,
         },
     }
 
@@ -86,6 +95,13 @@ def normalize_external_camera_settings(data):
     }
 
 
+def normalize_printer_integration_settings(data):
+    merged = cli.model.merge_dict_defaults(data, default_camera_settings()["integration"])
+    return {
+        "enabled": bool(merged.get("enabled")),
+    }
+
+
 def _printer_from_config(cfg, printer_index):
     printers = getattr(cfg, "printers", None) or []
     if printer_index < 0 or printer_index >= len(printers):
@@ -111,6 +127,7 @@ def resolve_camera_settings(cfg, printer_index=0, source_override=None):
     if source_override is not None:
         source = _normalize_source(source_override, default=configured_source)
     external = normalize_external_camera_settings(entry.get("external"))
+    integration = normalize_printer_integration_settings(entry.get("integration"))
     external_configured = bool(external["stream_url"] or external["snapshot_url"])
 
     effective_source = None
@@ -146,6 +163,7 @@ def resolve_camera_settings(cfg, printer_index=0, source_override=None):
             **external,
             "configured": external_configured,
         },
+        "integration": integration,
     }
 
 
@@ -160,10 +178,17 @@ def update_camera_settings(cfg, printer_index, payload):
     current = resolve_camera_settings(cfg, printer_index)
     source = _normalize_source(payload.get("source", current.get("source")))
     external_payload = payload.get("external")
+    integration_payload = payload.get("integration")
     merged_external = normalize_external_camera_settings(
         cli.model.merge_dict_defaults(
             external_payload if isinstance(external_payload, dict) else {},
             current.get("external"),
+        )
+    )
+    merged_integration = normalize_printer_integration_settings(
+        cli.model.merge_dict_defaults(
+            integration_payload if isinstance(integration_payload, dict) else {},
+            current.get("integration"),
         )
     )
     _validate_camera_url(merged_external.get("stream_url"), "stream_url")
@@ -176,6 +201,7 @@ def update_camera_settings(cfg, printer_index, payload):
     per_printer[printer.sn] = {
         "source": source,
         "external": merged_external,
+        "integration": merged_integration,
     }
     root["per_printer"] = per_printer
     cfg.camera = root
@@ -195,6 +221,7 @@ def runtime_camera_state(camera_settings):
         "external_configured": bool(external.get("configured")),
         "external_refresh_sec": external.get("refresh_sec") or DEFAULT_EXTERNAL_REFRESH_SEC,
         "external_stream_preview": bool(stream_url),
+        "integration_enabled": bool((camera_settings.get("integration") or {}).get("enabled")),
     }
 
 
@@ -210,6 +237,19 @@ def build_printer_video_url(host, port, api_key=None, *, for_timelapse=False, pr
     query = []
     if for_timelapse:
         query.append("for_timelapse=1")
+    if printer_index is not None:
+        query.append(f"printer_index={int(printer_index)}")
+    if api_key:
+        query.append(f"apikey={quote(api_key, safe='')}")
+    if query:
+        url = f"{url}?{'&'.join(query)}"
+    return url
+
+
+def build_printer_integration_stream_url(base_url, api_key=None, *, printer_index=None):
+    base = str(base_url or "").rstrip("/")
+    url = f"{base}{PRINTER_INTEGRATION_STREAM_PATH}" if base else PRINTER_INTEGRATION_STREAM_PATH
+    query = []
     if printer_index is not None:
         query.append(f"printer_index={int(printer_index)}")
     if api_key:
@@ -318,6 +358,48 @@ def open_external_mjpeg_stream(ffmpeg_path, input_url, *, scale=None):
         raise CameraCaptureError(f"External camera stream could not start ffmpeg: {exc}") from exc
 
 
+def open_printer_fmp4_stream(ffmpeg_path, *, input_fps=PRINTER_STREAM_INPUT_FPS):
+    try:
+        fps = max(1, int(float(input_fps)))
+    except (TypeError, ValueError):
+        fps = PRINTER_STREAM_INPUT_FPS
+
+    cmd = [
+        ffmpeg_path,
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-fflags",
+        "+genpts",
+        "-r",
+        str(fps),
+        "-f",
+        "h264",
+        "-i",
+        "pipe:0",
+        "-an",
+        "-c:v",
+        "copy",
+        "-movflags",
+        "+frag_keyframe+empty_moov+default_base_moof",
+        "-frag_duration",
+        "1000000",
+        "-f",
+        "mp4",
+        "pipe:1",
+    ]
+
+    try:
+        return subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        raise CameraCaptureError(f"Printer integration stream could not start ffmpeg: {exc}") from exc
+
+
 def iter_mjpeg_frames(proc, *, chunk_size=8192, max_buffer=4 * 1024 * 1024, stale_timeout=_MJPEG_STALE_READ_TIMEOUT_SEC):
     stdout = getattr(proc, "stdout", None)
     if stdout is None:
@@ -385,6 +467,63 @@ def iter_mjpeg_frames(proc, *, chunk_size=8192, max_buffer=4 * 1024 * 1024, stal
             yield frame
 
 
+def iter_process_chunks(
+    proc,
+    *,
+    stream_attr="stdout",
+    chunk_size=65536,
+    stale_timeout=_PROCESS_STREAM_STALE_READ_TIMEOUT_SEC,
+):
+    stream = getattr(proc, stream_attr, None)
+    if stream is None:
+        return
+
+    chunks = queue.Queue(maxsize=_PROCESS_STREAM_READER_QUEUE_SIZE)
+
+    def _reader():
+        try:
+            while True:
+                chunk = stream.read(chunk_size)
+                while True:
+                    try:
+                        chunks.put(chunk, timeout=0.5)
+                        break
+                    except queue.Full:
+                        if getattr(proc, "poll", lambda: None)() is not None:
+                            return
+                if not chunk:
+                    break
+        except Exception as exc:
+            try:
+                chunks.put(exc, timeout=0.5)
+            except queue.Full:
+                pass
+        finally:
+            try:
+                chunks.put(_PROCESS_STREAM_READ_DONE, timeout=0.5)
+            except queue.Full:
+                pass
+
+    threading.Thread(target=_reader, daemon=True, name=f"{stream_attr}-reader").start()
+
+    while True:
+        try:
+            read_timeout = max(0.001, float(stale_timeout))
+        except (TypeError, ValueError):
+            read_timeout = _PROCESS_STREAM_STALE_READ_TIMEOUT_SEC
+        try:
+            chunk = chunks.get(timeout=read_timeout)
+        except queue.Empty:
+            break
+        if chunk is _PROCESS_STREAM_READ_DONE:
+            break
+        if isinstance(chunk, Exception):
+            break
+        if not chunk:
+            break
+        yield chunk
+
+
 def stop_external_mjpeg_stream(proc):
     if not proc:
         return
@@ -397,6 +536,10 @@ def stop_external_mjpeg_stream(proc):
                 proc.kill()
     except OSError:
         pass
+
+
+def stop_subprocess(proc):
+    stop_external_mjpeg_stream(proc)
 
 
 def capture_camera_snapshot_to_file(

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -172,14 +172,34 @@ class PrintHistory:
         """Remove old entries beyond retention and max count."""
         if self._retention_days > 0:
             cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=self._retention_days)).isoformat()
-            conn.execute("DELETE FROM print_history WHERE started_at < ?", (cutoff,))
+            if self._printer_index is None:
+                conn.execute("DELETE FROM print_history WHERE started_at < ?", (cutoff,))
+            else:
+                conn.execute(
+                    "DELETE FROM print_history WHERE started_at < ? AND printer_index=?",
+                    (cutoff, self._printer_index),
+                )
 
         if self._max_entries > 0:
-            conn.execute("""
-                DELETE FROM print_history WHERE id NOT IN (
-                    SELECT id FROM print_history ORDER BY id DESC LIMIT ?
+            if self._printer_index is None:
+                conn.execute("""
+                    DELETE FROM print_history WHERE id NOT IN (
+                        SELECT id FROM print_history ORDER BY id DESC LIMIT ?
+                    )
+                """, (self._max_entries,))
+            else:
+                conn.execute(
+                    """
+                    DELETE FROM print_history
+                    WHERE printer_index=? AND id NOT IN (
+                        SELECT id FROM print_history
+                        WHERE printer_index=?
+                        ORDER BY id DESC
+                        LIMIT ?
+                    )
+                    """,
+                    (self._printer_index, self._printer_index, self._max_entries),
                 )
-            """, (self._max_entries,))
         self._delete_unreferenced_archives(conn)
 
     def _ensure_archive_dir(self):
@@ -565,19 +585,32 @@ class PrintHistory:
         """Return recent print history as list of dicts."""
         with self._lock:
             with self._connect() as conn:
-                rows = conn.execute(
-                    "SELECT * FROM print_history ORDER BY id DESC LIMIT ? OFFSET ?",
-                    (limit, offset)
-                ).fetchall()
+                if self._printer_index is None:
+                    rows = conn.execute(
+                        "SELECT * FROM print_history ORDER BY id DESC LIMIT ? OFFSET ?",
+                        (limit, offset)
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT * FROM print_history WHERE printer_index=? ORDER BY id DESC LIMIT ? OFFSET ?",
+                        (self._printer_index, limit, offset)
+                    ).fetchall()
                 return [self._decorate_entry(r, conn=conn) for r in rows]
 
     def get_entry(self, entry_id):
         with self._lock:
             with self._connect() as conn:
-                row = conn.execute(
-                    "SELECT * FROM print_history WHERE id=?",
-                    (int(entry_id),),
-                ).fetchone()
+                entry_id = int(entry_id)
+                if self._printer_index is None:
+                    row = conn.execute(
+                        "SELECT * FROM print_history WHERE id=?",
+                        (entry_id,),
+                    ).fetchone()
+                else:
+                    row = conn.execute(
+                        "SELECT * FROM print_history WHERE id=? AND printer_index=?",
+                        (entry_id, self._printer_index),
+                    ).fetchone()
                 if not row:
                     return None
                 return self._decorate_entry(row, conn=conn)
@@ -629,7 +662,12 @@ class PrintHistory:
         """Return total number of entries."""
         with self._lock:
             with self._connect() as conn:
-                return conn.execute("SELECT COUNT(*) FROM print_history").fetchone()[0]
+                if self._printer_index is None:
+                    return conn.execute("SELECT COUNT(*) FROM print_history").fetchone()[0]
+                return conn.execute(
+                    "SELECT COUNT(*) FROM print_history WHERE printer_index=?",
+                    (self._printer_index,),
+                ).fetchone()[0]
 
     def delete_entries(self, entry_ids):
         ids = []
@@ -647,18 +685,24 @@ class PrintHistory:
         placeholders = ",".join("?" for _ in ids)
         with self._lock:
             with self._connect() as conn:
+                scoped_params = tuple(ids)
+                scoped_filter = ""
+                if self._printer_index is not None:
+                    scoped_filter = " AND printer_index=?"
+                    scoped_params = tuple(ids) + (self._printer_index,)
                 archive_relpaths = [
                     row[0]
                     for row in conn.execute(
                         f"SELECT DISTINCT archive_relpath FROM print_history "
-                        f"WHERE id IN ({placeholders}) AND archive_relpath IS NOT NULL AND archive_relpath != ''",
-                        tuple(ids),
+                        f"WHERE id IN ({placeholders}){scoped_filter} "
+                        f"AND archive_relpath IS NOT NULL AND archive_relpath != ''",
+                        scoped_params,
                     ).fetchall()
                     if row[0]
                 ]
                 cursor = conn.execute(
-                    f"DELETE FROM print_history WHERE id IN ({placeholders})",
-                    tuple(ids),
+                    f"DELETE FROM print_history WHERE id IN ({placeholders}){scoped_filter}",
+                    scoped_params,
                 )
                 deleted = cursor.rowcount or 0
                 if archive_relpaths:
@@ -681,11 +725,49 @@ class PrintHistory:
                 return deleted
 
     def clear(self):
-        """Delete all history entries."""
+        """Delete history entries for the current printer scope."""
         with self._lock:
             with self._connect() as conn:
-                conn.execute("DELETE FROM print_history")
+                if self._printer_index is None:
+                    archive_relpaths = [
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT DISTINCT archive_relpath FROM print_history "
+                            "WHERE archive_relpath IS NOT NULL AND archive_relpath != ''"
+                        ).fetchall()
+                        if row[0]
+                    ]
+                    conn.execute("DELETE FROM print_history")
+                else:
+                    archive_relpaths = [
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT DISTINCT archive_relpath FROM print_history "
+                            "WHERE printer_index=? AND archive_relpath IS NOT NULL AND archive_relpath != ''",
+                            (self._printer_index,),
+                        ).fetchall()
+                        if row[0]
+                    ]
+                    conn.execute(
+                        "DELETE FROM print_history WHERE printer_index=?",
+                        (self._printer_index,),
+                    )
+                if archive_relpaths:
+                    still_referenced = {
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT DISTINCT archive_relpath FROM print_history "
+                            f"WHERE archive_relpath IN ({','.join('?' for _ in archive_relpaths)})",
+                            tuple(archive_relpaths),
+                        ).fetchall()
+                        if row[0]
+                    }
+                    self._delete_archive_relpaths(
+                        [relpath for relpath in archive_relpaths if relpath not in still_referenced]
+                    )
+                self._delete_unreferenced_archives(conn)
                 conn.commit()
-                log.info("Print history cleared")
-        if self._archive_dir and os.path.isdir(self._archive_dir):
-            shutil.rmtree(self._archive_dir, ignore_errors=True)
+                if self._printer_index is None:
+                    log.info("Print history cleared")
+                else:
+                    log.info("Print history cleared for printer_index=%s", self._printer_index)

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -129,8 +129,71 @@ class PrintHistory:
                 "CREATE INDEX IF NOT EXISTS idx_print_history_task_printer "
                 "ON print_history(task_id, printer_index)"
             )
+            self._migrate_legacy_printer_scope(conn)
         except Exception as e:
             log.warning(f"History: schema migration failed: {e}")
+
+    @staticmethod
+    def _unique_printer_map(rows, key_name):
+        grouped = {}
+        for row in rows:
+            key = str(row[key_name] or "").strip()
+            if not key:
+                continue
+            try:
+                printer_index = int(row["printer_index"])
+            except (TypeError, ValueError):
+                continue
+            grouped.setdefault(key, set()).add(printer_index)
+        return {
+            key: next(iter(printer_indexes))
+            for key, printer_indexes in grouped.items()
+            if len(printer_indexes) == 1
+        }
+
+    def _migrate_legacy_printer_scope(self, conn):
+        """Claim old NULL-scoped rows only when their owning printer is unambiguous."""
+        legacy_rows = conn.execute(
+            "SELECT id, task_id, archive_relpath FROM print_history WHERE printer_index IS NULL"
+        ).fetchall()
+        if not legacy_rows:
+            return
+
+        task_map = self._unique_printer_map(
+            conn.execute(
+                "SELECT task_id, printer_index FROM print_history "
+                "WHERE printer_index IS NOT NULL AND task_id IS NOT NULL AND task_id != ''"
+            ).fetchall(),
+            "task_id",
+        )
+        archive_map = self._unique_printer_map(
+            conn.execute(
+                "SELECT archive_relpath, printer_index FROM print_history "
+                "WHERE printer_index IS NOT NULL "
+                "AND archive_relpath IS NOT NULL AND archive_relpath != ''"
+            ).fetchall(),
+            "archive_relpath",
+        )
+
+        migrated = 0
+        for row in legacy_rows:
+            candidates = set()
+            task_id = str(row["task_id"] or "").strip()
+            archive_relpath = str(row["archive_relpath"] or "").strip()
+            if task_id and task_id in task_map:
+                candidates.add(task_map[task_id])
+            if archive_relpath and archive_relpath in archive_map:
+                candidates.add(archive_map[archive_relpath])
+            if len(candidates) != 1:
+                continue
+            conn.execute(
+                "UPDATE print_history SET printer_index=? WHERE id=? AND printer_index IS NULL",
+                (next(iter(candidates)), row["id"]),
+            )
+            migrated += 1
+
+        if migrated:
+            log.info("History: claimed %s legacy row(s) with inferred printer assignments", migrated)
 
     def _select_existing_task_row(self, conn, task_id):
         if not task_id:

--- a/web/service/video.py
+++ b/web/service/video.py
@@ -65,9 +65,11 @@ class VideoQueue(Service):
         self.video_enabled = False
         self.timelapse_enabled = False
         self.light_control_enabled = False
+        self.integration_enabled = False
         self.last_frame_at = None
         self._enable_generation = 0  # increments each time video is enabled
         self._viewer_count = 0
+        self._integration_client_count = 0
         self._lock = threading.Lock()
         self._pppp_ref_held = False
         self._recycle_pppp_on_restart = False
@@ -98,6 +100,7 @@ class VideoQueue(Service):
             getattr(self, "video_enabled", False)
             or getattr(self, "timelapse_enabled", False)
             or getattr(self, "light_control_enabled", False)
+            or getattr(self, "integration_enabled", False)
         )
 
     def _sync_persistent_state(self):
@@ -120,7 +123,9 @@ class VideoQueue(Service):
             f"video_enabled={bool(getattr(self, 'video_enabled', False))}, "
             f"timelapse_enabled={bool(getattr(self, 'timelapse_enabled', False))}, "
             f"light_control_enabled={bool(getattr(self, 'light_control_enabled', False))}, "
+            f"integration_enabled={bool(getattr(self, 'integration_enabled', False))}, "
             f"viewers={int(getattr(self, '_viewer_count', 0))}, "
+            f"integration_clients={int(getattr(self, '_integration_client_count', 0))}, "
             f"wanted={bool(getattr(self, 'wanted', False))}, "
             f"live_active={bool(getattr(self, '_live_active', False))}, "
             f"api_id={'set' if getattr(self, 'api_id', None) is not None else 'none'}, "
@@ -724,6 +729,30 @@ class VideoQueue(Service):
             self._viewer_count += 1
             viewer_count = self._viewer_count
         return viewer_count
+
+    def integration_client_connected(self):
+        with self._lock:
+            self._integration_client_count += 1
+            self.integration_enabled = True
+            integration_count = self._integration_client_count
+        self._sync_persistent_state()
+        if self.state == RunState.Stopped or not self.wanted:
+            self.start()
+        return integration_count
+
+    def integration_client_disconnected(self):
+        with self._lock:
+            if self._integration_client_count > 0:
+                self._integration_client_count -= 1
+            else:
+                self._integration_client_count = 0
+            integration_count = self._integration_client_count
+            if integration_count == 0:
+                self.integration_enabled = False
+        self._sync_persistent_state()
+        if integration_count == 0 and not self._video_requested() and self.state == RunState.Running:
+            self.stop()
+        return integration_count
 
     def viewer_disconnected(self):
         stop_requested = False


### PR DESCRIPTION
This build adds a video endpoint intended for integration with Frigate or similar NVR / camera software. The goal is to provide a simpler stream path for external consumers that want to pull the printer camera feed directly. Frigate supports HTTP MJPEG and JPEG-style inputs, and its documentation also notes that MJPEG sources may be better handled through go2rtc/restreaming depending on the setup.

Important: this integration path is currently untested on my side, because I do not personally use Frigate. Please test with caution in your environment. If you run into issues, please share the exact Frigate config used along with relevant logs from both Frigate/go2rtc and ankerctl so the endpoint behavior can be reviewed and adjusted. Frigate’s docs specifically point users to logs and the go2rtc stream interface when troubleshooting stream connection problems.

Changes:

Home Z Command
The Home page Home Z button uses:

UI click handler: sendHomeCommand("z") in static/ankersrv.js (line 2607) API route: POST /api/printer/home with {"axis":"z"} in web/init.py#L3541 (line 3541) MQTT native home command: ZZ_MQTT_CMD_MOVE_ZERO with axis z, which maps to value = 2 in web/service/mqtt.py (line 89) and web/service/mqtt.py (line 1835) What I Changed

Set the legacy filament swap default homing template to native:home_z in web/init.py#L1097 (line 1097) Added a safe migration so older saved advanced configs using native:home_all automatically upgrade to native:home_z, without overwriting custom commands, in web/init.py#L1252 (line 1252) Updated the legacy swap status text so it now says it is using the native Home Z quick-home sequence in web/init.py#L1889 (line 1889) Important Note

Internally, send_home("all") was already being normalized to z, so this is partly a clarity and migration fix. The useful part is that old saved filament-swap advanced configs now get aligned to the same Home Z behavior explicitly, which should reduce confusion and keep swap homing on the faster path by default. Validation

Ran python -m pytest tests\\test_filament_api.py -q Ran python -m pytest tests\\test_settings_and_notifications_api.py -q

What Changed

Added a new API endpoint for integrations: /api/camera/printer-stream It remuxes the printer’s raw H.264 feed into fragmented MP4 with ffmpeg, which is much friendlier for Frigate and other FFmpeg-based consumers. Main route: web/init.py
Added per-printer camera integration settings
New config shape and helpers: web/camera.py
The endpoint URL is generated per printer and exposed back to the UI: web/init.py Added VideoQueue ownership for integration clients This keeps the printer video service alive for the integration stream without depending on the Home page camera selection. New lifecycle hooks: web/service/video.py
Added a new Setup page card
“Printer Integration Stream” lives beside the existing external camera setup and lets you enable/disable the endpoint per printer. UI card: static/tabs/setup.html
UI logic/save handler: static/ankersrv.js
Security

The new stream endpoint is protected by API-key GET protection now, so it does not bypass auth when API-key mode is enabled. Protected route list: web/init.py
How To Use

Go to Setup -> Camera
In Printer Integration Stream, enable it for the printer you want Save
Copy the generated endpoint URL shown there
Use that URL in Frigate or another FFmpeg-based consumer Example shape:

http://127.0.0.1:4470/api/camera/printer-stream?printer_index=0&apikey=YOUR_KEY Validation

Full test suite passed:
403 passed, 16 skipped
New/updated tests cover:
stream auth and enable/disable behavior: tests/test_reports_video_and_webserver.py camera settings persistence: tests/test_settings_and_notifications_api.py protected endpoint coverage: tests/test_security_validation.py ffmpeg remux helper coverage: tests/test_camera_helpers.py