### PR TITLE
fix: PPPP Wire/Channel locking refactor + upload memoryview/size limit (M5+M4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,8 @@ ANKERCTL_API_KEY=REPLACE_WITH_SECURE_KEY
 # Port des Webservers (default: 4470)
 #FLASK_PORT=4470
 
-# Maximale Upload-Größe in Megabyte (default: 2048)
-#UPLOAD_MAX_MB=2048
+# Maximale Upload-Größe in Megabyte (default: 512)
+#UPLOAD_MAX_MB=512
 
 # Upload-Geschwindigkeit zum Drucker in Mbit/s (Werte: 5, 10, 25, 50, 100; default: 10)
 #UPLOAD_RATE_MBPS=10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ PRINTER_INDEX          # Select printer (default: 0)
 FLASK_HOST             # Web server host (default: 127.0.0.1)
 FLASK_PORT             # Web server port (default: 4470)
 FLASK_SECRET_KEY       # Session cookie secret (auto-generated if unset; set for persistence)
-UPLOAD_MAX_MB          # Max file upload size in MB (default: 2048)
+UPLOAD_MAX_MB          # Max file upload size in MB (default: 512)
 
 # --- Security ---
 ANKERCTL_API_KEY       # API key for write-operation auth (unset = no auth)

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ ankerctl is configured through environment variables. For Docker deployments, co
 | `FLASK_SECRET_KEY` | *(auto-generated)* | Session cookie secret; set this explicitly if you want it to persist across restarts |
 | `PRINTER_INDEX` | `0` | Select printer by index when multiple printers are configured |
 | **Upload** | | |
-| `UPLOAD_MAX_MB` | `2048` | Maximum upload file size in MB |
+| `UPLOAD_MAX_MB` | `512` | Maximum upload file size in MB |
 | `UPLOAD_RATE_MBPS` | `10` | Upload speed to printer in Mbit/s (choices: 5, 10, 25, 50, 100) |
 | **Security** | | |
 | `ANKERCTL_API_KEY` | *(unset)* | API key for write-operation authentication |

--- a/documentation/SECURITY_AUDIT.md
+++ b/documentation/SECURITY_AUDIT.md
@@ -117,7 +117,7 @@ Benutzerfreundliche Fehlermeldungen, Details nur in Server-Logs via `log.excepti
 **Datei:** `web/__init__.py`
 **Status:** Behoben (Phase 1)
 
-Konfigurierbares Limit via `UPLOAD_MAX_MB` ENV (Default: 2 GB).
+Konfigurierbares Limit via `UPLOAD_MAX_MB` ENV (Default: 512 MB).
 
 ---
 

--- a/documentation/SECURITY_IMPLEMENTATION_PLAN.md
+++ b/documentation/SECURITY_IMPLEMENTATION_PLAN.md
@@ -11,7 +11,7 @@ Basierend auf dem [Security Audit](./SECURITY_AUDIT.md). Alle Phasen umgesetzt.
 | 1.1 | Config-Verzeichnis `0700` (K2) | `cli/config.py` | `os.chmod(dirs.user_config_path, 0o700)` nach `mkdir()` |
 | 1.2 | `secrets` statt `random` (H1) | `libflagship/seccode.py` | `secrets.randbelow(90000000) + 10000000` |
 | 1.3 | Mutable Default fixen (M5) | `libflagship/httpapi.py` | `invalid_dsks=None` + Body-Initialisierung |
-| 1.4 | Upload-Limit (M4) | `web/__init__.py` | `UPLOAD_MAX_MB` ENV (Default: 2 GB) |
+| 1.4 | Upload-Limit (M4) | `web/__init__.py` | `UPLOAD_MAX_MB` ENV (Default: 512 MB) |
 
 ---
 

--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -6,9 +6,8 @@ import logging as log
 import time
 
 from enum import Enum
-from multiprocessing import Pipe
 from datetime import datetime, timedelta
-from threading import Thread, Event, Lock
+from threading import Thread, Event, Lock, Condition
 from socket import AF_INET
 from dataclasses import dataclass
 
@@ -120,32 +119,26 @@ class Wire:
 
     def __init__(self):
         self.buf = bytearray()
-        self.rx, self.tx = Pipe(False)
+        self._cond = Condition()
 
     def peek(self, size, timeout=None):
-        # Zero timeout on self.rx.poll() means "wait forever", but we want it to
-        # mean "no wait", so we emulate that by setting it to 1us.
-        if timeout == 0.0:
-            timeout = 0.000001
-
-        if timeout is not None:
-            deadline = datetime.now() + timedelta(seconds=timeout)
-
-        while len(self.buf) < size:
-            if timeout and not self.rx.poll(timeout=(deadline - datetime.now()).total_seconds()):
+        with self._cond:
+            if not self._cond.wait_for(lambda: len(self.buf) >= size, timeout=timeout):
                 return None
-            self.buf.extend(self.rx.recv())
-
-        return bytes(self.buf[:size])
+            return bytes(self.buf[:size])
 
     def read(self, size, timeout=None):
-        res = self.peek(size, timeout)
-        if res:
+        with self._cond:
+            if not self._cond.wait_for(lambda: len(self.buf) >= size, timeout=timeout):
+                return None
+            res = bytes(self.buf[:size])
             del self.buf[:size]
-        return res
+            return res
 
     def write(self, data):
-        self.tx.send(data)
+        with self._cond:
+            self.buf.extend(data)
+            self._cond.notify_all()
 
 
 class Channel:
@@ -166,6 +159,7 @@ class Channel:
         self.max_in_flight = max_in_flight
         self.max_age_warn = max_age_warn
         self.lock = Lock()
+        self._tx_lock = Lock()
         self._rx_gap_report_at = 0.0
         self._rx_gap_report_skips = 0
         self._rx_gap_report_packets = 0
@@ -250,12 +244,13 @@ class Channel:
 
         txq = self.txqueue
 
-        if self.backlog and len(txq) < self.max_in_flight:
-            while self.backlog and len(txq) < self.max_in_flight:
-                txq.append(self.backlog.pop(0))
+        with self._tx_lock:
+            if self.backlog and len(txq) < self.max_in_flight:
+                while self.backlog and len(txq) < self.max_in_flight:
+                    txq.append(self.backlog.pop(0))
 
-            # sort list to make sure oldest deadline is first
-            txq.sort()
+                # sort list to make sure oldest deadline is first
+                txq.sort()
 
         res = []
         now = datetime.now()
@@ -279,19 +274,23 @@ class Channel:
         return self.rx.read(nbytes, timeout)
 
     def write(self, payload, block=True, timeout=None):
-        pdata = payload[:]
+        # memoryview avoids re-copying the shrinking tail on each chunk
+        # (bytes slicing is O(n^2) for large payloads); chunks are converted
+        # back to bytes since packet packing requires a bytes/Bytes payload.
+        pdata = memoryview(payload)
 
         tx_ctr_start = self.tx_ctr
 
         # schedule all packets, starting from current time
         deadline = datetime.now()
-        while pdata:
-            # schedule transmission in 1kb chunks
-            data, pdata = pdata[:1024], pdata[1024:]
-            self.backlog.append((deadline, self.tx_ctr, data))
-            self.tx_ctr += 1
+        with self._tx_lock:
+            while pdata:
+                # schedule transmission in 1kb chunks
+                data, pdata = bytes(pdata[:1024]), pdata[1024:]
+                self.backlog.append((deadline, self.tx_ctr, data))
+                self.tx_ctr += 1
 
-        tx_ctr_done = self.tx_ctr
+            tx_ctr_done = self.tx_ctr
 
         deadline = None
         if block and timeout is not None:
@@ -317,7 +316,8 @@ class Channel:
     def reset_tx(self):
         with self.lock:
             self.txqueue.clear()
-            self.backlog.clear()
+            with self._tx_lock:
+                self.backlog.clear()
             self.acks.clear()
             self.tx_ack = self.tx_ctr
             self.event.set()

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -522,7 +522,7 @@ def _build_windows_launcher_bat(install_dir):
 def _configure_request_limits(flask_app, env=None):
     # Keep large GCode uploads configurable, but bound multipart metadata more
     # tightly. These form limits apply to multipart parsing, not the file size.
-    max_upload_mb = _env_int("UPLOAD_MAX_MB", 2048, env=env)
+    max_upload_mb = _env_int("UPLOAD_MAX_MB", 512, env=env)
     max_form_memory_kb = _env_int("UPLOAD_MAX_FORM_MEMORY_KB", 512, env=env)
     max_form_parts = _env_int("UPLOAD_MAX_FORM_PARTS", 20, env=env)
 


### PR DESCRIPTION
## Summary

Phase 3b of the code review fix plan (see `CODE_REVIEW_REPORT.md`), addressing **M5** and **M4**.

### M5 — PPPP `Wire` over `multiprocessing.Pipe`

- `Wire` is rewritten from a `multiprocessing.Pipe(False)`-backed buffer to a plain `bytearray` guarded by `threading.Condition`. The `peek/read/write` interface and timeout semantics (`None` = block forever, `0.0`/positive = bounded wait) are preserved exactly.
- This removes per-call pipe `send`/`recv` overhead (pickling + syscalls) for what is purely intra-process, cross-thread data.

**Design deviation from the report:** the report suggested reusing `Channel.lock` to also guard `backlog`/`txqueue` in `write()`/`poll()`. Instead this PR introduces a small dedicated `Channel._tx_lock` that protects `self.backlog` only (the one field genuinely shared between the `run()` thread's `poll()` and a consumer thread's `write()`).

Reasoning: `Channel.lock` can be held for a long, blocking duration by `recv_xzyh`/`recv_aabb` (e.g. `timeout=None`). `run()`'s main loop calls `poll()` sequentially for all 8 channels (`for idx, ch in enumerate(self.chans): ...`). If `poll()`'s backlog-merge took `Channel.lock`, a consumer blocked in `recv_xzyh` on channel 1 would stall `poll()` — and therefore retransmission/ack-scheduling — for channels 2-8 as well. `_tx_lock` is never held across a blocking `Wire` call, so it achieves the report's safety goal (protect the backlog from concurrent mutation) without this stall risk.

`reset_tx()` now clears `backlog` under `_tx_lock` (nested inside the existing `Channel.lock`).

### M4 — Upload path holds full GCode file (multiple times) in RAM

- `Channel.write()` previously did `pdata = payload[:]` then repeatedly `data, pdata = pdata[:1024], pdata[1024:]`. While `bytes[:]` is a no-op in CPython, `pdata[1024:]` re-copies the shrinking remainder on every iteration — O(n²) for large payloads (benchmarked ~40x slower at 5MB vs. the new approach, growing quadratically).
- Fixed by walking the payload via `memoryview(payload)` (O(1) slicing), but materializing each 1KB chunk back to `bytes` before queuing (`bytes(pdata[:1024])`), since `Tail.pack()` in the transwarp-generated `libflagship/amtypes.py` requires `isinstance(data, bytes)` and would raise `AttributeError` on a raw `memoryview`.
- Lowered the `UPLOAD_MAX_MB` default from 2048 to 512 (still configurable via `UPLOAD_MAX_MB` env var) to reduce worst-case memory pressure on low-RAM hosts (e.g. Raspberry Pi). Updated `.env.example`, `CLAUDE.md`, `README.md`, `documentation/SECURITY_AUDIT.md`, `documentation/SECURITY_IMPLEMENTATION_PLAN.md` accordingly.

## Test plan

- [x] `python -m pytest -q` — 427 passed, 0 failed, 16 skipped (matches baseline)
- [x] `tests/test_protocol_pppp.py` — 10 passed
- [ ] CI green (8/8 checks)