### PR TITLE
Reconcile multi-printer history behavior after PR #70

### DIFF
--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1112,6 +1112,24 @@ $(function () {
         }
     }
 
+    function withPrinterQuery(url, printerIndex) {
+        const parsedPrinterIndex = Number(printerIndex);
+        if (!Number.isFinite(parsedPrinterIndex)) {
+            return withActivePrinterQuery(url);
+        }
+        try {
+            const resolved = new URL(url, window.location.origin);
+            resolved.searchParams.set("printer_index", String(parsedPrinterIndex));
+            if (resolved.origin === window.location.origin) {
+                return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+            }
+            return resolved.toString();
+        } catch (_err) {
+            const separator = String(url).includes("?") ? "&" : "?";
+            return `${url}${separator}printer_index=${encodeURIComponent(parsedPrinterIndex)}`;
+        }
+    }
+
     function processPrinterAlertEntries(entries, notifyUser) {
         if (!Array.isArray(entries) || !entries.length) {
             return;
@@ -4028,12 +4046,48 @@ $(function () {
     const HISTORY_LIMIT = 25;
     const selectedHistoryIds = new Set();
 
+    function historyFilterPrinterIndex() {
+        if (historyFilter === "__all__" || historyFilter === "active") {
+            return null;
+        }
+        const parsed = parseInt(historyFilter, 10);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function historyScopeLabel() {
+        if (historyFilter === "__all__") {
+            return "all printers";
+        }
+        const scopedPrinterIndex = historyFilter === "active" ? getActivePrinterIndex() : historyFilterPrinterIndex();
+        if (!Number.isFinite(scopedPrinterIndex)) {
+            return historyFilter === "active" ? "the active printer" : "the selected printer";
+        }
+        const printer = historyPrinters.find(function (entry) {
+            return Number(entry.index) === scopedPrinterIndex;
+        });
+        if (printer && printer.name) {
+            return printer.name;
+        }
+        return `Printer ${scopedPrinterIndex + 1}`;
+    }
+
+    function updateHistoryScopeUi() {
+        const clearButton = $("#history-clear");
+        if (historyFilter === "__all__") {
+            clearButton.attr("title", "Clear history across all printers");
+        } else {
+            clearButton.attr("title", `Clear history for ${historyScopeLabel()}`);
+        }
+    }
+
     function renderHistoryFilterDropdown(printers, activeIndex) {
         historyPrinters = printers || [];
         const wrap = $("#history-filter-wrap");
         const sel = $("#history-printer-filter");
         if (historyPrinters.length <= 1) {
             wrap.addClass("d-none");
+            historyFilter = "active";
+            updateHistoryScopeUi();
             return;
         }
         wrap.removeClass("d-none");
@@ -4046,6 +4100,7 @@ $(function () {
             sel.append(`<option value="${p.index}">${label}</option>`);
         });
         sel.val(historyFilter);
+        updateHistoryScopeUi();
     }
 
     function fetchAndRenderHistoryFilter() {
@@ -4119,8 +4174,11 @@ $(function () {
                     const checkboxCell = canDelete
                         ? `<input type="checkbox" class="form-check-input history-select-checkbox" data-history-id="${e.id}" ${isChecked ? "checked" : ""} aria-label="Select ${safeFilename}">`
                         : '<input type="checkbox" class="form-check-input" disabled aria-label="Cannot delete in-progress history entry">';
+                    const printerIndexAttr = (e.printer_index === null || e.printer_index === undefined)
+                        ? ""
+                        : ` data-history-printer-index="${escapeHtml(String(e.printer_index))}"`;
                     const actionCell = e.can_reprint
-                        ? `<button class="btn btn-sm btn-outline-primary history-reprint-btn" data-history-id="${e.id}" data-history-name="${safeFilename}">Reprint</button>`
+                        ? `<button class="btn btn-sm btn-outline-primary history-reprint-btn" data-history-id="${e.id}" data-history-name="${safeFilename}"${printerIndexAttr}>Reprint</button>`
                         : '<span class="text-muted small">-</span>';
                     const printerCell = `<td class="small text-nowrap text-muted">${escapeHtml(e.printer_name || "—")}</td>`;
                     const row = `<tr>
@@ -4165,6 +4223,7 @@ $(function () {
     $("#history-printer-filter").on("change", function () {
         historyFilter = $(this).val();
         historyOffset = 0;
+        updateHistoryScopeUi();
         loadHistory(false);
     });
 
@@ -4174,6 +4233,7 @@ $(function () {
             historyFilter = "active";
             historyOffset = 0;
             fetchAndRenderHistoryFilter();
+            updateHistoryScopeUi();
             loadHistory(false);
         }
     });
@@ -4248,8 +4308,12 @@ $(function () {
     });
 
     $("#history-clear").on("click", function () {
-        if (!confirm("Clear all print history?")) return;
-        fetch(withActivePrinterQuery("/api/history"), { method: "DELETE" })
+        const clearMessage = historyFilter === "__all__"
+            ? "Clear history across all printers?"
+            : `Clear history for ${historyScopeLabel()}?`;
+        if (!confirm(clearMessage)) return;
+        const filterParam = historyFilter === "__all__" ? "all" : historyFilter;
+        fetch(withActivePrinterQuery(`/api/history?filter=${encodeURIComponent(filterParam)}`), { method: "DELETE" })
             .then(() => {
                 selectedHistoryIds.clear();
                 historyOffset = 0;
@@ -4262,6 +4326,7 @@ $(function () {
         const btn = $(this);
         const entryId = btn.attr("data-history-id");
         const entryName = btn.attr("data-history-name") || "selected file";
+        const entryPrinterIndex = parseInt(btn.attr("data-history-printer-index"), 10);
         if (!entryId) {
             return;
         }
@@ -4270,7 +4335,18 @@ $(function () {
         }
         btn.prop("disabled", true);
         try {
-            const resp = await fetch(withActivePrinterQuery(`/api/history/${encodeURIComponent(entryId)}/reprint`), {
+            let reprintUrl = `/api/history/${encodeURIComponent(entryId)}/reprint`;
+            if (historyFilter === "__all__" && Number.isFinite(entryPrinterIndex)) {
+                reprintUrl = withPrinterQuery(reprintUrl, entryPrinterIndex);
+            } else {
+                const scopedPrinterIndex = historyFilterPrinterIndex();
+                if (Number.isFinite(scopedPrinterIndex)) {
+                    reprintUrl = withPrinterQuery(reprintUrl, scopedPrinterIndex);
+                } else {
+                    reprintUrl = withActivePrinterQuery(reprintUrl);
+                }
+            }
+            const resp = await fetch(reprintUrl, {
                 method: "POST",
             });
             const data = await resp.json().catch(() => ({}));

--- a/static/tabs/history.html
+++ b/static/tabs/history.html
@@ -9,7 +9,7 @@
                             <button class="btn btn-sm btn-outline-danger" id="history-delete-selected" disabled>
                                 {{ macro.bi_icon("trash3") }} Delete Selected
                             </button>
-                            <button class="btn btn-sm btn-outline-danger" id="history-clear" title="Clear all history (all printers)">
+                            <button class="btn btn-sm btn-outline-danger" id="history-clear">
                                 {{ macro.bi_icon("trash") }} Clear
                             </button>
                         </div>

--- a/tests/test_print_history.py
+++ b/tests/test_print_history.py
@@ -135,6 +135,44 @@ def test_history_clear_and_fallback_finish_latest_active(tmp_path):
     assert history.get_count() == 0
 
 
+def test_printer_scoped_history_includes_legacy_rows_in_view_and_count(tmp_path):
+    db_path = tmp_path / "history.db"
+    legacy_history = PrintHistory(db_path=db_path)
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    legacy_id = legacy_history.record_start("legacy.gcode", task_id="legacy-task")
+    row0_id = history0.record_start("thing1.gcode", task_id="thing1-task")
+    history1.record_start("thing2.gcode", task_id="thing2-task")
+
+    entries = history0.get_history(limit=10, printer_index=0)
+
+    assert [entry["id"] for entry in entries] == [row0_id, legacy_id]
+    assert [entry["filename"] for entry in entries] == ["thing1.gcode", "legacy.gcode"]
+    assert history0.get_count(printer_index=0) == 2
+
+
+def test_printer_scoped_clear_preserves_other_printers_and_legacy_rows(tmp_path):
+    db_path = tmp_path / "history.db"
+    legacy_history = PrintHistory(db_path=db_path)
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+
+    legacy_id = legacy_history.record_start("legacy.gcode", task_id="legacy-task")
+    row0_id = history0.record_start("thing1.gcode", task_id="thing1-task")
+    row1_id = history1.record_start("thing2.gcode", task_id="thing2-task")
+    legacy_history.record_finish(task_id="legacy-task", progress=100)
+    history0.record_finish(task_id="thing1-task", progress=100)
+    history1.record_finish(task_id="thing2-task", progress=100)
+
+    history0.clear(printer_index=0)
+
+    assert history0.get_entry(row0_id) is None
+    assert history0.get_entry(row1_id) is not None
+    assert history0.get_entry(legacy_id) is not None
+    assert history0.get_count(printer_index=0) == 1
+
+
 def test_archive_upload_and_reprint_flags(tmp_path):
     history = PrintHistory(db_path=tmp_path / "history.db")
 

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -449,7 +449,7 @@ def test_history_routes_require_auth_and_clear_entries():
             or [{"id": 1, "filename": "cube.gcode", "thumbnail_available": False, "printer_index": printer_index}]
         ),
         get_count=lambda printer_index=None: calls.append(("count", printer_index)) or 3,
-        clear=lambda: calls.append(("clear",)),
+        clear=lambda printer_index=None: calls.append(("clear", printer_index)),
     )
     mqtt = SimpleNamespace(history=history)
     client = app.test_client()
@@ -467,7 +467,43 @@ def test_history_routes_require_auth_and_clear_entries():
     assert authorized.get_json()["total"] == 3
     assert authorized.get_json()["entries"][0]["thumbnail_url"] is None
     assert cleared.status_code == 200
-    assert calls == [("get", 500, 0, 0), ("count", 0), ("clear",)]
+    assert calls == [("get", 500, 0, 0), ("count", 0), ("clear", 0)]
+
+
+def test_history_clear_route_respects_filter_scope():
+    clear_calls = []
+    history = SimpleNamespace(
+        get_history=lambda limit, offset, printer_index=None: [],
+        get_count=lambda printer_index=None: 0,
+        clear=lambda printer_index=None: clear_calls.append(printer_index),
+    )
+    cfg = _base_config()
+    cfg.printers = [
+        _printer(sn="SN0", name="Thing 1"),
+        _printer(sn="SN1", name="Thing 2"),
+    ]
+    services = FakeServices()
+    services._services = {
+        "mqttqueue:0": SimpleNamespace(history=history),
+        "mqttqueue:1": SimpleNamespace(history=history),
+    }
+    services.svcs = dict(services._services)
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.config["printer_index"] = 1
+    app.svc = services
+
+    try:
+        active = client.delete("/api/history", headers={"X-Api-Key": API_KEY})
+        specific = client.delete("/api/history?filter=0", headers={"X-Api-Key": API_KEY})
+        all_printers = client.delete("/api/history?filter=all", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert active.status_code == 200
+    assert specific.status_code == 200
+    assert all_printers.status_code == 200
+    assert clear_calls == [1, 0, None]
 
 
 def test_history_route_uses_requested_or_active_indexed_mqtt_service():
@@ -651,6 +687,64 @@ def test_history_reprint_route_dispatches_archived_upload_and_validates_busy(tmp
     args, kwargs = upload_calls[0]
     assert args[1] == "cube.gcode"
     assert kwargs["start_print"] is True
+    assert kwargs["archive_info"]["archive_relpath"] == archive_info["archive_relpath"]
+
+
+def test_history_reprint_route_respects_requested_printer_index(tmp_path):
+    cfg = _base_config()
+    cfg.printers = [
+        _printer(sn="SN0", name="Thing 1"),
+        _printer(sn="SN1", name="Thing 2"),
+    ]
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+    history1 = PrintHistory(db_path=db_path, printer_index=1)
+    archive_info = history1.archive_upload("thing2.gcode", b"G28\nM104 S205\n")
+    entry_id = history1.record_start(
+        "thing2.gcode",
+        archive_relpath=archive_info["archive_relpath"],
+        archive_size=archive_info["archive_size"],
+    )
+    history1.record_finish(filename="thing2.gcode")
+
+    upload_calls = []
+    services = FakeServices()
+    services._services = {
+        "mqttqueue:0": SimpleNamespace(
+            is_printing=False,
+            has_pending_print_start=False,
+            is_preparing_print=False,
+            history=history0,
+        ),
+        "mqttqueue:1": SimpleNamespace(
+            is_printing=False,
+            has_pending_print_start=False,
+            is_preparing_print=False,
+            history=history1,
+        ),
+        "filetransfer": SimpleNamespace(
+            send_bytes=lambda *args, **kwargs: upload_calls.append((args, kwargs)),
+        ),
+    }
+    services.svcs = dict(services._services)
+
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(config=cfg)
+    app.config["printer_index"] = 0
+    app.svc = services
+
+    try:
+        response = client.post(
+            f"/api/history/{entry_id}/reprint?printer_index=1",
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    assert len(upload_calls) == 1
+    _, kwargs = upload_calls[0]
+    assert kwargs["printer_index"] == 1
     assert kwargs["archive_info"]["archive_relpath"] == archive_info["archive_relpath"]
 
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -4427,13 +4427,16 @@ def app_api_history():
     filter_arg = (request.args.get("filter") or "active").lower()
     if filter_arg == "all":
         history_filter = None
+        selected_history_printer_index = None
     elif filter_arg == "active":
         history_filter = printer_index
+        selected_history_printer_index = printer_index
     else:
         try:
-            history_filter = int(filter_arg)
+            selected_history_printer_index = int(filter_arg)
         except (TypeError, ValueError):
-            history_filter = printer_index
+            selected_history_printer_index = printer_index
+        history_filter = selected_history_printer_index
 
     # Build a name lookup from config so each entry carries a printer_name.
     printer_names = {}
@@ -4457,8 +4460,15 @@ def app_api_history():
     serialized_entries = []
     for entry in entries:
         item = dict(entry)
+        thumbnail_printer_index = item.get("printer_index")
+        if thumbnail_printer_index is None:
+            thumbnail_printer_index = selected_history_printer_index if history_filter is not None else printer_index
         item["thumbnail_url"] = (
-            url_for("app_api_history_thumbnail", entry_id=item["id"], printer_index=printer_index)
+            url_for(
+                "app_api_history_thumbnail",
+                entry_id=item["id"],
+                printer_index=thumbnail_printer_index,
+            )
             if item.get("thumbnail_available")
             else None
         )
@@ -4473,10 +4483,20 @@ def app_api_history():
 
 @app.delete("/api/history")
 def app_api_history_clear():
-    """Clear all print history."""
-    printer_index = _requested_printer_index()
-    with borrow_mqtt(printer_index) as mqtt:
-        mqtt.history.clear()
+    """Clear print history within the current history filter scope."""
+    requested_printer_index = _requested_printer_index()
+    filter_arg = (request.args.get("filter") or "active").lower()
+    if filter_arg == "all":
+        clear_printer_index = None
+    elif filter_arg == "active":
+        clear_printer_index = requested_printer_index
+    else:
+        try:
+            clear_printer_index = int(filter_arg)
+        except (TypeError, ValueError):
+            clear_printer_index = requested_printer_index
+    with borrow_mqtt(requested_printer_index) as mqtt:
+        mqtt.history.clear(printer_index=clear_printer_index)
     return {"status": "ok"}
 
 

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -564,18 +564,21 @@ class PrintHistory:
     def get_history(self, limit=50, offset=0, printer_index=None):
         """Return recent print history as list of dicts.
 
-        Pass printer_index to restrict to one printer; None returns all.
+        Pass printer_index to restrict to one printer while still including
+        legacy rows that predate the printer_index column. None returns all.
         """
         params = []
         where = ""
+        order_by = " ORDER BY id DESC"
         if printer_index is not None:
-            where = " WHERE printer_index=?"
+            where = " WHERE printer_index=? OR printer_index IS NULL"
             params.append(int(printer_index))
+            order_by = " ORDER BY CASE WHEN printer_index IS NULL THEN 1 ELSE 0 END, id DESC"
         params.extend([limit, offset])
         with self._lock:
             with self._connect() as conn:
                 rows = conn.execute(
-                    f"SELECT * FROM print_history{where} ORDER BY id DESC LIMIT ? OFFSET ?",
+                    f"SELECT * FROM print_history{where}{order_by} LIMIT ? OFFSET ?",
                     params,
                 ).fetchall()
                 return [self._decorate_entry(r, conn=conn) for r in rows]
@@ -635,10 +638,14 @@ class PrintHistory:
         return self.get_history(limit=limit, offset=offset)
 
     def get_count(self, printer_index=None):
-        """Return total number of entries. Pass printer_index to filter by printer."""
+        """Return total number of entries.
+
+        Pass printer_index to filter by printer while still counting legacy
+        rows that have no printer_index.
+        """
         where, params = "", ()
         if printer_index is not None:
-            where = " WHERE printer_index=?"
+            where = " WHERE printer_index=? OR printer_index IS NULL"
             params = (int(printer_index),)
         with self._lock:
             with self._connect() as conn:
@@ -695,12 +702,50 @@ class PrintHistory:
                     log.info("History: deleted %d selected entr%s", deleted, "y" if deleted == 1 else "ies")
                 return deleted
 
-    def clear(self):
-        """Delete all history entries."""
+    def clear(self, printer_index=None):
+        """Delete history entries.
+
+        When printer_index is provided, only rows for that printer are removed.
+        Legacy rows with NULL printer_index are preserved.
+        """
         with self._lock:
             with self._connect() as conn:
-                conn.execute("DELETE FROM print_history")
-                conn.commit()
-                log.info("Print history cleared")
-        if self._archive_dir and os.path.isdir(self._archive_dir):
+                if printer_index is None:
+                    conn.execute("DELETE FROM print_history")
+                    conn.commit()
+                    log.info("Print history cleared")
+                    delete_archive_dir = True
+                else:
+                    scoped_index = int(printer_index)
+                    archive_relpaths = [
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT DISTINCT archive_relpath FROM print_history "
+                            "WHERE printer_index=? AND archive_relpath IS NOT NULL AND archive_relpath != ''",
+                            (scoped_index,),
+                        ).fetchall()
+                        if row[0]
+                    ]
+                    conn.execute(
+                        "DELETE FROM print_history WHERE printer_index=?",
+                        (scoped_index,),
+                    )
+                    if archive_relpaths:
+                        still_referenced = {
+                            row[0]
+                            for row in conn.execute(
+                                "SELECT DISTINCT archive_relpath FROM print_history "
+                                f"WHERE archive_relpath IN ({','.join('?' for _ in archive_relpaths)})",
+                                tuple(archive_relpaths),
+                            ).fetchall()
+                            if row[0]
+                        }
+                        self._delete_archive_relpaths(
+                            [relpath for relpath in archive_relpaths if relpath not in still_referenced]
+                        )
+                    self._delete_unreferenced_archives(conn)
+                    conn.commit()
+                    log.info("Print history cleared for printer %d", scoped_index)
+                    delete_archive_dir = False
+        if delete_archive_dir and self._archive_dir and os.path.isdir(self._archive_dir):
             shutil.rmtree(self._archive_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

This PR supersedes #70 on top of the current `master` after #73 landed.

It keeps the existing history scope model already on `master` (`filter=active|all|<printer_index>`) and adds the missing behavior from #70 without reintroducing the alternate `all_printers=1` flow.

## Changes

- Include legacy history rows with `printer_index IS NULL` in per-printer history views and counts
- Scope `DELETE /api/history` to the current history filter instead of clearing everything unconditionally
- Route history reprint to the entry's original printer when viewing all printers
- Update the History tab clear confirmation/tooltip so they reflect the current filter scope
- Add service- and API-level regression coverage for the reconciled behavior

## Why this replaces #70

`master` already contains a different multi-printer history UI/API model from the merged camera/history work, so #70 no longer merges cleanly and would introduce a second competing scope mechanism. This follow-up ports the useful behavior onto the current codebase instead.

## Test plan

- [x] `python -m pytest tests/test_print_history.py tests/test_printer_media_history_api.py -x`
- [x] `make check`

Results:
- `43 passed` for the targeted history suites
- `406 passed, 16 skipped` for `make check`

Supersedes #70.