### PR TITLE
Fix HomeAssistant MQTT service permanently disabled if broker unreachable at startup

### DIFF
--- a/tests/test_homeassistant_service.py
+++ b/tests/test_homeassistant_service.py
@@ -25,6 +25,7 @@ class FakeMQTTClient:
         self.loop_stopped = False
         self.disconnected = False
         self.will = None
+        self.reconnect_delay = None
 
     def username_pw_set(self, user, password):
         self.username_password = (user, password)
@@ -34,6 +35,12 @@ class FakeMQTTClient:
 
     def connect(self, host, port, keepalive=60):
         self.connected = (host, port, keepalive)
+
+    def connect_async(self, host, port, keepalive=60):
+        self.connected = (host, port, keepalive)
+
+    def reconnect_delay_set(self, min_delay=1, max_delay=120):
+        self.reconnect_delay = (min_delay, max_delay)
 
     def loop_start(self):
         self.loop_started = True
@@ -160,9 +167,65 @@ def test_homeassistant_start_and_stop(monkeypatch):
 
     assert fake_client.username_password == ("ha-user", "ha-pass")
     assert fake_client.connected == ("mqtt.example", 1884, 60)
+    assert fake_client.reconnect_delay == (1, 60)
     assert fake_client.loop_started is True
     assert fake_client.disconnected is True
     assert fake_client.loop_stopped is True
