### PR TITLE
Add multi-printer history view with per-printer filtering

### DIFF
--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1112,6 +1112,21 @@ $(function () {
         }
     }
 
+    function withHistoryScopeQuery(url) {
+        const base = withActivePrinterQuery(url);
+        if (!historyAllPrinters) return base;
+        try {
+            const resolved = new URL(base, window.location.origin);
+            resolved.searchParams.set("all_printers", "1");
+            if (resolved.origin === window.location.origin) {
+                return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+            }
+            return resolved.toString();
+        } catch (_err) {
+            return `${base}${base.includes("?") ? "&" : "?"}all_printers=1`;
+        }
+    }
+
     function processPrinterAlertEntries(entries, notifyUser) {
         if (!Array.isArray(entries) || !entries.length) {
             return;
@@ -3964,6 +3979,7 @@ $(function () {
      * Print History Tab
      */
     let historyOffset = 0;
+    let historyAllPrinters = false;
     const HISTORY_LIMIT = 25;
     const selectedHistoryIds = new Set();
 
@@ -4008,7 +4024,7 @@ $(function () {
     }
 
     function loadHistory(append) {
-        fetch(withActivePrinterQuery(`/api/history?limit=${HISTORY_LIMIT}&offset=${historyOffset}`))
+        fetch(withHistoryScopeQuery(`/api/history?limit=${HISTORY_LIMIT}&offset=${historyOffset}`))
             .then(r => r.json())
             .then(data => {
                 const tbody = $("#history-tbody");
@@ -4017,26 +4033,38 @@ $(function () {
                     selectedHistoryIds.clear();
                 }
                 if (data.entries.length === 0 && !append) {
-                    tbody.html('<tr><td colspan="6" class="text-center text-muted py-4">No history yet</td></tr>');
+                    const emptyMsg = historyAllPrinters ? "No history yet across all printers" : "No history yet";
+                    tbody.html(`<tr><td colspan="6" class="text-center text-muted py-4">${emptyMsg}</td></tr>`);
                 }
                 data.entries.forEach(e => {
                     const started = e.started_at ? new Date(e.started_at + "Z").toLocaleString() : "-";
                     const safeFilename = escapeHtml(e.filename);
+                    const safePrinterName = escapeHtml(e.printer_name || "Unknown");
                     const thumbnail = buildGCodeThumbnail(e.thumbnail_url, e.filename || "History thumbnail");
                     const canDelete = e.status !== "started";
                     const isChecked = selectedHistoryIds.has(e.id);
                     const checkboxCell = canDelete
                         ? `<input type="checkbox" class="form-check-input history-select-checkbox" data-history-id="${e.id}" ${isChecked ? "checked" : ""} aria-label="Select ${safeFilename}">`
                         : '<input type="checkbox" class="form-check-input" disabled aria-label="Cannot delete in-progress history entry">';
+                    const printerAttr = (e.printer_index !== null && e.printer_index !== undefined)
+                        ? ` data-history-printer-index="${e.printer_index}"`
+                        : "";
                     const actionCell = e.can_reprint
-                        ? `<button class="btn btn-sm btn-outline-primary history-reprint-btn" data-history-id="${e.id}" data-history-name="${safeFilename}">Reprint</button>`
+                        ? `<button class="btn btn-sm btn-outline-primary history-reprint-btn" data-history-id="${e.id}" data-history-name="${safeFilename}"${printerAttr}>Reprint</button>`
                         : '<span class="text-muted small">-</span>';
+                    // Show printer attribution below the filename when viewing all printers
+                    const printerMeta = historyAllPrinters
+                        ? `<div class="text-muted small">${safePrinterName}</div>`
+                        : "";
                     const row = `<tr>
                         <td class="text-center align-middle">${checkboxCell}</td>
                         <td class="history-file-cell" title="${safeFilename}">
                             <div class="d-flex align-items-center gap-2">
                                 ${thumbnail}
-                                <div class="text-truncate" style="max-width:200px;">${safeFilename}</div>
+                                <div>
+                                    <div class="text-truncate" style="max-width:200px;">${safeFilename}</div>
+                                    ${printerMeta}
+                                </div>
                             </div>
                         </td>
                         <td>${statusBadge(e.status)}</td>
@@ -4046,7 +4074,8 @@ $(function () {
                     </tr>`;
                     tbody.append(row);
                 });
-                $("#history-count").text(`${Math.min(historyOffset + data.entries.length, data.total)} / ${data.total} entries`);
+                const countSuffix = historyAllPrinters ? " across all printers" : "";
+                $("#history-count").text(`${Math.min(historyOffset + data.entries.length, data.total)} / ${data.total} entries${countSuffix}`);
                 if (historyOffset + data.entries.length < data.total) {
                     $("#history-load-more").show();
                 } else {
@@ -4071,6 +4100,21 @@ $(function () {
     $("#history-load-more").on("click", function () {
         historyOffset += HISTORY_LIMIT;
         loadHistory(true);
+    });
+
+    $("#history-all-printers").on("change", function () {
+        historyAllPrinters = !!$(this).prop("checked");
+        // Update Clear button label to reflect the current scope
+        const clearBtn = $("#history-clear");
+        if (historyAllPrinters) {
+            clearBtn.html('<i class="bi bi-trash"></i> Clear All Printers').attr("title", "Clear history across all printers");
+        } else {
+            clearBtn.html('<i class="bi bi-trash"></i> Clear').removeAttr("title");
+        }
+        historyOffset = 0;
+        selectedHistoryIds.clear();
+        $("#history-tbody").empty();
+        loadHistory(false);
     });
 
     $(document).on("change", ".history-select-checkbox", function () {
@@ -4138,8 +4182,11 @@ $(function () {
     });
 
     $("#history-clear").on("click", function () {
-        if (!confirm("Clear all print history?")) return;
-        fetch(withActivePrinterQuery("/api/history"), { method: "DELETE" })
+        const confirmMsg = historyAllPrinters
+            ? "Clear history across all printers?"
+            : "Clear all print history?";
+        if (!confirm(confirmMsg)) return;
+        fetch(withHistoryScopeQuery("/api/history"), { method: "DELETE" })
             .then(() => {
                 selectedHistoryIds.clear();
                 historyOffset = 0;
@@ -4152,6 +4199,7 @@ $(function () {
         const btn = $(this);
         const entryId = btn.attr("data-history-id");
         const entryName = btn.attr("data-history-name") || "selected file";
+        const entryPrinterIndexAttr = btn.attr("data-history-printer-index");
         if (!entryId) {
             return;
         }
@@ -4160,9 +4208,19 @@ $(function () {
         }
         btn.prop("disabled", true);
         try {
-            const resp = await fetch(withActivePrinterQuery(`/api/history/${encodeURIComponent(entryId)}/reprint`), {
-                method: "POST",
-            });
+            // When viewing all-printers history, route the reprint to the printer that
+            // originally ran the job (from data-history-printer-index), not the active one.
+            let reprintUrl;
+            if (historyAllPrinters && entryPrinterIndexAttr !== undefined && entryPrinterIndexAttr !== "") {
+                const pi = parseInt(entryPrinterIndexAttr, 10);
+                const base = `/api/history/${encodeURIComponent(entryId)}/reprint`;
+                reprintUrl = Number.isFinite(pi)
+                    ? `${base}?printer_index=${encodeURIComponent(pi)}`
+                    : withActivePrinterQuery(base);
+            } else {
+                reprintUrl = withActivePrinterQuery(`/api/history/${encodeURIComponent(entryId)}/reprint`);
+            }
+            const resp = await fetch(reprintUrl, { method: "POST" });
             const data = await resp.json().catch(() => ({}));
             if (!resp.ok) {
                 throw new Error(data.error || `HTTP ${resp.status}`);

--- a/static/tabs/history.html
+++ b/static/tabs/history.html
@@ -5,7 +5,11 @@
                 <div class="card">
                     <div class="card-header fs-5 d-flex justify-content-between align-items-center">
                         <span>{{ macro.bi_icon("clock-history") }} Print History</span>
-                        <div class="d-flex gap-2">
+                        <div class="d-flex gap-2 align-items-center">
+                            <div class="form-check form-switch mb-0 me-2">
+                                <input class="form-check-input" type="checkbox" id="history-all-printers" role="switch" aria-label="Show history from all printers">
+                                <label class="form-check-label small text-nowrap" for="history-all-printers">All printers</label>
+                            </div>
                             <button class="btn btn-sm btn-outline-danger" id="history-delete-selected" disabled>
                                 {{ macro.bi_icon("trash3") }} Delete Selected
                             </button>

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -77,8 +77,14 @@ class FakeHistoryList:
             "thumbnail_available": False,
         }]
 
+    def get_history_for_printer(self, printer_index, limit=50, offset=0):
+        return self.get_history(limit=limit, offset=offset)
+
     def get_count(self):
         return 1
+
+    def get_count_for_printer(self, printer_index):
+        return self.get_count()
 
 
 def _install_app_state(*, mqtt=None, videoqueue=None, filetransfer=None, config=None, login=True, video_supported=True, unsupported=False):
@@ -435,8 +441,11 @@ def test_history_routes_require_auth_and_clear_entries():
     calls = []
     history = SimpleNamespace(
         get_history=lambda limit, offset: calls.append(("get", limit, offset)) or [{"filename": "cube.gcode"}],
+        get_history_for_printer=lambda printer_index, limit, offset: calls.append(("get_printer", printer_index, limit, offset)) or [{"filename": "cube.gcode"}],
         get_count=lambda: 3,
+        get_count_for_printer=lambda printer_index: 3,
         clear=lambda: calls.append(("clear",)),
+        clear_for_printer=lambda printer_index: calls.append(("clear_printer", printer_index)),
     )
     mqtt = SimpleNamespace(history=history)
     client = app.test_client()
@@ -454,7 +463,7 @@ def test_history_routes_require_auth_and_clear_entries():
     assert authorized.get_json()["total"] == 3
     assert authorized.get_json()["entries"][0]["thumbnail_url"] is None
     assert cleared.status_code == 200
-    assert calls == [("get", 500, 0), ("clear",)]
+    assert calls == [("get_printer", 0, 500, 0), ("clear_printer", 0)]
 
 
 def test_history_route_uses_requested_or_active_indexed_mqtt_service():

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -3992,25 +3992,59 @@ def app_api_snapshot():
         download_name=f"ankerctl_snapshot_{timestamp}.jpg",
     )
 
+def _configured_printer_name_map():
+    """Return {printer_index: name_str} for all configured printers."""
+    config = app.config.get("config")
+    if not config:
+        return {}
+    try:
+        with config.open() as cfg:
+            if not cfg:
+                return {}
+            printers = getattr(cfg, "printers", None) or []
+            return {
+                i: getattr(p, "name", None) or f"Printer {i + 1}"
+                for i, p in enumerate(printers)
+            }
+    except Exception:
+        return {}
+
+
 @app.get("/api/history")
 def app_api_history():
-    """Return print history as JSON with pagination."""
+    """Return print history as JSON with pagination.
+
+    Query params:
+      all_printers=1  — return entries for all printers (no printer filter)
+      limit           — max entries to return (default 50, max 500)
+      offset          — pagination offset (default 0)
+    """
     printer_index = _requested_printer_index()
-    limit = request.args.get("limit", 50, type=int)
-    offset = request.args.get("offset", 0, type=int)
-    # Clamp parameters to safe ranges to prevent excessive queries or errors
-    limit = max(1, min(limit, 500))
-    offset = max(0, offset)
+    all_printers = request.args.get("all_printers") == "1"
+    limit = max(1, min(request.args.get("limit", 50, type=int), 500))
+    offset = max(0, request.args.get("offset", 0, type=int))
+    printer_names = _configured_printer_name_map()
     with borrow_mqtt(printer_index) as mqtt:
         if not mqtt:
             return {"entries": [], "total": 0}
-        entries = mqtt.history.get_history(limit=limit, offset=offset)
-        total = mqtt.history.get_count()
+        if all_printers:
+            entries = mqtt.history.get_history(limit=limit, offset=offset)
+            total = mqtt.history.get_count()
+        else:
+            entries = mqtt.history.get_history_for_printer(printer_index, limit=limit, offset=offset)
+            total = mqtt.history.get_count_for_printer(printer_index)
     serialized_entries = []
     for entry in entries:
         item = dict(entry)
+        pi = item.get("printer_index")
+        # Resolve a human-readable printer name; gracefully handle NULL legacy entries
+        item["printer_name"] = printer_names.get(pi, f"Printer {pi + 1}" if pi is not None else "Unknown")
         item["thumbnail_url"] = (
-            url_for("app_api_history_thumbnail", entry_id=item["id"], printer_index=printer_index)
+            url_for(
+                "app_api_history_thumbnail",
+                entry_id=item["id"],
+                printer_index=pi if pi is not None else printer_index,
+            )
             if item.get("thumbnail_available")
             else None
         )
@@ -4020,10 +4054,21 @@ def app_api_history():
 
 @app.delete("/api/history")
 def app_api_history_clear():
-    """Clear all print history."""
+    """Clear print history.
+
+    Query params:
+      all_printers=1  — clear entries for ALL printers
+      (default)       — clear only entries for the requested printer_index
+    """
     printer_index = _requested_printer_index()
+    all_printers = request.args.get("all_printers") == "1"
     with borrow_mqtt(printer_index) as mqtt:
-        mqtt.history.clear()
+        if not mqtt:
+            return {"status": "ok"}
+        if all_printers:
+            mqtt.history.clear()
+        else:
+            mqtt.history.clear_for_printer(printer_index)
     return {"status": "ok"}
 
 

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -680,6 +680,38 @@ class PrintHistory:
                     log.info("History: deleted %d selected entr%s", deleted, "y" if deleted == 1 else "ies")
                 return deleted
 
+    def get_history_for_printer(self, printer_index, limit=50, offset=0):
+        """Return history filtered to a specific printer_index (NULL entries included)."""
+        with self._lock:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT * FROM print_history "
+                    "WHERE printer_index=? OR printer_index IS NULL "
+                    "ORDER BY id DESC LIMIT ? OFFSET ?",
+                    (printer_index, limit, offset),
+                ).fetchall()
+                return [self._decorate_entry(r, conn=conn) for r in rows]
+
+    def get_count_for_printer(self, printer_index):
+        """Return count for a specific printer_index (NULL entries included)."""
+        with self._lock:
+            with self._connect() as conn:
+                return conn.execute(
+                    "SELECT COUNT(*) FROM print_history WHERE printer_index=? OR printer_index IS NULL",
+                    (printer_index,),
+                ).fetchone()[0]
+
+    def clear_for_printer(self, printer_index):
+        """Delete only entries belonging to printer_index (not NULL entries)."""
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    "DELETE FROM print_history WHERE printer_index=?",
+                    (printer_index,),
+                )
+                conn.commit()
+                log.info("Print history cleared for printer %d", printer_index)
+
     def clear(self):
         """Delete all history entries."""
         with self._lock:


### PR DESCRIPTION
## Summary

Inspired by a suggestion from @P0k3sm0t in #69 — thanks for the idea!

- **"All printers" toggle** in the History tab card header. When on, all history entries across every configured printer are shown; each row displays the printer name below the filename.
- **Per-printer filtering** when the toggle is off: only entries matching the active printer's `printer_index` are shown (NULL legacy entries included for backwards compatibility).
- **Scoped Clear**: the Clear button confirms and clears only the active printer's entries by default, or all entries when in all-printers mode.
- **Reprint routing**: in all-printers mode, Reprint sends the job to the printer that originally ran it (via `data-history-printer-index` on the button).
- **`printer_name`** added to every history API response entry for display purposes.

## Changes

| File | What changed |
|---|---|
| `web/service/history.py` | Added `get_history_for_printer()`, `get_count_for_printer()`, `clear_for_printer()` |
| `web/__init__.py` | Added `_configured_printer_name_map()` helper; `GET /api/history` and `DELETE /api/history` branch on `?all_printers=1` |
| `static/tabs/history.html` | "All printers" form-switch in card header |
| `static/ankersrv.js` | `historyAllPrinters` state, `withHistoryScopeQuery()` helper, printer attribution in rows, scoped Clear/Reprint |

## Notes on legacy entries

Rows with `printer_index IS NULL` (created before the column was added) are included in every printer's per-printer view. They won't be deleted by a per-printer Clear — only a full all-printers Clear removes them. This is intentional: we don't want to silently drop historical data.

## Test plan

- [ ] Single printer: toggle has no visible effect beyond label changes
- [ ] Two printers: toggle shows entries from both, each row labels the source printer
- [ ] Clear (per-printer): only removes entries for the active printer; other printer's entries remain
- [ ] Clear (all printers): removes everything
- [ ] Reprint in all-printers mode: job goes to the correct printer, not the currently active one
- [ ] Legacy NULL entries: appear under every printer's view, not deleted by per-printer Clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)