### PR TITLE
fix: bound MQTT/upload stream queues, remove redundant XZYH drain (Phase 3a)

### DIFF
--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -540,7 +540,10 @@ def test_pppp_service_worker_run_handles_reset_aabb_and_xzyh(monkeypatch):
 
     assert notifications[0][0] == 0
     assert notifications[0][1].data == b"x"
-    assert drained == [1]
+    # Single-channel API: the skip_rx_gap path is skipped (len(chans) == 1) and
+    # the AABB packet doesn't trigger an XZYH drain (M6 - no redundant
+    # unconditional drain of channel 1).
+    assert drained == []
 
     drained.clear()
     notifications.clear()
@@ -551,7 +554,8 @@ def test_pppp_service_worker_run_handles_reset_aabb_and_xzyh(monkeypatch):
     )
     svc.worker_run(timeout=0.1)
 
-    assert drained == [1, 0]
+    # XZYH-prefixed DRW data on channel 0 drains channel 0 only.
+    assert drained == [0]
 
     channel = FakeFD(
         peeks=[b"abcd" + b"\x00" * 12, b"abcd"],

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -359,6 +359,8 @@ SNAPSHOT_FRAME_WAIT_SEC = 3.0
 SNAPSHOT_FRAME_MAX_AGE_SEC = 2.0
 SNAPSHOT_FFMPEG_TIMEOUT_SEC = 30
 VIDEO_STREAM_QUEUE_MAX = 30
+MQTT_STREAM_QUEUE_MAX = 500
+UPLOAD_STREAM_QUEUE_MAX = 500
 
 
 def _video_has_recent_frame(vq, wait_sec=SNAPSHOT_FRAME_WAIT_SEC, max_age_sec=SNAPSHOT_FRAME_MAX_AGE_SEC):
@@ -742,11 +744,11 @@ def borrow_pppp(printer_index=None, ready=True):
     raise RuntimeError("No pppp service candidates available")
 
 
-def stream_mqtt(printer_index=None):
+def stream_mqtt(printer_index=None, maxsize=0):
     last_error = None
     for name in _mqtt_service_candidates(printer_index):
         try:
-            return app.svc.stream(name)
+            return app.svc.stream(name, maxsize=maxsize)
         except (AssertionError, KeyError, AttributeError) as err:
             last_error = err
             continue
@@ -2248,7 +2250,7 @@ def mqtt(sock):
             log.info("/ws/mqtt: new client connected, cancelling MQTT reconnect back-off")
             _mqtt_svc_ref.reset_reconnect_backoff()
     try:
-        for data in stream_mqtt(printer_index):
+        for data in stream_mqtt(printer_index, maxsize=MQTT_STREAM_QUEUE_MAX):
             log.debug(f"MQTT message: {data}")
             sock.send(json.dumps(data))
     except ConnectionClosed:
@@ -2553,7 +2555,7 @@ def upload(sock):
         return
 
     try:
-        for data in app.svc.stream("filetransfer"):
+        for data in app.svc.stream("filetransfer", maxsize=UPLOAD_STREAM_QUEUE_MAX):
             sock.send(json.dumps(data))
     except ConnectionClosed:
         log.debug("/ws/upload closed by client")

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -350,8 +350,6 @@ class PPPPService(Service):
             if chans[1].skip_rx_gap(max_queued=8):
                 self._drain_xzyh(chan=1)
 
-        self._drain_xzyh(chan=1)
-
         if not msg or msg.type != Type.DRW:
             return
 


### PR DESCRIPTION
## Summary
Phase 3 ("Ressourcen & Hotpath") of the code review fix plan, part 1 of 2 — the low-risk, mechanical items:

- **M1**: `/ws/mqtt` and `/ws/upload` streams now use bounded queues (`MQTT_STREAM_QUEUE_MAX = 500`, `UPLOAD_STREAM_QUEUE_MAX = 500`), matching the existing `VIDEO_STREAM_QUEUE_MAX = 30` pattern. `ServiceManager._enqueue_stream_item` already implements drop-oldest-on-overflow, so this just threads `maxsize` through to the two previously-unbounded call sites — preventing unbounded memory growth on slow consumers.
- **M6**: removed the redundant unconditional `self._drain_xzyh(chan=1)` in `PPPPService.worker_run()`. The `skip_rx_gap` branch and the per-message DRW-path `_drain_xzyh(chan=msg.chan)` already cover channel-1 draining; the extra call was a duplicate no-op in the common case.

Part 2 (M5: `Wire`/`Channel` locking refactor, M4: `memoryview` in `Channel.write`) will follow as a separate PR on a follow-up branch, per the report's recommendation to split Phase 3 into 1-2 PRs given the higher risk of touching the PPPP hot path.

## Test plan
- [x] `python -m pytest -q` → 427 passed, 0 failed, 16 skipped (matches pre-change baseline)
- [x] Targeted re-run of `tests/test_service_recovery_paths.py`, `tests/test_protocol_pppp.py`, `tests/test_service_framework.py` → 38 passed (assertions updated for the corrected drain behavior in M6)
- [ ] CI (8 checks)