### PR TITLE
fix: cosmetic cleanup pass (L1, L2, L3, L5, L6)

### DIFF
--- a/libflagship/ppppapi.py
+++ b/libflagship/ppppapi.py
@@ -255,10 +255,16 @@ class Channel:
         res = []
         now = datetime.now()
 
+        retransmitted = False
         while txq and txq[0][0] < now:
             deadline, index, pkt = txq.pop(0)
             res.append(PktDrw(chan=self.index, index=index, data=pkt))
             txq.append((deadline + self.timeout, index, pkt))
+            retransmitted = True
+
+        if retransmitted:
+            # restore deadline ordering after appending rescheduled packets
+            txq.sort()
 
         # the returned chunks will be (re)transmitted
         return res

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1294,8 +1294,10 @@ $(function () {
         }
 
         _message(event) {
-            // Check for server-side auth rejection before processing
-            if (typeof event.data === "string") {
+            // Check for server-side auth rejection before processing. Only
+            // needed on the first message: a rejection closes the socket
+            // immediately, so once we're open this can't happen anymore.
+            if (!this.is_open && typeof event.data === "string") {
                 try {
                     const parsed = JSON.parse(event.data);
                     if (parsed.error === "unauthorized") {
@@ -1811,7 +1813,8 @@ $(function () {
             }
             const now = window.performance && window.performance.now ? window.performance.now() : Date.now();
             this.videoQueue.push({
-                data: event.data.slice(0),
+                // event.data is a fresh ArrayBuffer per message, no copy needed
+                data: event.data,
                 receivedAt: now,
             });
             if (this.videoQueue.length > this.videoBufferMaxPackets) {

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -1875,10 +1875,15 @@ class MqttQueue(Service):
             return
 
         lines = cli.util.normalize_gcode_lines(gcode)
+        first = True
         for line in lines:
             if self._is_duplicate_g28(line):
                 log.debug("Ignoring duplicate homing command: %s", line)
                 continue
+            if not first:
+                # pace commands; no need to wait after the last one
+                time.sleep(0.1)
+            first = False
             cmd = {
                 "commandType": MqttMsgType.ZZ_MQTT_CMD_GCODE_COMMAND.value,
                 "cmdData": line,
@@ -1886,7 +1891,6 @@ class MqttQueue(Service):
             }
             log.debug("Sending GCode command: %s", line)
             self.client.command(cmd)
-            time.sleep(0.1)
 
     def _is_duplicate_g28(self, line):
         parts = line.split()

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -1,5 +1,5 @@
 import json
-import logging as log
+import logging
 import threading
 import time
 
@@ -14,6 +14,8 @@ from libflagship.pppp import P2PCmdType, PktClose, Duid, Type, Xzyh, Aabb
 from libflagship.ppppapi import AnkerPPPPAsyncApi, PPPPState
 
 import cli.pppp
+
+log = logging.getLogger("pppp")
 
 # Some printers take a few extra seconds to accept a fresh PPPP session after
 # a video/timelapse recovery. A slightly longer deadline avoids unnecessary
@@ -165,7 +167,7 @@ class PPPPService(Service):
         )
         if not ip_addr:
             self._log_repeated(
-                log.WARNING,
+                logging.WARNING,
                 ("no_ip", printer_index, printer.p2p_duid),
                 "%s: PPPP connect aborted because no printer IP was resolved "
                 "(printer=%s, duid=%s)",
@@ -184,7 +186,7 @@ class PPPPService(Service):
 
         started_at = datetime.now()
         self._log_repeated(
-            log.INFO,
+            logging.INFO,
             ("connect_attempt", printer_index, ip_addr),
             "%s: trying connect to printer %s (%s) over pppp using ip %s "
             "(deadline=%.1fs)",
@@ -202,7 +204,7 @@ class PPPPService(Service):
             if remaining <= 0:
                 elapsed = (datetime.now() - started_at).total_seconds()
                 self._log_repeated(
-                    log.WARNING,
+                    logging.WARNING,
                     ("connect_timeout", printer_index, ip_addr),
                     "%s: PPPP connection timed out after %.1fs "
                     "(printer=%s, ip=%s, state=%s)",
@@ -219,7 +221,7 @@ class PPPPService(Service):
             except ConnectionResetError:
                 elapsed = (datetime.now() - started_at).total_seconds()
                 self._log_repeated(
-                    log.WARNING,
+                    logging.WARNING,
                     ("connect_reset", printer_index, ip_addr),
                     "%s: PPPP connection reset after %.1fs "
                     "(printer=%s, ip=%s)",


### PR DESCRIPTION
## Summary

Phase 4 of the code review fix plan (see `CODE_REVIEW_REPORT.md`) — the collected "Kosmetik" cleanup PR covering L1, L2, L3, L5, L6.

- **L1** (`static/ankersrv.js` `AutoWebSocket._message`): the auth-rejection `JSON.parse` now only runs while `!this.is_open`. A server-side `unauthorized` rejection always arrives as the very first message and immediately closes the socket, so there's no need to re-parse every subsequent text message just for this check.
- **L2** (`static/ankersrv.js` video WS handler): removed `event.data.slice(0)`. Each WebSocket message delivers its own standalone `ArrayBuffer`, so the defensive copy was unnecessary per-frame overhead.
- **L3** (`web/service/mqtt.py` `send_gcode`): `time.sleep(0.1)` now runs *between* commands instead of after every command, so the last line no longer adds a trailing delay to the API response. Pacing between commands is unchanged.
- **L5** (`web/service/pppp.py`): replaced `import logging as log` with `logging` + `log = logging.getLogger("pppp")`, matching the convention used by `mqtt.py`/`history.py`/`timelapse.py`. Logging-level constants (`log.WARNING`/`log.INFO`) now reference `logging.WARNING`/`logging.INFO`.
- **L6** (`libflagship/ppppapi.py` `Channel.poll()`): after the retransmit loop re-appends rescheduled packets to `txqueue`, re-sort the queue so deadline ordering doesn't drift over time.

## Test plan

- [x] `python -m pytest -q` — 427 passed, 0 failed, 16 skipped (matches baseline)
- [ ] CI green (8/8 checks)