### PR TITLE
Reject negative printer_index values

### DIFF
--- a/ankerctl.py
+++ b/ankerctl.py
@@ -79,7 +79,7 @@ pass_env = click.make_pass_decorator(Environment)
 @click.option("--insecure", "-k", is_flag=True, help="Disable TLS certificate validation")
 @click.option("--verbose", "-v", count=True, help="Increase verbosity")
 @click.option("--quiet", "-q", count=True, help="Decrease verbosity")
-@click.option("--printer", "-p", type=int, default=environ.get('PRINTER_INDEX') or 0, help="Select printer number")
+@click.option("--printer", "-p", type=click.IntRange(min=0), default=environ.get('PRINTER_INDEX') or 0, help="Select printer number")
 @click.pass_context
 def main(ctx, pppp_dump, verbose, quiet, insecure, printer):
     ctx.ensure_object(Environment)

--- a/cli/mqtt.py
+++ b/cli/mqtt.py
@@ -26,8 +26,8 @@ FILE_LIST_SOURCE_VALUES = {
 def mqtt_open(config, printer_index, insecure):
 
     with config.open() as cfg:
-        if printer_index >= len(cfg.printers):
-            raise ValueError(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1}")
+        if printer_index < 0 or printer_index >= len(cfg.printers):
+            raise ValueError(f"Printer number {printer_index} out of range, must be in 0..{len(cfg.printers)-1}")
         printer = cfg.printers[printer_index]
         acct = cfg.account
         server = servertable[acct.region]

--- a/cli/pppp.py
+++ b/cli/pppp.py
@@ -31,8 +31,8 @@ def pppp_open(config, printer_index, timeout=None, dumpfile=None):
         deadline = datetime.now() + timedelta(seconds=timeout)
 
     with config.open() as cfg:
-        if printer_index >= len(cfg.printers):
-            raise ValueError(f"Printer number {printer_index} out of range, max printer number is {len(cfg.printers)-1}")
+        if printer_index < 0 or printer_index >= len(cfg.printers):
+            raise ValueError(f"Printer number {printer_index} out of range, must be in 0..{len(cfg.printers)-1}")
         printer = cfg.printers[printer_index]
         ip_addr = pppp_resolve_printer_ip(config, printer, printer_index, dumpfile=dumpfile)
         if not ip_addr:

--- a/tests/test_ankerctl_cli.py
+++ b/tests/test_ankerctl_cli.py
@@ -321,3 +321,29 @@ def test_pppp_open_raises_on_invalid_printer_index():
     import pytest
     with pytest.raises(ValueError, match="out of range"):
         cli.pppp.pppp_open(config, printer_index=0)
+
+
+def test_mqtt_open_raises_on_negative_printer_index():
+    """Negative indices must not silently select the last printer via
+    Python's negative indexing."""
+    import cli.mqtt
+    config = FakeConfigContext(printers=[SimpleNamespace(name="p0"), SimpleNamespace(name="p1")])
+    import pytest
+    with pytest.raises(ValueError, match="out of range"):
+        cli.mqtt.mqtt_open(config, printer_index=-1, insecure=False)
+
+
+def test_pppp_open_raises_on_negative_printer_index():
+    import cli.pppp
+    config = FakeConfigContext(printers=[SimpleNamespace(name="p0"), SimpleNamespace(name="p1")])
+    import pytest
+    with pytest.raises(ValueError, match="out of range"):
+        cli.pppp.pppp_open(config, printer_index=-1)
+
+
+def test_printer_option_rejects_negative_values():
+    """click IntRange(min=0) rejects --printer -1 at argument parse time."""
+    runner = CliRunner()
+    result = runner.invoke(ankerctl.main, ["--printer", "-1", "config", "show"])
+    assert result.exit_code != 0
+    assert "is not in the range" in result.output or "Invalid value" in result.output


### PR DESCRIPTION
## Summary

PR #50 made `mqtt_open()` / `pppp_open()` raise `ValueError` on out-of-range
printer indices, but only on the upper bound (`>= len(cfg.printers)`). A
negative value slipped past that check and then matched Python's
negative-indexing semantics, silently selecting the last printer in the
list — so `PRINTER_INDEX=-1` would "work" by picking the wrong printer
instead of raising a clear error.

## Changes

- `ankerctl.py` — `--printer` / `-p` option now uses
  `click.IntRange(min=0)`. Negative CLI values and negative `PRINTER_INDEX`
  env var values fail at argument-parse time with a clear error from Click.
- `cli/mqtt.py`, `cli/pppp.py` — bounds check extended to also reject
  negative indices. Error message tightened from
  `"max printer number is {n}"` to `"must be in 0..{n}"`.

No behavior change for valid indices.

## Test plan

- [x] `pytest tests/test_ankerctl_cli.py` — 14 passed (11 existing + 3 new)
- [x] `pytest tests/test_cli_pppp.py tests/test_mqttqueue_service.py tests/test_service_recovery_paths.py` — 95 passed

### New tests added

- `test_mqtt_open_raises_on_negative_printer_index` — regression test for
  the mqtt path.
- `test_pppp_open_raises_on_negative_printer_index` — regression test for
  the pppp path.
- `test_printer_option_rejects_negative_values` — verifies Click rejects
  `--printer -1` at argument-parse time.