+
+
+def test_homeassistant_start_survives_unreachable_broker(monkeypatch):
+    """connect_async stores params without doing I/O, so a broker that is
+    unreachable at startup should still leave the client active — paho's
+    background thread will retry."""
+    fake_client = FakeMQTTClient()
+
+    class FakePahoModule:
+        class CallbackAPIVersion:
+            VERSION1 = object()
+
+        @staticmethod
+        def Client(*args, **kwargs):
+            return fake_client
+
+    monkeypatch.setattr("web.service.homeassistant.paho_mqtt", FakePahoModule)
+
+    svc = HomeAssistantService(FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer")
+    svc.start()
+
+    # Broker is unreachable, so we are not connected yet — but the client
+    # is alive and loop_start has been called, so paho will keep retrying.
+    assert svc._client is fake_client
+    assert svc._connected is False
+    assert fake_client.loop_started is True
+    assert fake_client.reconnect_delay == (1, 60)
+
+
+def test_homeassistant_start_handles_invalid_broker_config(monkeypatch):
+    """connect_async raises ValueError for bad host/port — that's a
+    genuine misconfiguration, not transient unreachability, so we give up
+    cleanly rather than leaving paho's thread running."""
+    fake_client = FakeMQTTClient()
+
+    def bad_connect_async(host, port, keepalive=60):
+        raise ValueError(f"invalid port: {port}")
+    fake_client.connect_async = bad_connect_async
+
+    class FakePahoModule:
+        class CallbackAPIVersion:
+            VERSION1 = object()
+
+        @staticmethod
+        def Client(*args, **kwargs):
+            return fake_client
+
+    monkeypatch.setattr("web.service.homeassistant.paho_mqtt", FakePahoModule)
+
+    svc = HomeAssistantService(FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer")
+    svc.start()
+
+    assert svc._client is None
+    # loop_start must NOT have been called when connect_async failed
+    assert fake_client.loop_started is False
 
 
 def test_homeassistant_reload_restarts_on_config_change(monkeypatch):

--- a/web/service/homeassistant.py
+++ b/web/service/homeassistant.py
@@ -140,7 +140,14 @@ class HomeAssistantService:
     # ------------------------------------------------------------------
 
     def start(self):
-        """Connect to the HA MQTT broker and publish discovery configs."""
+        """Connect to the HA MQTT broker and publish discovery configs.
+
+        Uses connect_async() + loop_start() so a broker that is briefly
+        unreachable at startup (for example, when ankerctl and Mosquitto are
+        launched together in docker-compose) does not permanently disable HA
+        integration. paho's background thread retries with exponential
+        backoff.
+        """
         if not self._enabled:
             return
 
@@ -157,16 +164,27 @@ class HomeAssistantService:
         self._client.on_disconnect = self._on_disconnect
         self._client.on_message = self._on_message
 
+        # Bound reconnect backoff so brief broker outages recover quickly
+        # but sustained unreachability doesn't hammer the network.
+        self._client.reconnect_delay_set(min_delay=1, max_delay=60)
+
         # Set LWT (Last Will and Testament) so HA marks device offline
         avail_topic = self._availability_topic()
         self._client.will_set(avail_topic, payload="offline", qos=1, retain=True)
 
         try:
-            self._client.connect(self._host, self._port, keepalive=60)
-            self._client.loop_start()
-        except Exception as err:
-            log.error(f"HA MQTT: connection failed: {err}")
+            # connect_async() stores params without doing network I/O.
+            # loop_start() spins up paho's background thread which performs
+            # the initial connect and any subsequent reconnect attempts.
+            self._client.connect_async(self._host, self._port, keepalive=60)
+        except (ValueError, OSError) as err:
+            # Raised only for invalid host/port syntax, not for transient
+            # unreachability. Treat as a genuine misconfiguration.
+            log.error(f"HA MQTT: invalid broker configuration: {err}")
             self._client = None
+            return
+
+        self._client.loop_start()
 
     def stop(self):
         """Disconnect from the HA MQTT broker and mark device offline."""


### PR DESCRIPTION
## Summary

The Home Assistant MQTT service uses paho's blocking `connect()` call. If the
MQTT broker is unreachable when ankerctl starts (e.g. ankerctl and Mosquitto
launched together in docker-compose, or a brief broker restart), the connect
raises, `_client` is set to `None`, and HA integration is **permanently
disabled** until something forces a `reload_config()`.

This PR switches to `connect_async()` + `loop_start()`, paho's recommended
non-blocking pattern. paho's background thread handles the initial connect and
all subsequent reconnects, so a broker that comes online a few seconds later
is picked up automatically.

## Details

- `connect_async()` stores params and returns immediately — no network I/O.
- `loop_start()` spins up paho's background thread, which performs the actual
  connect and retries on failure using paho's built-in exponential backoff.
- `reconnect_delay_set(min_delay=1, max_delay=60)` bounds the backoff so brief
  outages recover quickly without hammering the network on sustained
  unreachability.
- The narrower `(ValueError, OSError)` catch only fires on genuine config
  errors (bad host/port syntax). Those are unrecoverable, so we clear
  `_client` and bail without leaving an orphaned paho thread running.
- `loop_start()` moved out of the `try` block so it only runs when
  `connect_async()` succeeds.

`stop()` is unchanged and remains safe — `disconnect()` and `loop_stop()` are
both no-ops when the client never connected.

## Who this affects

Anyone running ankerctl and the MQTT broker on the same Docker host where
the broker container takes a moment to come up. Previously the HA integration
would silently stay offline; now it connects once the broker is reachable.

## Test plan

- [x] `pytest tests/test_homeassistant_service.py` — 9 passed (7 existing + 2 new)
- [x] `pytest tests/test_mqttqueue_service.py tests/test_service_crash_recovery.py tests/test_service_recovery_paths.py` — 125 passed
- [x] Manual: can't easily test paho reconnect behavior without a real broker, but the unit test for unreachable broker simulates the critical path (connect_async succeeds without I/O, loop_start runs, _client stays alive, _connected remains False).

### New tests added

- `test_homeassistant_start_survives_unreachable_broker` — the regression
  test: verifies `_client` stays alive and retryable when the broker is
  unreachable.
- `test_homeassistant_start_handles_invalid_broker_config` — verifies
  `loop_start()` is **not** called when `connect_async()` raises, so no
  orphan paho thread.

### Existing tests updated

- `test_homeassistant_start_and_stop` now also asserts
  \`reconnect_delay == (1, 60)\`.
- \`FakeMQTTClient\` gained \`connect_async()\` and \`reconnect_delay_set()\` shims.