### PR TITLE
Security/stability review pass, PPPP upload hardening, fan telemetry

### DIFF
--- a/ankerctl.py
+++ b/ankerctl.py
@@ -202,7 +202,7 @@ def mqtt_send(env, command_type, args, force):
             log.fatal("Refusing to perform factory reset (override with --force)")
             raise SystemExit(1)
 
-        if command_type == MqttMsgType.ZZ_MQTT_CMD_DEVICE_NAME_SET and "devName" not in cmd:
+        if command_type == MqttMsgType.ZZ_MQTT_CMD_DEVICE_NAME_SET and not cmd.get("devName"):
             log.fatal("Sending DEVICE_NAME_SET without devName=<name> will crash printer (override with --force)")
             raise SystemExit(1)
 
@@ -283,6 +283,10 @@ def mqtt_rename_printer(env, newname):
     """
     Set a new nickname for your printer
     """
+
+    if not newname.strip():
+        log.fatal("Printer name cannot be empty")
+        raise SystemExit(1)
 
     client = cli.mqtt.mqtt_open(env.config, env.printer_index, env.insecure, env.mqtt_ca_cert)
 
@@ -417,7 +421,6 @@ def pppp_print_file(env, file, no_act, upload_rate_mbps):
     file, so anytime a file is uploaded, the old one is deleted.
     """
     env.load_config()
-    api = cli.pppp.pppp_open(env.config, env.printer_index, dumpfile=env.pppp_dump)
 
     user_id = "-"
     with env.config.open() as cfg:
@@ -430,6 +433,7 @@ def pppp_print_file(env, file, no_act, upload_rate_mbps):
     fui = FileUploadInfo.from_data(data, file.name, user_name="ankerctl", user_id=user_id, machine_id=file_uuid)
     log.info(f"Going to upload {fui.size} bytes as {fui.name!r}")
     log.info(f"Using upload rate limit: {rate_limit_mbps} Mbps")
+    api = cli.pppp.pppp_open(env.config, env.printer_index, dumpfile=env.pppp_dump)
     try:
         cli.pppp.pppp_send_file(api, fui, data, rate_limit_mbps=rate_limit_mbps)
         if no_act:
@@ -461,11 +465,11 @@ def pppp_capture_video(env, file, max_size):
     env.load_config()
     api = cli.pppp.pppp_open(env.config, env.printer_index, dumpfile=env.pppp_dump)
 
-    cmd = {"commandType": P2PSubCmdType.START_LIVE, "data": {"encryptkey": "x", "accountId": "y"}}
-    api.send_xzyh(json.dumps(cmd).encode(), cmd=P2PCmdType.P2P_JSON_CMD)
+    size = 0
     try:
+        cmd = {"commandType": P2PSubCmdType.START_LIVE, "data": {"encryptkey": "x", "accountId": "y"}}
+        api.send_xzyh(json.dumps(cmd).encode(), cmd=P2PCmdType.P2P_JSON_CMD, timeout=5.0)
         with tqdm(unit="b", total=max_size, unit_scale=True, unit_divisor=1024) as bar:
-            size = 0
             while True:
                 d = api.recv_xzyh(chan=1)
                 size += len(d.data)
@@ -475,8 +479,11 @@ def pppp_capture_video(env, file, max_size):
                 if size >= max_size:
                     break
     finally:
-        cmd = {"commandType": P2PSubCmdType.CLOSE_LIVE}
-        api.send_xzyh(json.dumps(cmd).encode(), cmd=P2PCmdType.P2P_JSON_CMD)
+        try:
+            cmd = {"commandType": P2PSubCmdType.CLOSE_LIVE}
+            api.send_xzyh(json.dumps(cmd).encode(), cmd=P2PCmdType.P2P_JSON_CMD, timeout=5.0)
+        finally:
+            api.stop()
 
     log.info(f"Successfully captured {cli.util.pretty_size(size)} video stream into {file.name}")
 
@@ -577,8 +584,9 @@ def config(ctx):
 
 @config.command("decode")
 @click.argument("fd", required=False, type=click.File("rb"), metavar="path/to/login.json")
+@click.option("--show-secrets", is_flag=True, help="Print full auth_token/user_id instead of redacting them")
 @pass_env
-def config_decode(env, fd):
+def config_decode(env, fd, show_secrets):
     """
     Decode a `login.json` file and print its contents.
     """
@@ -589,6 +597,12 @@ def config_decode(env, fd):
     log.info("Loading file..")
 
     cache = libflagship.logincache.load(fd.read())["data"]
+    if not show_secrets:
+        cache = dict(cache)
+        for key in ("auth_token", "user_id"):
+            value = cache.get(key)
+            if value:
+                cache[key] = f"{value[:10]}...<REDACTED>"
     print(json.dumps(cache, indent=4))
 
 
@@ -643,6 +657,12 @@ def config_login(env, country, email, password):
 
     if password is None:
         password = getpass.getpass("Please enter your password: ")
+    else:
+        log.warning(
+            "Passing the password as a command-line argument exposes it in your "
+            "shell history and to other local users via 'ps'. Omit it to be "
+            "prompted securely instead."
+        )
 
     if country:
         country = country.upper()

--- a/cli/config.py
+++ b/cli/config.py
@@ -78,13 +78,24 @@ class BaseConfigManager:
         if not path.exists():
             return default
 
-        with path.open() as f:
-            return json.load(f, object_hook=self._load_json)
+        try:
+            with path.open() as f:
+                return json.load(f, object_hook=self._load_json)
+        except (json.JSONDecodeError, UnicodeDecodeError) as err:
+            corrupt_path = path.with_name(f"{path.name}.corrupt-{int(datetime.now().timestamp())}")
+            log.critical(f"Config file {path} is corrupt ({err}); moving aside to {corrupt_path} and using defaults")
+            try:
+                path.rename(corrupt_path)
+            except OSError as rename_err:
+                log.critical(f"Failed to move aside corrupt config file {path}: {rename_err}")
+            return default
 
     def save(self, name, value):
         path = self.config_path(name)
-        path.write_text(json.dumps(value, default=self._save_json, indent=2) + "\n")
-        path.chmod(0o600)
+        tmp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+        tmp_path.write_text(json.dumps(value, default=self._save_json, indent=2) + "\n")
+        tmp_path.chmod(0o600)
+        os.replace(tmp_path, path)
 
 
 class AnkerConfigManager(BaseConfigManager):

--- a/cli/model.py
+++ b/cli/model.py
@@ -9,6 +9,9 @@ from libflagship.util import unhex, enhex
 DEFAULT_UPLOAD_RATE_MBPS = 10
 UPLOAD_RATE_MBPS_CHOICES = (5, 10, 25, 50, 100)
 MQTT_CA_CERT_ENVVAR = "ANKERCTL_MQTT_CA_CERT"
+HOTEND_STANDARD_NOZZLE_MAX_C = 260
+HOTEND_ALL_METAL_NOZZLE_MAX_C = 300
+HOTEND_BED_MAX_C = 100
 
 
 def default_apprise_config():
@@ -87,6 +90,7 @@ def default_filament_service_config():
             "FILAMENT_SWAP_HOME_PAUSE_S",
             os.getenv("FILAMENT_SWAP_HOME_SETTLE_S", 70),
         )),
+        "per_printer": {},
     }
 
 

--- a/cli/pppp.py
+++ b/cli/pppp.py
@@ -17,6 +17,8 @@ _PPPP_PROBE_ATTEMPTS = 2
 _PPPP_LAN_SEARCH_RETRIES = 3
 _PPPP_LAN_SEARCH_MIN_WINDOW = 0.35
 _PPPP_LAN_SEARCH_RETRY_GAP = 0.15
+_PPPP_OPEN_RETRY_GAP = 0.3
+_PPPP_OPEN_ATTEMPT_WINDOW = 3.0
 
 
 def _pppp_dumpfile(api, dumpfile):
@@ -27,8 +29,7 @@ def _pppp_dumpfile(api, dumpfile):
 
 
 def pppp_open(config, printer_index, timeout=None, dumpfile=None):
-    if timeout:
-        deadline = datetime.now() + timedelta(seconds=timeout)
+    deadline = datetime.now() + timedelta(seconds=timeout) if timeout else None
 
     with config.open() as cfg:
         if printer_index < 0 or printer_index >= len(cfg.printers):
@@ -38,22 +39,53 @@ def pppp_open(config, printer_index, timeout=None, dumpfile=None):
         if not ip_addr:
             raise ConnectionRefusedError("No printer IP found; ensure printer is online on the same network")
 
+    attempt = 0
+    while True:
+        attempt += 1
         api = AnkerPPPPApi.open_lan(Duid.from_string(printer.p2p_duid), host=ip_addr)
         _pppp_dumpfile(api, dumpfile)
 
-        log.info(f"Trying connect to printer {printer.name} ({printer.p2p_duid}) over pppp using ip {ip_addr}")
+        log.info(
+            f"Trying connect to printer {printer.name} ({printer.p2p_duid}) over pppp using ip {ip_addr}"
+            + (f" (attempt {attempt})" if attempt > 1 else "")
+        )
 
         api.connect_lan_search()
         api.start()
 
-        while api.state != PPPPState.Connected:
-            time.sleep(0.1)
-            if api.stopped.is_set() or (timeout and (datetime.now() > deadline)):
-                api.stop()
-                raise ConnectionRefusedError("Connection rejected by device")
+        # Cap each attempt to a sub-window of the overall deadline. A silent
+        # non-completing attempt (no CLOSE, connection just never establishes)
+        # must not consume the whole budget, or the retry loop below never
+        # gets a second attempt.
+        attempt_deadline = None
+        if deadline:
+            attempt_deadline = min(
+                deadline, datetime.now() + timedelta(seconds=_PPPP_OPEN_ATTEMPT_WINDOW)
+            )
 
-        log.info("Established pppp connection")
-        return api
+        while api.state != PPPPState.Connected and not api.stopped.is_set():
+            if attempt_deadline and datetime.now() > attempt_deadline:
+                break
+            time.sleep(0.1)
+
+        if api.state == PPPPState.Connected:
+            log.info("Established pppp connection")
+            return api
+
+        # Rejected by the printer (or timed out establishing this attempt).
+        # The printer can take a moment to free up its single PPPP session
+        # slot after a previous connection closes, so retry within the
+        # deadline instead of failing on the first rejection.
+        api.stop()
+        try:
+            api.sock.close()
+        except OSError as exc:
+            log.debug(f"PPPP socket close failed: {exc}")
+
+        if not deadline or datetime.now() >= deadline:
+            raise ConnectionRefusedError("Connection rejected by device")
+
+        time.sleep(_PPPP_OPEN_RETRY_GAP)
 
 
 def pppp_open_broadcast(dumpfile=None):
@@ -217,6 +249,29 @@ def pppp_resolve_printer_ip(config, printer, printer_index, dumpfile=None, timeo
     return ""
 
 
+def _send_xzyh_with_retry(api, data, cmd, reply_timeout, chan=0, retries=2):
+    # The printer's low-level PPPP handshake (P2P_RDY) can complete slightly
+    # before its higher-level file-transfer subsystem is ready to receive on
+    # this channel, so the very first packet sent right after a session is
+    # established can be silently dropped once in a while. Tolerate that the
+    # same way _retry_file_transfer_data() already tolerates it on chan=1.
+    attempts = retries + 1
+
+    for attempt in range(1, attempts + 1):
+        try:
+            return api.send_xzyh(data, cmd=cmd, timeout=reply_timeout)
+        except TimeoutError as exc:
+            is_drw_timeout = "PPPP DRW ACK" in str(exc)
+            if not is_drw_timeout or attempt >= attempts:
+                raise
+
+            log.warning(
+                f"Retrying file transfer handshake send after transport timeout "
+                f"(attempt {attempt + 1}/{attempts})"
+            )
+            api.reset_chan_tx(chan=chan)
+
+
 def _pppp_send_file_handshake(api, fui, reply_timeout=2.0):
     file_uuid = (fui.machine_id or "").strip()
     if not file_uuid or file_uuid == "-":
@@ -233,7 +288,9 @@ def _pppp_send_file_handshake(api, fui, reply_timeout=2.0):
     }
 
     log.info("Requesting file transfer..")
-    api.send_xzyh(json.dumps(payload).encode(), cmd=P2PCmdType.P2P_SEND_FILE)
+    _send_xzyh_with_retry(
+        api, json.dumps(payload).encode(), cmd=P2PCmdType.P2P_SEND_FILE, reply_timeout=reply_timeout, chan=0
+    )
 
     try:
         reply = api.recv_xzyh(chan=0, timeout=reply_timeout)
@@ -242,14 +299,14 @@ def _pppp_send_file_handshake(api, fui, reply_timeout=2.0):
 
     if not reply:
         log.warning("No P2P_SEND_FILE reply; falling back to legacy handshake")
-        api.send_xzyh(file_uuid[:16].encode(), cmd=P2PCmdType.P2P_SEND_FILE)
+        api.send_xzyh(file_uuid[:16].encode(), cmd=P2PCmdType.P2P_SEND_FILE, timeout=reply_timeout)
         return
 
     if reply.data:
         code = int.from_bytes(reply.data[:4], "little", signed=False)
         if code != 0:
             log.warning(f"P2P_SEND_FILE reply error 0x{code:08x}; falling back to legacy handshake")
-            api.send_xzyh(file_uuid[:16].encode(), cmd=P2PCmdType.P2P_SEND_FILE)
+            api.send_xzyh(file_uuid[:16].encode(), cmd=P2PCmdType.P2P_SEND_FILE, timeout=reply_timeout)
 
 
 def _retry_file_transfer_data(api, chunk, pos, reply_timeout, retries=2):

--- a/cli/util.py
+++ b/cli/util.py
@@ -330,8 +330,10 @@ def extract_layer_count(data: bytes) -> int | None:
 
     for line in text.splitlines():
         line = line.strip()
+        if not line:
+            continue  # Blank lines (e.g. around thumbnail blocks) don't end the header
         if not line.startswith(";"):
-            break  # Header ends at first non-comment line
+            break  # Header ends at first non-comment content line
         for pattern in _LAYER_COUNT_PATTERNS:
             m = pattern.match(line)
             if m:

--- a/cli/util.py
+++ b/cli/util.py
@@ -340,3 +340,30 @@ def extract_layer_count(data: bytes) -> int | None:
     # Fallback: count ;LAYER_CHANGE markers (PrusaSlicer)
     count = text.count(";LAYER_CHANGE")
     return count if count > 0 else None
+
+
+_FILAMENT_METADATA_PATTERNS = {
+    "type": re.compile(r"^;\s*filament_type\s*=\s*(.+?)\s*$", re.IGNORECASE),
+    "vendor": re.compile(r"^;\s*filament_vendor\s*=\s*(.+?)\s*$", re.IGNORECASE),
+}
+
+
+def extract_filament_info(data: bytes) -> dict:
+    """Extract slicer filament type and vendor comments from GCode."""
+    try:
+        text = data.decode("utf-8", errors="replace")
+    except Exception:
+        return {}
+
+    result = {}
+    for line in text.splitlines():
+        for key, pattern in _FILAMENT_METADATA_PATTERNS.items():
+            match = pattern.match(line.strip())
+            if not match:
+                continue
+            value = match.group(1).strip().strip('"').strip()
+            if value:
+                result[key] = value
+        if len(result) == len(_FILAMENT_METADATA_PATTERNS):
+            break
+    return result

--- a/libflagship/httpapi.py
+++ b/libflagship/httpapi.py
@@ -33,6 +33,22 @@ def require_auth_token(func):
     return wrapper
 
 
+_SENSITIVE_JSON_KEYS = {
+    "auth_token", "token", "password", "secret_key", "dsk_key", "mqtt_key", "p2p_key",
+}
+
+
+def _redact_sensitive(value):
+    if isinstance(value, dict):
+        return {
+            k: ("[REDACTED]" if k.lower() in _SENSITIVE_JSON_KEYS else _redact_sensitive(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    return value
+
+
 def unwrap_api(func):
 
     @functools.wraps(func)
@@ -42,7 +58,8 @@ def unwrap_api(func):
         data = func(self, *args, **kwargs)
         if data.ok:
             jsn = data.json()
-            log.debug(f"JSON result: {json.dumps(jsn, indent=4)}")
+            if log.getLogger().isEnabledFor(log.DEBUG):
+                log.debug(f"JSON result: {json.dumps(_redact_sensitive(jsn), indent=4)}")
             if jsn["code"] == 0:
                 data = jsn.get("data")
                 return data

--- a/static/ankersrv.css
+++ b/static/ankersrv.css
@@ -101,12 +101,12 @@ code {
 .print-telemetry-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.65rem;
+    gap: 0.5rem;
 }
 
 .print-telemetry-item {
     min-width: 0;
-    padding: 0.7rem;
+    padding: 0.6rem;
     border: 1px solid var(--bs-border-color);
     border-radius: var(--bs-border-radius);
     background: var(--bs-tertiary-bg);
@@ -120,14 +120,14 @@ code {
 }
 
 .print-telemetry-value {
-    font-size: 1.05rem;
+    font-size: 0.95rem;
     font-weight: 650;
     white-space: nowrap;
 }
 
 .print-telemetry-icon {
     color: var(--agreen2);
-    font-size: 1.05rem;
+    font-size: 1rem;
 }
 
 .fan-speed-meter {

--- a/static/ankersrv.css
+++ b/static/ankersrv.css
@@ -98,6 +98,61 @@ code {
     height: 28px;
 }
 
+.print-telemetry-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.65rem;
+}
+
+.print-telemetry-item {
+    min-width: 0;
+    padding: 0.7rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    background: var(--bs-tertiary-bg);
+}
+
+.print-telemetry-label {
+    color: var(--bs-secondary-color);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.print-telemetry-value {
+    font-size: 1.05rem;
+    font-weight: 650;
+    white-space: nowrap;
+}
+
+.print-telemetry-icon {
+    color: var(--agreen2);
+    font-size: 1.05rem;
+}
+
+.fan-speed-meter {
+    height: 4px;
+    margin-top: 0.4rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bs-border-color);
+}
+
+.fan-speed-meter > span {
+    display: block;
+    width: 0;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--agreen2);
+    transition: width 0.2s ease;
+}
+
+@media (max-width: 575.98px) {
+    .print-telemetry-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 .icon {
     display: block;
     height: 18px;
@@ -196,4 +251,3 @@ code {
         min-width: 0;
     }
 }
-

--- a/static/ankersrv.css
+++ b/static/ankersrv.css
@@ -188,6 +188,13 @@ code {
 
 /* Bootstrap overrides */
 
+/* Keep flash messages visible above open modals (Bootstrap stacks the
+   backdrop at z-index 1050 and modals at 1055). */
+#messages {
+    position: relative;
+    z-index: 1100;
+}
+
 .img-thumbnail {
     border: 0 none;
     padding: 0;

--- a/static/ankersrv.css
+++ b/static/ankersrv.css
@@ -112,6 +112,13 @@ code {
     background: var(--bs-tertiary-bg);
 }
 
+.print-telemetry-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.25rem;
+}
+
 .print-telemetry-label {
     color: var(--bs-secondary-color);
     font-size: 0.72rem;
@@ -123,6 +130,10 @@ code {
     font-size: 0.95rem;
     font-weight: 650;
     white-space: nowrap;
+}
+
+.print-telemetry-value-speed {
+    font-size: 0.86rem;
 }
 
 .print-telemetry-icon {

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -534,6 +534,7 @@ $(function () {
 
     const _filamentStatus = {
         label: "Unknown",
+        materialLabel: null,
         detail: null,
         issue: null,
         pauseReason: null,
@@ -583,12 +584,12 @@ $(function () {
         const value = String(label || "Unknown");
         el.text(value);
         el.removeClass("text-success text-warning text-danger text-muted");
-        if (value === "Loaded") {
-            el.addClass("text-success");
-        } else if (value === "Not Loaded") {
+        if (value === "Not Loaded") {
             el.addClass("text-danger");
         } else if (value === "Changing") {
             el.addClass("text-warning");
+        } else if (/loaded$/i.test(value)) {
+            el.addClass("text-success");
         } else {
             el.addClass("text-muted");
         }
@@ -619,6 +620,11 @@ $(function () {
             label = "Unknown";
             detail = detail || "Filament presence cannot be confirmed until the printer starts printing.";
             detailTone = "muted";
+        }
+        if (label === "Loaded") {
+            label = _filamentStatus.materialLabel
+                ? `${_filamentStatus.materialLabel} - Loaded`
+                : "Unknown Filament loaded";
         }
         if (!detail && pausedForFilament && _filamentStatus.label === "Loaded") {
             detail = "Filament loaded. Resume the print when ready.";
@@ -1047,6 +1053,7 @@ $(function () {
 
         const filament = data.filament || {};
         _filamentStatus.label = String(filament.label || "Unknown");
+        _filamentStatus.materialLabel = filament.material_label || null;
         _filamentStatus.detail = filament.detail || null;
         _filamentStatus.issue = filament.issue || null;
         _filamentStatus.pauseReason = filament.pause_reason_label || null;
@@ -1736,6 +1743,7 @@ $(function () {
             updateFanSpeed(null);
             $("#print-layer").text("0 / 0");
             _filamentStatus.label = "Unknown";
+            _filamentStatus.materialLabel = null;
             _filamentStatus.detail = null;
             _filamentStatus.issue = null;
             _filamentStatus.pauseReason = null;

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -74,6 +74,14 @@ $(function () {
         return Number.isFinite(Number(temp)) ? `${Math.round(Number(temp))}°C` : "--";
     }
 
+    function updateFanSpeed(value) {
+        const parsed = Number(value);
+        const available = value !== null && value !== "" && Number.isFinite(parsed);
+        const percent = available ? Math.max(0, Math.min(100, Math.round(parsed))) : 0;
+        $("#fan-speed").text(available ? `${percent} %` : "– %");
+        $("#fan-speed-meter-fill").css("width", `${percent}%`);
+    }
+
     /**
      * Calculate the percentage between two numbers
      * @param {number} layer
@@ -1064,6 +1072,9 @@ $(function () {
                 bedTarget: temperature.bed_target,
             });
         }
+        if (Object.prototype.hasOwnProperty.call(data, "telemetry")) {
+            updateFanSpeed((data.telemetry || {}).fan_speed);
+        }
         applyCameraRuntimeState(data.camera || {});
 
         if (data.print && data.print.state !== undefined) {
@@ -1629,10 +1640,13 @@ $(function () {
                     });
                 }
                 pushTempData("bed", getTemp(data.currentTemp), getTemp(data.targetTemp));
+            } else if (data.commandType == 1005) {
+                // Returns part cooling fan speed as a percentage.
+                updateFanSpeed(data.value);
             } else if (data.commandType == 1006) {
                 // Returns Print Speed
                 const X = getSpeedFactor(data.value);
-                $("#print-speed").text(`${data.value}mm/s ${X}`);
+                $("#print-speed").text(`${data.value} mm/s ${X}`);
             } else if (data.commandType == 1007) {
                 // auto_leveling: value = current probe point (1 center + 7×7 = 50 points total)
                 const point = data.value;
@@ -1718,7 +1732,8 @@ $(function () {
                 bedCurrent: null,
                 bedTarget: null,
             });
-            $("#print-speed").text("0mm/s");
+            $("#print-speed").text("0 mm/s");
+            updateFanSpeed(null);
             $("#print-layer").text("0 / 0");
             _filamentStatus.label = "Unknown";
             _filamentStatus.detail = null;

--- a/static/ankersrv.js
+++ b/static/ankersrv.js
@@ -1380,6 +1380,8 @@ $(function () {
     }
 
     const Z_OFFSET_STEP_MM = 0.01;
+    const Z_OFFSET_MIN_MM = -2.0;
+    const Z_OFFSET_MAX_MM = 2.0;
     let _zOffsetCurrentMm = null;
 
     function setZOffsetControlsEnabled(enabled) {
@@ -1394,7 +1396,8 @@ $(function () {
         if (!Number.isFinite(number)) {
             return null;
         }
-        return Math.round(number * 100) / 100;
+        const clamped = Math.min(Z_OFFSET_MAX_MM, Math.max(Z_OFFSET_MIN_MM, number));
+        return Math.round(clamped * 100) / 100;
     }
 
     function extractZOffsetMm(payload) {
@@ -2886,9 +2889,11 @@ $(function () {
     // ------------------------------------------------------------------
 
     /**
-     * localStorage key and cap for bed level snapshots.
+     * localStorage key (scoped per printer) and cap for bed level snapshots.
      */
-    const BED_SNAP_KEY = "ankerctl_bed_snapshots";
+    function bedSnapKey() {
+        return `ankerctl_bed_snapshots_p${getActivePrinterIndex()}`;
+    }
     const BED_SNAP_MAX = 10;
 
     /**
@@ -2900,7 +2905,7 @@ $(function () {
     /** Load snapshots array from localStorage. */
     function bedSnapLoad() {
         try {
-            return JSON.parse(localStorage.getItem(BED_SNAP_KEY) || "[]");
+            return JSON.parse(localStorage.getItem(bedSnapKey()) || "[]");
         } catch (_) {
             return [];
         }
@@ -2908,7 +2913,7 @@ $(function () {
 
     /** Persist snapshots array to localStorage. */
     function bedSnapSave(snaps) {
-        localStorage.setItem(BED_SNAP_KEY, JSON.stringify(snaps));
+        localStorage.setItem(bedSnapKey(), JSON.stringify(snaps));
     }
 
     /**
@@ -3623,6 +3628,70 @@ $(function () {
     });
 
     loadCameraSettings();
+
+    /**
+     * Hotend setting (Setup -> Printer): all-metal hotend raises the nozzle limit to 300°C.
+     * Stored per-printer in the filament-service settings, but managed independently here.
+     */
+    function setHotendStatus(message, kind = "muted") {
+        const statusEl = document.getElementById("printer-hotend-status");
+        if (!statusEl) {
+            return;
+        }
+        statusEl.textContent = message;
+        statusEl.className = `text-${kind} small mt-2`;
+    }
+
+    async function loadHotendSettings() {
+        const checkboxEl = document.getElementById("printer-all-metal-hotend");
+        if (!checkboxEl) {
+            return;
+        }
+        try {
+            const resp = await fetch(withActivePrinterQuery("/api/settings/filament-service"));
+            const data = await resp.json().catch(() => ({}));
+            if (!resp.ok) {
+                throw new Error(data.error || `HTTP ${resp.status}`);
+            }
+            checkboxEl.checked = !!(data.filament_service || {}).all_metal_hotend;
+        } catch (err) {
+            setHotendStatus(`Failed to load hotend setting: ${err.message || err}`, "danger");
+        }
+    }
+
+    $("#printer-save-hotend-btn").on("click", async function () {
+        const btn = $(this);
+        const checkboxEl = document.getElementById("printer-all-metal-hotend");
+        btn.prop("disabled", true);
+        try {
+            const resp = await fetch(withActivePrinterQuery("/api/settings/filament-service"), {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    filament_service: { all_metal_hotend: !!checkboxEl?.checked },
+                }),
+            });
+            const data = await resp.json().catch(() => ({}));
+            if (!resp.ok) {
+                throw new Error(data.error || `HTTP ${resp.status}`);
+            }
+            if (checkboxEl) {
+                checkboxEl.checked = !!(data.filament_service || {}).all_metal_hotend;
+            }
+            setHotendStatus("Hotend setting saved.", "success");
+        } catch (err) {
+            setHotendStatus(`Failed to save hotend setting: ${err.message || err}`, "danger");
+        } finally {
+            btn.prop("disabled", false);
+        }
+    });
+
+    // Reload the per-printer hotend setting when the active printer changes (navbar switch).
+    document.addEventListener("printerChanged", function () {
+        loadHotendSettings();
+    });
+
+    loadHotendSettings();
 
     /**
      * GCode Console
@@ -6488,7 +6557,7 @@ $(function () {
 
     async function filamentLoadSwapSettings() {
         try {
-            const resp = await fetch("/api/settings/filament-service");
+            const resp = await fetch(withActivePrinterQuery("/api/settings/filament-service"));
             const data = await resp.json();
             if (!resp.ok) {
                 filamentSetSwapSettingsStatus(

--- a/static/tabs/filaments.html
+++ b/static/tabs/filaments.html
@@ -30,7 +30,7 @@
                                         </div>
                                         <div class="col-sm-6">
                                             <label for="filament-service-temp" class="form-label">Target Nozzle (°C)</label>
-                                            <input type="number" class="form-control" id="filament-service-temp" min="0" max="500" step="1" readonly>
+                                            <input type="number" class="form-control" id="filament-service-temp" min="0" max="300" step="1" readonly>
                                         </div>
                                         <div class="col-12 d-flex flex-wrap gap-2">
                                             <button class="btn btn-outline-warning" id="filament-service-preheat-btn">
@@ -249,19 +249,19 @@
                 <div class="row g-3 mb-3">
                     <div class="col-sm-6">
                         <label for="filament-nozzle-temp-first" class="form-label">Nozzle Temp - First Layer (°C)</label>
-                        <input type="number" class="form-control" id="filament-nozzle-temp-first" min="0" max="500" step="1">
+                        <input type="number" class="form-control" id="filament-nozzle-temp-first" min="0" max="300" step="1">
                     </div>
                     <div class="col-sm-6">
                         <label for="filament-nozzle-temp-other" class="form-label">Nozzle Temp - Other Layers (°C)</label>
-                        <input type="number" class="form-control" id="filament-nozzle-temp-other" min="0" max="500" step="1">
+                        <input type="number" class="form-control" id="filament-nozzle-temp-other" min="0" max="300" step="1">
                     </div>
                     <div class="col-sm-6">
                         <label for="filament-bed-temp-first" class="form-label">Bed Temp - First Layer (°C)</label>
-                        <input type="number" class="form-control" id="filament-bed-temp-first" min="0" max="200" step="1">
+                        <input type="number" class="form-control" id="filament-bed-temp-first" min="0" max="100" step="1">
                     </div>
                     <div class="col-sm-6">
                         <label for="filament-bed-temp-other" class="form-label">Bed Temp - Other Layers (°C)</label>
-                        <input type="number" class="form-control" id="filament-bed-temp-other" min="0" max="200" step="1">
+                        <input type="number" class="form-control" id="filament-bed-temp-other" min="0" max="100" step="1">
                     </div>
                 </div>
 

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -416,33 +416,27 @@
                         </div>
                         <div class="print-telemetry-grid">
                             <div class="print-telemetry-item">
-                                <div class="d-flex align-items-center gap-2">
+                                <div class="print-telemetry-heading">
                                     {{ macro.bi_icon("layers-half", class="print-telemetry-icon") }}
-                                    <div>
-                                        <div class="print-telemetry-label">Layer</div>
-                                        <div id="print-layer" class="print-telemetry-value">0 / 0</div>
-                                    </div>
+                                    <div class="print-telemetry-label">Layer</div>
                                 </div>
+                                <div id="print-layer" class="print-telemetry-value">0 / 0</div>
                             </div>
                             <div class="print-telemetry-item">
-                                <div class="d-flex align-items-center gap-2">
+                                <div class="print-telemetry-heading">
                                     {{ macro.bi_icon("speedometer", class="print-telemetry-icon") }}
-                                    <div>
-                                        <div class="print-telemetry-label">Speed</div>
-                                        <div id="print-speed" class="print-telemetry-value">0 mm/s</div>
-                                    </div>
+                                    <div class="print-telemetry-label">Speed</div>
                                 </div>
+                                <div id="print-speed" class="print-telemetry-value print-telemetry-value-speed">0 mm/s</div>
                             </div>
                             <div class="print-telemetry-item">
-                                <div class="d-flex align-items-center gap-2">
+                                <div class="print-telemetry-heading">
                                     {{ macro.bi_icon("fan", class="print-telemetry-icon") }}
-                                    <div class="flex-grow-1">
-                                        <div class="print-telemetry-label">Fan</div>
-                                        <div id="fan-speed" class="print-telemetry-value">– %</div>
-                                        <div class="fan-speed-meter" aria-hidden="true">
-                                            <span id="fan-speed-meter-fill"></span>
-                                        </div>
-                                    </div>
+                                    <div class="print-telemetry-label">Fan</div>
+                                </div>
+                                <div id="fan-speed" class="print-telemetry-value">– %</div>
+                                <div class="fan-speed-meter" aria-hidden="true">
+                                    <span id="fan-speed-meter-fill"></span>
                                 </div>
                             </div>
                         </div>

--- a/static/tabs/home.html
+++ b/static/tabs/home.html
@@ -414,29 +414,39 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="row g-3">
-                            <div class="col-md-6">
-                                <div class="input-group">
-                                    <div class="input-group-text print-info-label" id="printLayer">
-                                        {{ macro.bi_icon("layers-half") }}
+                        <div class="print-telemetry-grid">
+                            <div class="print-telemetry-item">
+                                <div class="d-flex align-items-center gap-2">
+                                    {{ macro.bi_icon("layers-half", class="print-telemetry-icon") }}
+                                    <div>
+                                        <div class="print-telemetry-label">Layer</div>
+                                        <div id="print-layer" class="print-telemetry-value">0 / 0</div>
                                     </div>
-                                    <span id="print-layer" class="form-control text-center" title="Print Layers"
-                                        aria-describedby="printLayer">
-                                        0/0
-                                    </span>
                                 </div>
                             </div>
-                            <div class="col-md-6">
-                                <div class="input-group">
-                                    <div class="input-group-text print-info-label" id="printSpeed">
-                                        {{ macro.bi_icon("speedometer") }}
+                            <div class="print-telemetry-item">
+                                <div class="d-flex align-items-center gap-2">
+                                    {{ macro.bi_icon("speedometer", class="print-telemetry-icon") }}
+                                    <div>
+                                        <div class="print-telemetry-label">Speed</div>
+                                        <div id="print-speed" class="print-telemetry-value">0 mm/s</div>
                                     </div>
-                                    <span id="print-speed" class="form-control text-center small" title="Print Speed"
-                                        aria-describedby="printSpeed">
-                                        0mm/s
-                                    </span>
                                 </div>
                             </div>
+                            <div class="print-telemetry-item">
+                                <div class="d-flex align-items-center gap-2">
+                                    {{ macro.bi_icon("fan", class="print-telemetry-icon") }}
+                                    <div class="flex-grow-1">
+                                        <div class="print-telemetry-label">Fan</div>
+                                        <div id="fan-speed" class="print-telemetry-value">– %</div>
+                                        <div class="fan-speed-meter" aria-hidden="true">
+                                            <span id="fan-speed-meter-fill"></span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row g-3 mt-0">
                             <div class="col-12">
                                 <div class="input-group">
                                     <div class="input-group-text print-info-label" id="filamentState">

--- a/static/tabs/setup.html
+++ b/static/tabs/setup.html
@@ -282,6 +282,26 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-lg-6">
+                                <div class="card h-100">
+                                    <div class="card-header fs-4">
+                                        Hotend
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="printer-all-metal-hotend">
+                                            <label class="form-check-label" for="printer-all-metal-hotend">
+                                                All-Metal Hotend (raises nozzle limit to 300°C)
+                                            </label>
+                                        </div>
+                                        <div class="form-text">Per-printer setting. Stock hotend limit is 260°C.</div>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm mt-3" id="printer-save-hotend-btn">
+                                            {{ macro.bi_icon("save") }} Save
+                                        </button>
+                                        <div id="printer-hotend-status" class="text-muted small mt-2"></div>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="col-12">
                                 <div class="card">
                                     <div class="card-header fs-4 d-flex justify-content-between align-items-center">
@@ -556,7 +576,7 @@
                                             <div class="col-lg-4">
                                                 <label class="form-label" for="z-offset-target">Absolute target (mm)</label>
                                                 <div class="input-group">
-                                                    <input id="z-offset-target" type="number" class="form-control" step="0.01" inputmode="decimal" placeholder="0.00">
+                                                    <input id="z-offset-target" type="number" class="form-control" step="0.01" min="-2.00" max="2.00" inputmode="decimal" placeholder="0.00">
                                                     <button id="z-offset-set-btn" type="button" class="btn btn-primary">
                                                         <i class="bi bi-check2"></i> Set
                                                     </button>

--- a/tests/test_ankerctl_cli.py
+++ b/tests/test_ankerctl_cli.py
@@ -390,3 +390,158 @@ def test_printer_option_rejects_negative_values():
     result = runner.invoke(ankerctl.main, ["--printer", "-1", "config", "show"])
     assert result.exit_code != 0
     assert "is not in the range" in result.output or "Invalid value" in result.output
+
+
+def test_pppp_print_file_stops_session_on_invalid_upload_rate(monkeypatch, tmp_path):
+    """Regression: api.stop() must run even when --upload-rate-mbps
+    validation fails, so the PPPP session isn't leaked."""
+    runner = CliRunner()
+    fake_config = FakeConfigContext(printers=[SimpleNamespace(name="p0")])
+    opens = []
+    stops = []
+
+    class FakeApi:
+        def stop(self):
+            stops.append(True)
+
+    def fake_pppp_open(config, printer_index, dumpfile=None):
+        opens.append(True)
+        return FakeApi()
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr("ankerctl.Environment.upgrade_config_if_needed", lambda self: None)
+    monkeypatch.setattr("ankerctl.Environment.load_config", lambda self, required=True: None)
+    monkeypatch.setattr("ankerctl.cli.pppp.pppp_open", fake_pppp_open)
+
+    gcode = tmp_path / "job.gcode"
+    gcode.write_bytes(b"G28\n")
+
+    result = runner.invoke(
+        ankerctl.main,
+        ["pppp", "print-file", str(gcode), "--upload-rate-mbps", "7"],
+    )
+
+    assert result.exit_code != 0
+    assert len(stops) == len(opens)
+
+
+def test_pppp_capture_video_stops_session_after_capture(monkeypatch, tmp_path):
+    """Regression: capture-video must call api.stop() after capture completes."""
+    runner = CliRunner()
+    fake_config = FakeConfigContext(printers=[SimpleNamespace(name="p0")])
+    sends = []
+    stops = []
+
+    timeouts = []
+
+    class FakeApi:
+        def send_xzyh(self, data, cmd=None, timeout=None):
+            sends.append(json.loads(data))
+            timeouts.append(timeout)
+
+        def recv_xzyh(self, chan=None):
+            return SimpleNamespace(data=b"x" * 2048)
+
+        def stop(self):
+            stops.append(True)
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr("ankerctl.Environment.upgrade_config_if_needed", lambda self: None)
+    monkeypatch.setattr("ankerctl.Environment.load_config", lambda self, required=True: None)
+    monkeypatch.setattr("ankerctl.cli.pppp.pppp_open", lambda *args, **kwargs: FakeApi())
+
+    out = tmp_path / "out.h264"
+    result = runner.invoke(
+        ankerctl.main,
+        ["pppp", "capture-video", "--max-size", "1kb", str(out)],
+    )
+
+    assert result.exit_code == 0
+    assert stops == [True]
+    assert len(sends) == 2  # START_LIVE + CLOSE_LIVE
+    # Regression: both control-command sends must pass an explicit timeout,
+    # otherwise a silently-dropped ACK blocks Channel.write() forever (same
+    # bug class as the file-upload handshake hang).
+    assert all(t is not None for t in timeouts)
+    assert out.read_bytes() == b"x" * 2048
+
+
+def test_mqtt_rename_printer_rejects_empty_name(monkeypatch):
+    """Regression: an empty printer name must be rejected before connecting."""
+    runner = CliRunner()
+    fake_config = FakeConfigManager()
+    opened = []
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr("ankerctl.Environment.upgrade_config_if_needed", lambda self: None)
+    monkeypatch.setattr("ankerctl.Environment.load_config", lambda self, required=True: None)
+    monkeypatch.setattr("ankerctl.cli.mqtt.mqtt_open", lambda *args, **kwargs: opened.append(True))
+
+    result = runner.invoke(ankerctl.main, ["mqtt", "rename-printer", ""])
+
+    assert result.exit_code == 1
+    assert opened == []
+
+
+def test_config_decode_redacts_auth_token_by_default(monkeypatch, tmp_path):
+    """Regression: full auth_token/user_id must not appear in default output."""
+    runner = CliRunner()
+    fake_config = FakeConfigManager()
+    cache = {
+        "auth_token": "SECRETTOKEN1234567890",
+        "user_id": "USERID9876543210",
+        "email": "user@example.com",
+    }
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr("ankerctl.libflagship.logincache.load", lambda data: {"data": dict(cache)})
+
+    login = tmp_path / "login.json"
+    login.write_bytes(b"irrelevant")
+
+    redacted = runner.invoke(ankerctl.main, ["config", "decode", str(login)])
+    full = runner.invoke(ankerctl.main, ["config", "decode", "--show-secrets", str(login)])
+
+    assert redacted.exit_code == 0
+    assert "SECRETTOKEN1234567890" not in redacted.output
+    assert "USERID9876543210" not in redacted.output
+    assert "SECRETTOKE...<REDACTED>" in redacted.output
+    assert "USERID9876...<REDACTED>" in redacted.output
+    assert "user@example.com" in redacted.output
+
+    assert full.exit_code == 0
+    assert "SECRETTOKEN1234567890" in full.output
+
+
+def test_config_login_warns_when_password_passed_positionally(monkeypatch, caplog):
+    """Regression: a warning must be logged when password is passed positionally."""
+    import logging
+
+    runner = CliRunner()
+    fake_config = FakeConfigContext(printers=[])
+    imported = []
+
+    monkeypatch.setattr("ankerctl.cli.config.configmgr", lambda: fake_config)
+    monkeypatch.setattr("ankerctl.cli.logfmt.setup_logging", lambda level, log_dir=None: None)
+    monkeypatch.setattr(
+        "ankerctl.cli.config.fetch_config_by_login",
+        lambda email, password, region, insecure, captcha_id=None, captcha_answer=None: {"auth_token": "abc"},
+    )
+    monkeypatch.setattr(
+        "ankerctl.cli.config.import_config_from_server",
+        lambda config, login, insecure: imported.append(login),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="main"):
+        result = runner.invoke(
+            ankerctl.main,
+            ["config", "login", "DE", "user@example.com", "somepassword"],
+        )
+
+    assert result.exit_code == 0
+    assert imported == [{"auth_token": "abc"}]
+    assert any("shell history" in record.message for record in caplog.records)

--- a/tests/test_apprise_client.py
+++ b/tests/test_apprise_client.py
@@ -62,3 +62,55 @@ def test_apprise_client_send_short_circuits_when_disabled():
 
     assert ok is False
     assert "disabled" in message.lower()
+
+
+def test_capture_live_snapshot_survives_light_restore_failure(monkeypatch, tmp_path):
+    import os
+    import time
+
+    import web as web_module
+    import web.camera as web_camera
+    from web.lib.service import RunState
+    from web.notifications import AppriseNotifier
+
+    class FakeVideoQueue:
+        def __init__(self):
+            self.saved_light_state = None
+            self.video_enabled = True
+            self.wanted = True
+            self.state = RunState.Running
+            self.last_frame_at = time.monotonic()
+            self.light_calls = []
+
+        def api_light_state(self, state):
+            self.light_calls.append(state)
+            if len(self.light_calls) > 1:
+                raise ConnectionError("pppp session dropped")
+
+    vq = FakeVideoQueue()
+
+    def fake_capture(camera_settings, ffmpeg_path, out_path, **kwargs):
+        with open(out_path, "wb") as fh:
+            fh.write(b"jpeg-data")
+
+    monkeypatch.setattr(
+        web_module,
+        "_resolve_camera_settings",
+        lambda printer_index=None: {"effective_source": web_camera.CAMERA_SOURCE_PRINTER},
+    )
+    monkeypatch.setattr(web_module, "_ffmpeg_path", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(web_module, "get_video_service", lambda printer_index=None: vq)
+    monkeypatch.setattr(web_module, "_local_web_host_port", lambda: ("127.0.0.1", 4470))
+    monkeypatch.setattr(web_camera, "capture_camera_snapshot_to_file", fake_capture)
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+
+    notifier = AppriseNotifier(None, settings={"progress": {"snapshot_light": True}})
+    result = notifier._capture_live_snapshot()
+
+    try:
+        assert result is not None
+        assert os.path.getsize(result) > 0
+    finally:
+        if result:
+            os.remove(result)
+    assert vq.light_calls == [True, False]

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -126,6 +126,31 @@ def test_config_manager_round_trips_serialized_config(tmp_path):
     assert loaded.printers[0].mqtt_key == b"\x01\x02"
 
 
+def test_config_manager_load_recovers_from_corrupt_json(tmp_path):
+    dirs = SimpleNamespace(user_config_path=tmp_path)
+    manager = AnkerConfigManager(dirs, classes=(Config, Account, Printer))
+    (tmp_path / "default.json").write_text('{"account": {"__type__": "Account", "auth_token"')
+
+    loaded = manager.load("default", "fallback-value")
+
+    assert loaded == "fallback-value"
+    remaining = list(tmp_path.iterdir())
+    assert not (tmp_path / "default.json").exists()
+    assert any(p.name.startswith("default.json.corrupt-") for p in remaining)
+
+
+def test_config_manager_save_is_atomic_and_leaves_no_tmp_file(tmp_path):
+    dirs = SimpleNamespace(user_config_path=tmp_path)
+    manager = AnkerConfigManager(dirs, classes=(Config, Account, Printer))
+    manager.save("default", _sample_config(upload_rate_mbps=10))
+
+    manager.save("default", _sample_config(upload_rate_mbps=99))
+
+    reloaded = manager.load("default", None)
+    assert reloaded.upload_rate_mbps == 99
+    assert [p.name for p in tmp_path.iterdir()] == ["default.json"]
+
+
 def test_logincache_load_parses_eufymake_webview_blob():
     token = "f88b0074484d9fd9dfcda327ef2b4dd28b4511235c0514df"
     token_fragment = base64.b64encode(f"{token}%".encode()).decode().rstrip("=")

--- a/tests/test_cli_login_and_logfmt.py
+++ b/tests/test_cli_login_and_logfmt.py
@@ -46,7 +46,7 @@ def test_config_decode_and_import_cli(monkeypatch, tmp_path):
     imported_cli = runner.invoke(ankerctl.main, ["config", "import", str(login_file)])
 
     assert decode.exit_code == 0
-    assert '"auth_token": "abc"' in decode.output
+    assert '"auth_token": "abc...<REDACTED>"' in decode.output
     assert imported_cli.exit_code == 0
     assert imported == [(fake_config, {"auth_token": "abc", "email": "user@example.com"}, False)]
 

--- a/tests/test_cli_pppp.py
+++ b/tests/test_cli_pppp.py
@@ -1,12 +1,99 @@
+import threading
+
+from datetime import datetime, timedelta
 from types import SimpleNamespace
+
+import pytest
 
 import cli.pppp
 
 from libflagship.pppp import Duid, PktPunchPkt
+from libflagship.ppppapi import AnkerPPPPApi, FileUploadInfo
 
 
 def _duid():
     return Duid(prefix="ABCDEF1", serial=123456, check="CHK01")
+
+
+class _FakeClock:
+    """Virtual clock so pppp_open retry tests don't take wall-clock time."""
+
+    def __init__(self):
+        self._now = datetime(2026, 1, 1)
+
+    def now(self):
+        return self._now
+
+    def sleep(self, seconds):
+        self._now += timedelta(seconds=seconds)
+
+
+def _patch_pppp_open_env(monkeypatch, make_api):
+    clock = _FakeClock()
+    attempts = []
+
+    monkeypatch.setattr("cli.pppp.datetime", SimpleNamespace(now=clock.now))
+    monkeypatch.setattr("cli.pppp.time.sleep", clock.sleep)
+    monkeypatch.setattr(
+        "cli.pppp.pppp_resolve_printer_ip",
+        lambda config, printer, printer_index, dumpfile=None: "10.0.0.25",
+    )
+    monkeypatch.setattr(
+        "cli.pppp.AnkerPPPPApi.open_lan",
+        lambda duid, host: attempts.append(True) or make_api(),
+    )
+    return attempts
+
+
+class _FakeOpenConfig:
+    def __init__(self):
+        self._printers = [SimpleNamespace(name="p0", p2p_duid=str(_duid()))]
+
+    def open(self):
+        return self
+
+    def __enter__(self):
+        return SimpleNamespace(printers=self._printers)
+
+    def __exit__(self, *args):
+        return False
+
+
+class _NeverConnectingApi:
+    def __init__(self, stopped):
+        self.state = None
+        self.stopped = SimpleNamespace(is_set=lambda: stopped)
+        self.sock = SimpleNamespace(close=lambda: None)
+
+    def connect_lan_search(self):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def test_pppp_open_retries_after_explicit_close(monkeypatch):
+    attempts = _patch_pppp_open_env(monkeypatch, lambda: _NeverConnectingApi(stopped=True))
+
+    with pytest.raises(ConnectionRefusedError):
+        cli.pppp.pppp_open(_FakeOpenConfig(), printer_index=0, timeout=2.0)
+
+    assert len(attempts) > 1
+
+
+def test_pppp_open_retries_when_connection_silently_never_completes(monkeypatch):
+    # Regression: a silent non-completing attempt (no CLOSE packet, state
+    # never reaches Connected) used to consume the entire deadline in the
+    # first attempt's wait loop, so the retry loop never got a second try.
+    attempts = _patch_pppp_open_env(monkeypatch, lambda: _NeverConnectingApi(stopped=False))
+
+    with pytest.raises(ConnectionRefusedError):
+        cli.pppp.pppp_open(_FakeOpenConfig(), printer_index=0, timeout=8.0)
+
+    assert len(attempts) > 1
 
 
 def test_probe_printer_ip_retries_before_succeeding(monkeypatch):
@@ -82,6 +169,92 @@ def test_lan_search_retries_and_deduplicates_replies(monkeypatch):
         }
     ]
     assert persisted == [(str(_duid()), "10.0.0.25")]
+
+
+def test_pppp_send_file_handshake_times_out_instead_of_hanging_when_never_acked():
+    # Regression (live-hardware bug): _pppp_send_file_handshake used to call
+    # api.send_xzyh() without an explicit timeout, so a silently-dropped
+    # handshake packet made Channel.write() block on a bare Event.wait() with
+    # no deadline -- forever. This left the exclusive PPPP session lock held
+    # indefinitely with zero further log output. It must now raise
+    # TimeoutError within reply_timeout seconds instead.
+    #
+    # A real AnkerPPPPApi is used (not a fake) so the test exercises the
+    # actual Channel.write() blocking path; the socket is never touched by
+    # send_xzyh/recv_xzyh, so a bare SimpleNamespace stands in for it. The
+    # handshake is run on a background thread and joined with a generous
+    # timeout so this test fails fast (rather than hanging the suite) if a
+    # future change reintroduces the unbounded wait.
+    #
+    # The initial send_xzyh() now retries transient DRW-ACK timeouts (see
+    # test_pppp_send_file_handshake_retries_transient_drw_ack_timeout_on_initial_send
+    # below), so with nothing ever acking this still must raise TimeoutError
+    # once the retry budget (reply_timeout * 3 attempts) is exhausted --
+    # bounded, not hanging forever.
+    api = AnkerPPPPApi(sock=SimpleNamespace(), duid=_duid(), addr=("10.0.0.25", 32108))
+
+    fui = FileUploadInfo.from_data(
+        b"gcode-data",
+        "job.gcode",
+        user_name="ankerctl",
+        user_id="-",
+        machine_id="-",
+    )
+
+    outcome = {}
+
+    def run():
+        try:
+            cli.pppp._pppp_send_file_handshake(api, fui, reply_timeout=0.2)
+        except BaseException as exc:  # noqa: BLE001 - captured for assertion below
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    thread.join(timeout=5.0)
+
+    assert not thread.is_alive(), "handshake hung instead of raising TimeoutError"
+    assert isinstance(outcome.get("error"), TimeoutError)
+    assert "PPPP DRW ACK" in str(outcome["error"])
+
+
+def test_pppp_send_file_handshake_retries_transient_drw_ack_timeout_on_initial_send():
+    # Live-hardware follow-up bug: right after a fast PPPP reconnect, the very
+    # first handshake packet on chan=0 (the initial send_xzyh() call inside
+    # _pppp_send_file_handshake) could time out waiting for the DRW ACK once,
+    # even though the transport was otherwise healthy -- the printer's
+    # file-transfer subsystem wasn't quite ready yet. This mirrors the
+    # tolerance _retry_file_transfer_data() already has for chan=1 data
+    # chunks; the initial handshake send must retry (with reset_chan_tx on
+    # chan=0 between attempts) instead of failing on the first timeout.
+    calls = {"send_xzyh": 0, "reset_chan_tx": []}
+
+    class FakeApi:
+        def send_xzyh(self, data, cmd, timeout=None, chan=0):
+            calls["send_xzyh"] += 1
+            if calls["send_xzyh"] == 1:
+                raise TimeoutError("Timed out waiting for PPPP DRW ACK")
+            return None
+
+        def recv_xzyh(self, chan=0, timeout=None):
+            # code=0 -> handshake accepted, no legacy-fallback send needed.
+            return SimpleNamespace(data=(0).to_bytes(4, "little"))
+
+        def reset_chan_tx(self, chan=1):
+            calls["reset_chan_tx"].append(chan)
+
+    fui = FileUploadInfo.from_data(
+        b"gcode-data",
+        "job.gcode",
+        user_name="ankerctl",
+        user_id="-",
+        machine_id="-",
+    )
+
+    cli.pppp._pppp_send_file_handshake(FakeApi(), fui, reply_timeout=0.2)
+
+    assert calls["send_xzyh"] == 2, "expected one retry after the transient DRW-ACK timeout"
+    assert calls["reset_chan_tx"] == [0], "retry must reset chan=0 (the handshake channel), not chan=1"
 
 
 def test_pppp_resolve_printer_ip_falls_back_to_saved_ip_when_probe_and_search_miss(monkeypatch):

--- a/tests/test_cli_util.py
+++ b/tests/test_cli_util.py
@@ -6,6 +6,7 @@ import pytest
 
 import cli.checkver
 from cli.util import (
+    extract_filament_info,
     extract_gcode_thumbnail,
     extract_layer_count,
     json_key_value,
@@ -102,6 +103,17 @@ def test_extract_layer_count_reads_header_and_falls_back_to_markers():
 
     assert extract_layer_count(header) == 42
     assert extract_layer_count(fallback) == 2
+
+
+def test_extract_filament_info_reads_orca_slicer_footer():
+    data = (
+        b"G28\n"
+        b"; filament_settings_id = \"Sunlu Rapid PETG\"\n"
+        b"; filament_type = PETG\n"
+        b"; filament_vendor = Sunlu\n"
+    )
+
+    assert extract_filament_info(data) == {"type": "PETG", "vendor": "Sunlu"}
 
 
 def test_extract_gcode_thumbnail_reads_embedded_png_and_prefers_largest():

--- a/tests/test_cli_util.py
+++ b/tests/test_cli_util.py
@@ -105,6 +105,12 @@ def test_extract_layer_count_reads_header_and_falls_back_to_markers():
     assert extract_layer_count(fallback) == 2
 
 
+def test_extract_layer_count_survives_blank_lines_in_header():
+    data = b"; thumbnail begin\n; thumbnail end\n\n;LAYER_COUNT:17\nG28\n"
+
+    assert extract_layer_count(data) == 17
+
+
 def test_extract_filament_info_reads_orca_slicer_footer():
     data = (
         b"G28\n"

--- a/tests/test_filament_api.py
+++ b/tests/test_filament_api.py
@@ -1,3 +1,4 @@
+import threading
 from contextlib import contextmanager
 from datetime import datetime
 from types import SimpleNamespace
@@ -90,6 +91,7 @@ def _install_state(tmp_path, mqtt):
     app.svc = FakeServices(mqtt)
     app.filaments = FilamentStore(tmp_path / "filaments.db")
     app.filament_swap_state = {}
+    app.filament_swap_threads = {}
 
     return old_values, old_svc, old_filaments, old_swap
 
@@ -100,6 +102,7 @@ def _restore_state(old_values, old_svc, old_filaments, old_swap):
         app.config[key] = value
     app.filaments = old_filaments
     app.filament_swap_state = old_swap
+    app.filament_swap_threads = {}
 
 
 def test_filament_crud_and_apply_routes(tmp_path):
@@ -379,7 +382,7 @@ def test_filament_swap_routes_cover_legacy_start_confirm_and_cancel(tmp_path, mo
     app.config["config"].cfg.filament_service["swap_load_length_mm"] = 65
     background_calls = []
 
-    def fake_start_background(target, token):
+    def fake_start_background(target, token, printer_index):
         background_calls.append((target, token))
         return SimpleNamespace()
 
@@ -487,7 +490,7 @@ def test_legacy_swap_sends_heat_before_homing_when_nozzle_is_cold(tmp_path, monk
     app.config["config"].cfg.filament_service["allow_legacy_swap"] = True
     background_calls = []
 
-    def fake_start_background(target, token):
+    def fake_start_background(target, token, printer_index):
         background_calls.append((target, token))
         return SimpleNamespace()
 
@@ -590,7 +593,7 @@ def test_legacy_swap_cancel_is_allowed_while_stage_is_running(tmp_path, monkeypa
     app.config["config"].cfg.filament_service["allow_legacy_swap"] = True
     background_calls = []
 
-    def fake_start_background(target, token):
+    def fake_start_background(target, token, printer_index):
         background_calls.append((target, token))
         return SimpleNamespace()
 
@@ -627,3 +630,182 @@ def test_legacy_swap_cancel_is_allowed_while_stage_is_running(tmp_path, monkeypa
     assert state.status_code == 200
     assert state.get_json()["pending"] is False
     assert sent == ["M104 S0"]
+
+
+def test_filament_service_preheat_clamps_absurd_profile_temp(tmp_path):
+    sent = []
+    mqtt = SimpleNamespace(is_printing=False, nozzle_temp=25, send_gcode=lambda gcode: sent.append(gcode))
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+
+    try:
+        # Simulate a legacy database row that predates store-level validation.
+        with app.filaments._lock:
+            with app.filaments._connect() as conn:
+                cur = conn.execute(
+                    "INSERT INTO filaments (name, nozzle_temp_other_layer) VALUES (?, ?)",
+                    ("Absurd", 999999),
+                )
+                profile_id = cur.lastrowid
+        preheat = client.post(
+            "/api/filaments/service/preheat",
+            json={"profile_id": profile_id},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert preheat.status_code == 200
+    assert preheat.get_json()["target_temp_c"] == 260
+    assert sent == ["M104 S260"]
+
+
+def test_filament_service_temp_clamps_to_printer_hotend_ceiling(tmp_path):
+    mqtt = SimpleNamespace(is_printing=False, send_gcode=lambda gcode: None, nozzle_temp=220)
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+
+    try:
+        profile = {"nozzle_temp_other_layer": 290}
+        standard = web_module._filament_service_temp(profile, printer_index=0)
+        app.config["config"].cfg.filament_service["per_printer"]["SN1"] = {"all_metal_hotend": True}
+        all_metal = web_module._filament_service_temp(profile, printer_index=0)
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert standard == 260
+    assert all_metal == 290
+
+
+def test_filaments_apply_route_uses_per_printer_nozzle_ceiling(tmp_path):
+    sent = []
+    mqtt = SimpleNamespace(is_printing=False, send_gcode=lambda gcode: sent.append(gcode), nozzle_temp=25)
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+
+    try:
+        # Simulate a legacy database row that predates store-level validation.
+        with app.filaments._lock:
+            with app.filaments._connect() as conn:
+                cur = conn.execute(
+                    "INSERT INTO filaments (name, nozzle_temp_first_layer, bed_temp_first_layer) VALUES (?, ?, ?)",
+                    ("High Temp", 290, 130),
+                )
+                profile_id = cur.lastrowid
+        standard = client.post(
+            f"/api/filaments/{profile_id}/apply",
+            headers={"X-Api-Key": API_KEY},
+        )
+        app.config["config"].cfg.filament_service["per_printer"]["SN1"] = {"all_metal_hotend": True}
+        all_metal = client.post(
+            f"/api/filaments/{profile_id}/apply",
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert standard.status_code == 200
+    assert standard.get_json()["gcode"] == "M104 S260\nM140 S100"
+    assert all_metal.status_code == 200
+    assert all_metal.get_json()["gcode"] == "M104 S290\nM140 S100"
+    assert sent == ["M104 S260\nM140 S100", "M104 S290\nM140 S100"]
+
+
+def test_filament_swap_start_rejected_while_previous_thread_still_running(tmp_path, monkeypatch):
+    sent = []
+    mqtt = SimpleNamespace(is_printing=False, nozzle_temp=25, send_gcode=lambda gcode: sent.append(gcode))
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+    app.config["config"].cfg.filament_service["allow_legacy_swap"] = True
+    release = threading.Event()
+
+    def fake_unload_worker(token):
+        release.wait(timeout=10)
+
+    monkeypatch.setattr(web_module, "_run_legacy_swap_unload", fake_unload_worker)
+    monkeypatch.setattr(web_module, "FILAMENT_SWAP_CANCEL_JOIN_TIMEOUT_S", 0.05)
+
+    try:
+        unload = app.filaments.create({"name": "PLA Stale", "nozzle_temp_other_layer": 220})
+        load = app.filaments.create({"name": "PETG Stale", "nozzle_temp_other_layer": 240})
+        body = {"unload_profile_id": unload["id"], "load_profile_id": load["id"]}
+        started = client.post(
+            "/api/filaments/service/swap/start",
+            json=body,
+            headers={"X-Api-Key": API_KEY},
+        )
+        old_thread = app.filament_swap_threads.get(0)
+        cancelled = client.post(
+            "/api/filaments/service/swap/cancel",
+            headers={"X-Api-Key": API_KEY},
+        )
+        rejected = client.post(
+            "/api/filaments/service/swap/start",
+            json=body,
+            headers={"X-Api-Key": API_KEY},
+        )
+        release.set()
+        old_thread.join(timeout=5)
+        allowed = client.post(
+            "/api/filaments/service/swap/start",
+            json=body,
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert started.status_code == 200
+    assert old_thread is not None
+    assert cancelled.status_code == 200
+    assert rejected.status_code == 409
+    assert rejected.get_json()["error"] == "A filament swap is already in progress"
+    assert allowed.status_code == 200
+
+
+def test_legacy_swap_worker_unexpected_error_sets_error_phase_and_cools_nozzle(tmp_path, monkeypatch):
+    sent = []
+    mqtt = SimpleNamespace(
+        is_printing=False,
+        nozzle_temp=25,
+        send_gcode=lambda gcode: sent.append(gcode),
+        send_home=lambda axis: None,
+    )
+    client = app.test_client()
+    old_values, old_svc, old_filaments, old_swap = _install_state(tmp_path, mqtt)
+    app.config["config"].cfg.filament_service["allow_legacy_swap"] = True
+    background_calls = []
+
+    def fake_start_background(target, token, printer_index):
+        background_calls.append((target, token))
+        return SimpleNamespace()
+
+    monkeypatch.setattr(web_module, "_filament_swap_start_background", fake_start_background)
+
+    try:
+        unload = app.filaments.create({"name": "PLA Crash", "nozzle_temp_other_layer": 220})
+        load = app.filaments.create({"name": "PETG Crash", "nozzle_temp_other_layer": 240})
+        started = client.post(
+            "/api/filaments/service/swap/start",
+            json={"unload_profile_id": unload["id"], "load_profile_id": load["id"]},
+            headers={"X-Api-Key": API_KEY},
+        )
+        target, token = background_calls.pop()
+
+        def boom(mqtt):
+            # TypeError: unexpected type not handled by the specific except
+            # clauses and not swallowed by borrow_mqtt's candidate loop.
+            raise TypeError("mqtt object is malformed")
+
+        monkeypatch.setattr(web_module, "_assert_filament_service_ready", boom)
+        target(token)
+        state = client.get(
+            "/api/filaments/service/swap",
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_state(old_values, old_svc, old_filaments, old_swap)
+
+    assert started.status_code == 200
+    swap = state.get_json()["swap"]
+    assert swap["phase"] == "error"
+    assert "mqtt object is malformed" in swap["error"]
+    assert "M104 S0" in sent

--- a/tests/test_filament_store.py
+++ b/tests/test_filament_store.py
@@ -56,6 +56,40 @@ def test_filament_store_requires_name(tmp_path):
         store.update(created["id"], {"name": "   "})
 
 
+def test_filament_store_rejects_out_of_range_temperatures(tmp_path):
+    store = FilamentStore(tmp_path / "filaments.db")
+
+    with pytest.raises(ValueError, match="nozzle_temp_other_layer"):
+        store.create({"name": "Bad", "nozzle_temp_other_layer": 999999})
+    with pytest.raises(ValueError, match="bed_temp_other_layer"):
+        store.create({"name": "Bad", "bed_temp_other_layer": 200})
+    with pytest.raises(ValueError, match="nozzle_temp_first_layer"):
+        store.create({"name": "Bad", "nozzle_temp_first_layer": -5})
+
+    created = store.create({"name": "Good", "nozzle_temp_other_layer": 220, "bed_temp_other_layer": 60})
+    with pytest.raises(ValueError, match="nozzle_temp_other_layer"):
+        store.update(created["id"], {"nozzle_temp_other_layer": 999999})
+    with pytest.raises(ValueError, match="bed_temp_first_layer"):
+        store.update(created["id"], {"bed_temp_first_layer": 131})
+
+    updated = store.update(created["id"], {"nozzle_temp_other_layer": 300, "bed_temp_other_layer": 100})
+    assert updated["nozzle_temp_other_layer"] == 300
+    assert updated["bed_temp_other_layer"] == 100
+
+
+def test_filament_store_rejects_temps_above_all_metal_ceiling(tmp_path):
+    store = FilamentStore(tmp_path / "filaments.db")
+
+    with pytest.raises(ValueError, match="nozzle_temp_other_layer"):
+        store.create({"name": "Too Hot", "nozzle_temp_other_layer": 301})
+    with pytest.raises(ValueError, match="bed_temp_other_layer"):
+        store.create({"name": "Too Hot", "bed_temp_other_layer": 101})
+
+    created = store.create({"name": "Boundary", "nozzle_temp_other_layer": 300, "bed_temp_other_layer": 100})
+    assert created["nozzle_temp_other_layer"] == 300
+    assert created["bed_temp_other_layer"] == 100
+
+
 def test_filament_store_migrates_legacy_columns(tmp_path):
     db_path = tmp_path / "legacy_filaments.db"
     conn = sqlite3.connect(db_path)

--- a/tests/test_homeassistant_service.py
+++ b/tests/test_homeassistant_service.py
@@ -102,10 +102,11 @@ def test_homeassistant_publish_discovery_emits_expected_entities():
 
     topics = [topic for topic, *_ in client.published]
     assert "ha/sensor/ankerctl_SN123/print_progress/config" in topics
+    assert "ha/sensor/ankerctl_SN123/fan_speed/config" in topics
     assert "ha/binary_sensor/ankerctl_SN123/mqtt_connected/config" in topics
     assert "ha/switch/ankerctl_SN123/light/config" in topics
     assert "ha/camera/ankerctl_SN123/camera/config" in topics
-    assert len(client.published) == 15
+    assert len(client.published) == 16
 
 
 def test_homeassistant_on_connect_and_light_command(monkeypatch):

--- a/tests/test_homeassistant_service.py
+++ b/tests/test_homeassistant_service.py
@@ -109,6 +109,19 @@ def test_homeassistant_publish_discovery_emits_expected_entities():
     assert len(client.published) == 16
 
 
+def test_homeassistant_ha_web_urls_use_resolved_api_key(monkeypatch):
+    svc = HomeAssistantService(
+        FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer", printer_index=0
+    )
+    monkeypatch.delenv("ANKERCTL_API_KEY", raising=False)
+    monkeypatch.setitem(web_module.app.config, "api_key", "resolved-key")
+
+    mjpeg_url, snapshot_url = svc._ha_web_urls()
+
+    assert "apikey=resolved-key" in mjpeg_url
+    assert "apikey=resolved-key" in snapshot_url
+
+
 def test_homeassistant_on_connect_and_light_command(monkeypatch):
     svc = HomeAssistantService(FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer")
     client = FakeMQTTClient()
@@ -262,6 +275,92 @@ def test_homeassistant_disconnect_and_publish_failures_are_non_fatal():
     svc._on_disconnect(None, None, 1)
 
     assert svc._connected is False
+
+
+def test_homeassistant_reload_config_survives_bad_port_type():
+    svc = HomeAssistantService(FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer")
+    prior_port = svc._port
+
+    bad_config = SimpleNamespace(
+        home_assistant={
+            "enabled": True,
+            "mqtt_host": "mqtt.example",
+            "mqtt_port": "not-a-number",
+            "mqtt_username": "ha-user",
+            "mqtt_password": "ha-pass",
+            "discovery_prefix": "ha",
+        }
+    )
+
+    svc.reload_config(bad_config)
+
+    assert svc._port == prior_port
+
+
+def test_register_mjpeg_camera_idempotency_matches_own_entry(monkeypatch):
+    svc = HomeAssistantService(FakeConfigManager(_service_config()), printer_sn="SN123", printer_name="Printer")
+    svc._ha_base_url = "http://ha.example"
+    svc._ha_token = "token"
+
+    camera_name = f"AnkerMake {svc._printer_sn}"
+    existing_entries = [{"domain": "mjpeg", "title": camera_name, "entry_id": "existing-entry-id"}]
+
+    calls = []
+
+    def fake_request(method, path, body=None, ha_base_url=None, ha_token=None):
+        calls.append((method, path))
+        if method == "GET":
+            return existing_entries
+        raise AssertionError("should not attempt to create a duplicate camera entry")
+
+    monkeypatch.setattr(svc, "_ha_rest_request", fake_request)
+
+    svc._register_ha_mjpeg_camera()
+
+    assert svc._ha_mjpeg_entry_id == "existing-entry-id"
+    assert calls == [("GET", "/api/config/config_entries")]
+
+
+def test_start_and_stop_hold_lock(monkeypatch):
+    """Fix 3: start()/stop() must hold self._lock for their duration so two
+    near-simultaneous reload_config() calls can't race on self._client."""
+    fake_client = FakeMQTTClient()
+    svc_holder = []
+    lock_states_on_connect = []
+
+    class FakePahoModule:
+        class CallbackAPIVersion:
+            VERSION1 = object()
+
+        @staticmethod
+        def Client(*args, **kwargs):
+            lock_states_on_connect.append(svc_holder[0]._lock.locked())
+            return fake_client
+
+    monkeypatch.setattr("web.service.homeassistant.paho_mqtt", FakePahoModule)
+
+    # Construct with enabled=False so __init__ -> reload_config() does not
+    # auto-start before svc_holder is populated for the FakePahoModule closure.
+    svc = HomeAssistantService(
+        FakeConfigManager(_service_config(enabled=False)), printer_sn="SN123", printer_name="Printer"
+    )
+    svc_holder.append(svc)
+    svc._enabled = True
+    svc.start()
+
+    assert lock_states_on_connect == [True]
+
+    lock_states_on_unregister = []
+    orig_unregister = svc._unregister_ha_mjpeg_camera
+
+    def spy_unregister():
+        lock_states_on_unregister.append(svc._lock.locked())
+        return orig_unregister()
+
+    svc._unregister_ha_mjpeg_camera = spy_unregister
+    svc.stop()
+
+    assert lock_states_on_unregister == [True]
 
 
 def test_rapid_reconnect_no_thread_leak():

--- a/tests/test_httpapi.py
+++ b/tests/test_httpapi.py
@@ -109,6 +109,37 @@ class TestAPIDecorators:
         assert result == {"result": "value"}
 
     @patch('requests.get')
+    def test_unwrap_api_redacts_secrets_from_debug_log(self, mock_get, caplog):
+        """unwrap_api must not leak auth tokens / device secrets into DEBUG logs"""
+        import logging
+
+        @unwrap_api
+        def dummy_method(self):
+            return mock_get.return_value
+
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "code": 0,
+            "data": {
+                "auth_token": "deadbeefcafebabe0123456789abcdef01234567",
+                "dsk_keys": [{"station_sn": "SN1", "dsk_key": "super-secret-dsk"}],
+                "user_id": "user-123",
+            },
+        }
+        mock_get.return_value = mock_response
+
+        mock_self = Mock()
+        mock_self.scope = "/test"
+
+        with caplog.at_level(logging.DEBUG):
+            dummy_method(mock_self)
+
+        assert "deadbeefcafebabe" not in caplog.text
+        assert "super-secret-dsk" not in caplog.text
+        assert "user-123" in caplog.text  # non-sensitive fields still logged for debugging
+
+    @patch('requests.get')
     def test_unwrap_api_raises_on_non_zero_code(self, mock_get):
         """unwrap_api raises APIError when API returns error code"""
 

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -49,6 +49,9 @@ def _queue():
     queue._filament_change_value = None
     queue._filament_change_progress = None
     queue._filament_change_step_len = None
+    queue._filament_vendor = None
+    queue._filament_type = None
+    queue._filament_metadata_source = None
     queue._control_username = "tester@example.com"
     queue._control_user_id = "user-123"
     queue._debug_log_payloads = False
@@ -144,6 +147,35 @@ def test_forward_to_ha_tracks_filament_state_from_material_change_mode():
     assert state["raw_value"] == 0
     assert state["progress"] == 0
     assert state["step_len"] == 0
+
+
+def test_filament_state_includes_gcode_vendor_and_type():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue.set_gcode_filament_info(vendor="Sunlu", type="PETG")
+    queue.mark_pending_print_start("part_0.2mm_PETG_Anker_M5.gcode")
+    state = queue.get_state()["filament"]
+
+    assert state["material_label"] == "Sunlu PETG"
+    assert state["vendor"] == "Sunlu"
+    assert state["type"] == "PETG"
+    assert state["metadata_source"] == "gcode"
+
+
+def test_filament_state_infers_type_from_filename():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue.mark_pending_print_start("part_0.2mm_PETG_Anker_M5.gcode")
+    state = queue.get_state()["filament"]
+
+    assert state["material_label"] == "PETG"
+    assert state["vendor"] is None
+    assert state["type"] == "PETG"
+    assert state["metadata_source"] == "filename"
 
 
 def test_handle_notification_tracks_filament_changing_state():

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -2,6 +2,7 @@ import logging
 import queue as queue_module
 import threading
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 from web.service.mqtt import MqttQueue, PrintState, EVENT_PRINT_FINISHED
@@ -176,6 +177,59 @@ def test_filament_state_infers_type_from_filename():
     assert state["vendor"] is None
     assert state["type"] == "PETG"
     assert state["metadata_source"] == "filename"
+
+
+def test_mqtt_reconnect_preserves_gcode_filament_metadata():
+    """worker_start() reconnect must not wipe GCode-derived filament info.
+
+    Regression test: a real print showed the correct filament type briefly
+    at print start, then reverted to "unknown" shortly after. Root cause was
+    worker_start() unconditionally calling _reset_print_state() on every MQTT
+    reconnect (e.g. after a transient WiFi hiccup mid-print). Unlike
+    _last_filename/_last_task_id/_state, which self-heal from the next live
+    ct=1000/ct=1001 telemetry, filament vendor/type has no telemetry source —
+    it is a one-shot value pushed from the GCode header at upload time — so
+    wiping it on reconnect loses it for the rest of the print.
+    """
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue.set_gcode_filament_info(vendor="ankerctl-smoketest", type="PETG")
+    queue.mark_pending_print_start("ankerctl_smoketest.gcode")
+    queue._state = PrintState.PRINTING
+
+    # Simulate the reset performed by worker_start() on reconnect.
+    queue._reset_print_state(preserve_filament_metadata=True)
+
+    state = queue.get_state()["filament"]
+    assert state["material_label"] == "ankerctl-smoketest PETG"
+    assert state["vendor"] == "ankerctl-smoketest"
+    assert state["type"] == "PETG"
+    assert state["metadata_source"] == "gcode"
+    # Print-lifecycle fields still reset normally on reconnect.
+    assert queue._state == PrintState.IDLE
+    assert queue._last_filename is None
+
+
+def test_normal_print_state_reset_still_clears_filament_metadata():
+    """A genuine print-lifecycle reset (finish/cancel/abort) must still clear
+    filament info so a subsequent print doesn't inherit stale material data."""
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue.set_gcode_filament_info(vendor="ankerctl-smoketest", type="PETG")
+    queue.mark_pending_print_start("ankerctl_smoketest.gcode")
+    queue._state = PrintState.PRINTING
+
+    queue._reset_print_state()
+
+    state = queue.get_state()["filament"]
+    assert state["material_label"] is None
+    assert state["vendor"] is None
+    assert state["type"] is None
+    assert state["metadata_source"] is None
 
 
 def test_handle_notification_tracks_filament_changing_state():
@@ -528,6 +582,52 @@ def test_deferred_filename_print_start_does_not_crash_when_timelapse_unavailable
 
     assert queue._pending_history_start is False
     assert history_calls == [("start", ("deferred.gcode",), {"task_id": None})]
+
+
+def test_worker_init_survives_ha_service_init_failure(monkeypatch, tmp_path):
+    """If HomeAssistantService raises during construction (e.g. a bad
+    persisted mqtt_port), worker_init() must not raise — self._ha ends up
+    None instead of killing the service thread outright."""
+    import web as web_module
+
+    class FakeConfigManager:
+        def __init__(self, cfg, config_root):
+            self.cfg = cfg
+            self.config_root = config_root
+
+        @contextmanager
+        def open(self):
+            yield self.cfg
+
+    cfg = SimpleNamespace(
+        account=SimpleNamespace(email="tester@example.com", user_id="user-1"),
+        printers=[SimpleNamespace(sn="SN123", name="Printer 1")],
+    )
+    manager = FakeConfigManager(cfg, config_root=tmp_path)
+
+    class RaisingHomeAssistantService:
+        def __init__(self, *args, **kwargs):
+            raise ValueError("invalid literal for int() with base 10: 'not-a-number'")
+
+    monkeypatch.setattr("web.service.mqtt.AppriseNotifier", lambda *a, **kw: SimpleNamespace())
+    monkeypatch.setattr("web.service.mqtt.PrintHistory", lambda *a, **kw: SimpleNamespace())
+    monkeypatch.setattr("web.service.mqtt.TimelapseService", lambda *a, **kw: SimpleNamespace())
+    monkeypatch.setattr("web.service.mqtt.HomeAssistantService", RaisingHomeAssistantService)
+
+    old_config = web_module.app.config.get("config")
+    web_module.app.config["config"] = manager
+
+    queue = object.__new__(MqttQueue)
+    queue.printer_index = 0
+    queue._state_lock = threading.RLock()
+    queue._print_state_event = threading.Event()
+
+    try:
+        queue.worker_init()
+    finally:
+        web_module.app.config["config"] = old_config
+
+    assert queue._ha is None
 
 
 def test_handle_notification_aborts_active_print_on_value_8(monkeypatch):
@@ -2004,3 +2104,28 @@ def test_handle_notification_print_finished_does_not_block_on_slow_notifier(monk
     assert elapsed < 0.2
     release.set()
     queue._notification_queue.join()
+
+
+def test_worker_stop_notifies_timelapse():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    calls = []
+    queue._timelapse = SimpleNamespace(handle_mqtt_service_stopped=lambda: calls.append(True))
+    queue._ha = SimpleNamespace(update_state=lambda **kwargs: None, stop=lambda: None)
+
+    queue.worker_stop()
+
+    assert calls == [True]
+
+
+def test_worker_stop_without_timelapse_service():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue._timelapse = None
+    queue._ha = SimpleNamespace(update_state=lambda **kwargs: None, stop=lambda: None)
+
+    queue.worker_stop()

--- a/tests/test_mqttqueue_service.py
+++ b/tests/test_mqttqueue_service.py
@@ -44,6 +44,7 @@ def _queue():
     queue._nozzle_temp_target = None
     queue._bed_temp = None
     queue._bed_temp_target = None
+    queue._fan_speed = None
     queue._filament_state = "unknown"
     queue._filament_change_value = None
     queue._filament_change_progress = None
@@ -109,6 +110,20 @@ def test_forward_to_ha_accepts_zero_temperature_targets():
     assert queue._bed_temp_target == 0
     assert {"nozzle_temp": 205, "nozzle_temp_target": 0} in ha_updates
     assert {"bed_temp": 60, "bed_temp_target": 0} in ha_updates
+
+
+def test_forward_to_ha_tracks_fan_speed_percent():
+    global ha_updates, history_calls, timelapse_calls, events
+    ha_updates, history_calls, timelapse_calls, events = [], [], [], []
+    queue = _queue()
+
+    queue._forward_to_ha({"commandType": 1005, "value": 0})
+    assert queue.get_state()["telemetry"]["fan_speed"] == 0
+    assert {"fan_speed": 0} in ha_updates
+
+    queue._forward_to_ha({"commandType": 1005, "value": 125})
+    assert queue.get_state()["telemetry"]["fan_speed"] == 100
+    assert {"fan_speed": 100} in ha_updates
 
 
 def test_forward_to_ha_tracks_filament_state_from_material_change_mode():

--- a/tests/test_print_history.py
+++ b/tests/test_print_history.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from web.service.history import PrintHistory
 
@@ -133,6 +133,117 @@ def test_history_clear_and_fallback_finish_latest_active(tmp_path):
 
     history.clear()
     assert history.get_count() == 0
+
+
+def test_clear_preserves_active_entry(tmp_path):
+    history = PrintHistory(db_path=tmp_path / "history.db")
+
+    history.record_start("done.gcode", task_id="t-done")
+    history.record_finish(task_id="t-done", progress=100)
+    active_id = history.record_start("active.gcode", task_id="t-active")
+
+    assert history.has_active_entry() is True
+    history.clear()
+
+    entry = history.get_entry(active_id)
+    assert entry is not None
+    assert entry["status"] == "started"
+    assert history.get_count() == 1
+
+
+def test_clear_with_active_entry_preserves_its_archive_file(tmp_path):
+    history = PrintHistory(db_path=tmp_path / "history.db")
+
+    done_info = history.archive_upload("done.gcode", b"G28\n")
+    done_id = history.record_start(
+        "done.gcode",
+        task_id="t-done",
+        archive_relpath=done_info["archive_relpath"],
+        archive_size=done_info["archive_size"],
+    )
+    history.record_finish(task_id="t-done", progress=100)
+
+    active_info = history.archive_upload("active.gcode", b"G28\nG1 X10\n")
+    active_id = history.record_start(
+        "active.gcode",
+        task_id="t-active",
+        archive_relpath=active_info["archive_relpath"],
+        archive_size=active_info["archive_size"],
+    )
+
+    history.clear()
+
+    assert history.get_entry(done_id) is None
+    archive_path = history.get_archive_path(active_id)
+    assert archive_path is not None
+    assert os.path.exists(archive_path)
+
+
+def test_scoped_clear_preserves_active_entry_for_that_printer(tmp_path):
+    db_path = tmp_path / "history.db"
+    history0 = PrintHistory(db_path=db_path, printer_index=0)
+
+    history0.record_start("done.gcode", task_id="t-done")
+    history0.record_finish(task_id="t-done", progress=100)
+    active_id = history0.record_start("active.gcode", task_id="t-active")
+
+    assert history0.has_active_entry(printer_index=0) is True
+    assert history0.has_active_entry(printer_index=1) is False
+    history0.clear(printer_index=0)
+
+    entry = history0.get_entry(active_id)
+    assert entry is not None
+    assert entry["status"] == "started"
+
+
+def test_prune_never_deletes_active_entry_past_retention(tmp_path):
+    history = PrintHistory(db_path=tmp_path / "history.db", retention_days=1)
+
+    active_id = history.record_start("long-print.gcode", task_id="t-long")
+    old_started = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=5)).isoformat()
+    with history._connect() as conn:
+        conn.execute("UPDATE print_history SET started_at=? WHERE id=?", (old_started, active_id))
+
+    history._prune()
+
+    assert history.get_entry(active_id) is not None
+
+
+def test_prune_via_other_printer_does_not_delete_active_entry(tmp_path):
+    db_path = tmp_path / "history.db"
+    history_a = PrintHistory(db_path=db_path, printer_index=0, retention_days=1)
+    history_b = PrintHistory(db_path=db_path, printer_index=1, retention_days=1)
+
+    active_id = history_a.record_start("long-print.gcode", task_id="a-task")
+    old_started = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=5)).isoformat()
+    with history_a._connect() as conn:
+        conn.execute("UPDATE print_history SET started_at=? WHERE id=?", (old_started, active_id))
+
+    history_b.record_start("other.gcode", task_id="b-task")
+    # record_start fires _prune() in a background thread; call it directly for determinism
+    history_b._prune()
+
+    assert history_a.get_entry(active_id) is not None
+    entry = history_a.get_entry(active_id)
+    assert entry["status"] == "started"
+
+
+def test_prune_max_entries_preserves_active_entry(tmp_path):
+    history = PrintHistory(db_path=tmp_path / "history.db", max_entries=2)
+
+    active_id = history.record_start("active.gcode", task_id="t-active")
+    with history._connect() as conn:
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO print_history (filename, status, started_at) VALUES (?, 'finished', ?)",
+                (f"newer-{i}.gcode", datetime.now(timezone.utc).replace(tzinfo=None).isoformat()),
+            )
+
+    history._prune()
+
+    entry = history.get_entry(active_id)
+    assert entry is not None
+    assert entry["status"] == "started"
 
 
 def test_printer_scoped_history_includes_legacy_rows_in_view_and_count(tmp_path):
@@ -277,6 +388,7 @@ def test_history_clear_removes_archived_gcode_files(tmp_path):
         archive_relpath=archive_info["archive_relpath"],
         archive_size=archive_info["archive_size"],
     )
+    history.record_finish(filename="cube.gcode")
     assert history.get_archive_path(row_id) is not None
 
     history.clear()

--- a/tests/test_printer_media_history_api.py
+++ b/tests/test_printer_media_history_api.py
@@ -1,8 +1,11 @@
+import io
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 import subprocess
 from types import SimpleNamespace
+
+import pytest
 
 from cli.model import Account, Config, Printer
 from web import app
@@ -152,6 +155,85 @@ def test_printer_gcode_route_normalizes_safe_commands_and_blocks_motion_while_pr
     assert safe.status_code == 200
     assert blocked.status_code == 409
     assert sent == ["G28\nM104 S200", "M117 Printing"]
+
+
+@pytest.mark.parametrize("gcode", ["G2 X10 Y10 I5", "G3 X10 Y10 I5", "G92 E0", "M84", "M18", "M420 S0", "M420 S 0"])
+def test_printer_gcode_blocks_expanded_unsafe_commands_while_printing(gcode):
+    sent = []
+    mqtt = SimpleNamespace(
+        is_printing=True,
+        send_gcode=lambda gcode: sent.append(gcode),
+    )
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        blocked = client.post(
+            "/api/printer/gcode",
+            json={"gcode": gcode},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert blocked.status_code == 409
+    assert sent == []
+
+
+def test_printer_gcode_allows_m420_query_while_printing():
+    sent = []
+    mqtt = SimpleNamespace(
+        is_printing=True,
+        send_gcode=lambda gcode: sent.append(gcode),
+    )
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        allowed = client.post(
+            "/api/printer/gcode",
+            json={"gcode": "M420 V"},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert allowed.status_code == 200
+    assert sent == ["M420 V"]
+
+
+def test_files_local_blocks_print_start_but_allows_upload_only_while_printing():
+    send_calls = []
+    mqtt = SimpleNamespace(
+        is_printing=True,
+        has_pending_print_start=False,
+        is_preparing_print=False,
+    )
+
+    def fake_send_file(fd, user_name, rate_limit_mbps=None, start_print=False, printer_index=None):
+        send_calls.append(start_print)
+
+    ft = SimpleNamespace(send_file=fake_send_file)
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt, filetransfer=ft)
+
+    try:
+        blocked = client.post(
+            "/api/files/local",
+            data={"print": "true", "file": (io.BytesIO(b"G28\n"), "test.gcode")},
+            headers={"X-Api-Key": API_KEY},
+        )
+        upload_only = client.post(
+            "/api/files/local",
+            data={"print": "false", "file": (io.BytesIO(b"G28\n"), "test.gcode")},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert blocked.status_code == 409
+    assert upload_only.status_code == 200
+    assert send_calls == [False]
 
 
 def test_printer_control_and_autolevel_routes_validate_and_dispatch():
@@ -441,6 +523,115 @@ def test_printer_z_offset_routes_refresh_set_and_nudge():
     assert send_calls == ["M290 Z+0.03", "M500", "M290 Z-0.02", "M500"]
 
 
+def test_printer_z_offset_routes_reject_out_of_range_targets():
+    send_calls = []
+    state = {"available": True, "steps": 190, "mm": 1.90, "source": "cached", "seq": 1}
+    mqtt = SimpleNamespace(
+        refresh_z_offset=lambda timeout=None: dict(state),
+        send_gcode=lambda gcode: send_calls.append(gcode),
+        get_z_offset_state=lambda: dict(state),
+    )
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        set_resp = client.post(
+            "/api/printer/z-offset",
+            json={"target_mm": 50},
+            headers={"X-Api-Key": API_KEY},
+        )
+        set_resp_neg = client.post(
+            "/api/printer/z-offset",
+            json={"target_mm": -50},
+            headers={"X-Api-Key": API_KEY},
+        )
+        # In-range current (1.90 mm) plus a delta that pushes past the bound.
+        nudge_resp = client.post(
+            "/api/printer/z-offset/nudge",
+            json={"delta_mm": 0.5},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert set_resp.status_code == 400
+    assert set_resp_neg.status_code == 400
+    assert nudge_resp.status_code == 400
+    assert "must be between" in set_resp.get_json()["error"]
+    assert send_calls == []
+
+
+def test_printer_control_restart_requires_active_print():
+    control_calls = []
+    mqtt = SimpleNamespace(
+        is_printing=False,
+        has_pending_print_start=False,
+        is_preparing_print=False,
+        send_print_control=lambda value: control_calls.append(value),
+    )
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        blocked = client.post(
+            "/api/printer/control",
+            json={"value": 0},
+            headers={"X-Api-Key": API_KEY},
+        )
+        mqtt.is_printing = True
+        allowed = client.post(
+            "/api/printer/control",
+            json={"value": 0},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert blocked.status_code == 409
+    assert allowed.status_code == 200
+    assert control_calls == [0]
+
+
+def test_bed_leveling_and_settings_summary_blocked_while_printing():
+    mqtt = SimpleNamespace(is_printing=True)
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        bed = client.get("/api/printer/bed-leveling", headers={"X-Api-Key": API_KEY})
+        summary = client.get("/api/printer/settings-summary", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert bed.status_code == 409
+    assert "while printing" in bed.get_json()["error"]
+    assert summary.status_code == 409
+    assert "while printing" in summary.get_json()["error"]
+
+
+def test_printer_gcode_route_rejects_too_many_lines():
+    sent = []
+    mqtt = SimpleNamespace(
+        is_printing=False,
+        send_gcode=lambda gcode: sent.append(gcode),
+    )
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        response = client.post(
+            "/api/printer/gcode",
+            json={"gcode": "\n".join(f"M117 line{i}" for i in range(201))},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 400
+    assert "Too many gcode lines" in response.get_json()["error"]
+    assert sent == []
+
+
 def test_history_routes_require_auth_and_clear_entries():
     calls = []
     history = SimpleNamespace(
@@ -449,6 +640,7 @@ def test_history_routes_require_auth_and_clear_entries():
             or [{"id": 1, "filename": "cube.gcode", "thumbnail_available": False, "printer_index": printer_index}]
         ),
         get_count=lambda printer_index=None: calls.append(("count", printer_index)) or 3,
+        has_active_entry=lambda printer_index=None: False,
         clear=lambda printer_index=None: calls.append(("clear", printer_index)),
     )
     mqtt = SimpleNamespace(history=history)
@@ -475,6 +667,7 @@ def test_history_clear_route_respects_filter_scope():
     history = SimpleNamespace(
         get_history=lambda limit, offset, printer_index=None: [],
         get_count=lambda printer_index=None: 0,
+        has_active_entry=lambda printer_index=None: False,
         clear=lambda printer_index=None: clear_calls.append(printer_index),
     )
     cfg = _base_config()
@@ -504,6 +697,23 @@ def test_history_clear_route_respects_filter_scope():
     assert specific.status_code == 200
     assert all_printers.status_code == 200
     assert clear_calls == [1, 0, None]
+
+
+def test_history_clear_route_rejects_active_print(tmp_path):
+    history = PrintHistory(db_path=tmp_path / "history.db", printer_index=0)
+    active_id = history.record_start("active.gcode", task_id="t-active")
+    mqtt = SimpleNamespace(history=history)
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt)
+
+    try:
+        response = client.delete("/api/history", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 409
+    assert "in progress" in response.get_json()["error"]
+    assert history.get_entry(active_id) is not None
 
 
 def test_history_route_uses_requested_or_active_indexed_mqtt_service():
@@ -768,6 +978,36 @@ def test_history_reprint_route_requires_archived_file(tmp_path):
 
     assert response.status_code == 404
     assert "No archived GCode" in response.get_json()["error"]
+
+
+def test_history_reprint_route_handles_archive_vanishing_before_read(tmp_path):
+    # TOCTOU: get_archive_path() succeeds but the file is gone by open() time
+    missing_path = tmp_path / "vanished.gcode"
+    history = SimpleNamespace(
+        get_entry=lambda entry_id: {
+            "id": entry_id,
+            "filename": "vanished.gcode",
+            "archive_relpath": "vanished.gcode",
+            "archive_size": 10,
+        },
+        get_archive_path=lambda entry_id: str(missing_path),
+    )
+    mqtt = SimpleNamespace(
+        is_printing=False,
+        has_pending_print_start=False,
+        is_preparing_print=False,
+        history=history,
+    )
+    client = app.test_client()
+    old_values, old_svc = _install_app_state(mqtt=mqtt, filetransfer=SimpleNamespace(send_bytes=lambda *args, **kwargs: None))
+
+    try:
+        response = client.post("/api/history/1/reprint", headers={"X-Api-Key": API_KEY})
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 404
+    assert "no longer available" in response.get_json()["error"]
 
 
 def test_timelapse_routes_list_download_delete_and_reject_traversal(tmp_path):

--- a/tests/test_protocol_pppp.py
+++ b/tests/test_protocol_pppp.py
@@ -170,6 +170,17 @@ def test_channel_write_poll_and_acknowledge():
     assert chan.txqueue == []
 
 
+def test_channel_write_raises_timeout_instead_of_blocking_forever_when_never_acked():
+    # Regression: Channel.write(block=True) with timeout=None waits on a bare
+    # Event.wait() with no deadline (see the `else: self.wait()` branch), so a
+    # silently-dropped outgoing packet blocks forever. Passing an explicit
+    # timeout must take the bounded-deadline branch instead and raise.
+    chan = Channel(index=0)
+
+    with pytest.raises(TimeoutError, match="PPPP DRW ACK"):
+        chan.write(b"payload", block=True, timeout=0.2)
+
+
 def test_channel_can_skip_stale_receive_gap_for_realtime_streams():
     chan = Channel(index=1)
 

--- a/tests/test_reports_video_and_webserver.py
+++ b/tests/test_reports_video_and_webserver.py
@@ -203,9 +203,10 @@ def test_read_printer_report_disconnects_client_and_summary_builds_groups(monkey
     manager = FakeConfigManager(_base_config())
     old_values, old_svc = _install_app_state(config=manager, printer_index=0, insecure=False)
     disconnects = []
+    opens = []
 
     client = SimpleNamespace(_mqtt=SimpleNamespace(disconnect=lambda: disconnects.append(True)))
-    monkeypatch.setattr("cli.mqtt.mqtt_open", lambda config, printer_index, insecure: client)
+    monkeypatch.setattr("cli.mqtt.mqtt_open", lambda config, printer_index, insecure: opens.append(True) or client)
     monkeypatch.setattr(
         "web._collect_printer_gcode_output",
         lambda client, gcode, window, drain: {
@@ -224,15 +225,16 @@ def test_read_printer_report_disconnects_client_and_summary_builds_groups(monkey
     assert report["name"] == "probe_offset"
     assert report["gcode"] == "M851"
     assert disconnects == [True]
+    assert opens == [True]
 
     mqtt = SimpleNamespace(
         get_z_offset_state=lambda: {"available": True, "steps": 25, "mm": 0.25, "source": "cached"},
         refresh_z_offset=lambda timeout=None: {"available": True, "steps": 25, "mm": 0.25, "source": "live"},
     )
-    old_values, old_svc = _install_app_state(svc=FakeBorrowServices(mqtt))
+    old_values, old_svc = _install_app_state(svc=FakeBorrowServices(mqtt), config=manager)
     monkeypatch.setattr(
         "web._read_printer_report",
-        lambda name, printer_index=None: {
+        lambda name, printer_index=None, client=None: {
             "name": name,
             "label": name,
             "gcode": {"settings": "M503", "probe_offset": "M851", "babystep": "M290 R"}[name],
@@ -253,6 +255,9 @@ def test_read_printer_report_disconnects_client_and_summary_builds_groups(monkey
     assert summary["live_z_offset"]["display"] == "0.25 mm"
     assert any(item["command"] == "M851" for item in summary["highlights"])
     assert any(item["command"] == "M290" for item in summary["groups"]["leveling"])
+    # Summary must open exactly one shared connection for all three reports.
+    assert opens == [True, True]
+    assert disconnects == [True, True]
 
 
 def test_bed_leveling_last_route_reads_latest_saved_grid(tmp_path, monkeypatch):
@@ -273,6 +278,71 @@ def test_bed_leveling_last_route_reads_latest_saved_grid(tmp_path, monkeypatch):
     assert response.status_code == 200
     assert response.get_json()["grid"] == [[0.2]]
     assert response.get_json()["saved_at"] == "20260101_110000"
+
+
+def test_bed_leveling_last_route_scopes_by_printer_index(tmp_path, monkeypatch):
+    client = app.test_client()
+    bed_dir = tmp_path / "bed_leveling"
+    bed_dir.mkdir()
+    (bed_dir / "20260101_100000_p0.bed").write_text(json.dumps({"grid": [[0.1]], "printer_index": 0}))
+    (bed_dir / "20260101_110000_p1.bed").write_text(json.dumps({"grid": [[0.2]], "printer_index": 1}))
+
+    monkeypatch.setattr("web._log_dir", str(tmp_path))
+    manager = FakeConfigManager(_base_config(), config_root=tmp_path)
+    old_values, old_svc = _install_app_state(login=True, api_key=None, config=manager, printer_index=0)
+
+    try:
+        response = client.get("/api/printer/bed-leveling/last?printer_index=0")
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    assert response.get_json()["grid"] == [[0.1]]
+    assert response.get_json()["saved_at"] == "20260101_100000"
+
+
+def test_bed_leveling_last_route_falls_back_to_legacy_unsuffixed_files(tmp_path, monkeypatch):
+    client = app.test_client()
+    bed_dir = tmp_path / "bed_leveling"
+    bed_dir.mkdir()
+    (bed_dir / "20260101_100000.bed").write_text(json.dumps({"grid": [[0.3]]}))
+
+    monkeypatch.setattr("web._log_dir", str(tmp_path))
+    manager = FakeConfigManager(_base_config(), config_root=tmp_path)
+    old_values, old_svc = _install_app_state(login=True, api_key=None, config=manager, printer_index=0)
+
+    try:
+        response = client.get("/api/printer/bed-leveling/last?printer_index=0")
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert response.status_code == 200
+    assert response.get_json()["grid"] == [[0.3]]
+    assert response.get_json()["saved_at"] == "20260101_100000"
+
+
+def test_read_bed_leveling_grid_skips_unparseable_rows(tmp_path, monkeypatch):
+    manager = FakeConfigManager(_base_config(), config_root=tmp_path)
+    old_values, old_svc = _install_app_state(config=manager, printer_index=0, insecure=False)
+
+    monkeypatch.setattr("web._log_dir", str(tmp_path))
+    monkeypatch.setattr("cli.mqtt.mqtt_open", lambda config, printer_index, insecure: object())
+    monkeypatch.setattr(
+        "cli.mqtt.mqtt_gcode_dump",
+        lambda client, gcode, collect_window=4.0: [
+            {"resData": "BL-Grid-0 -0.767-0.642 -0.500\n"},
+            {"resData": "BL-Grid-1 -0.500 -0.250\n"},
+        ],
+    )
+
+    try:
+        data, err = _read_bed_leveling_grid()
+    finally:
+        _restore_app_state(old_values, old_svc)
+
+    assert err is None
+    assert data["grid"] == [[-0.5, -0.25]]
+    assert data["rows"] == 1
 
 
 def test_video_download_requires_auth_and_streams_when_enabled():

--- a/tests/test_security_validation.py
+++ b/tests/test_security_validation.py
@@ -153,9 +153,47 @@ class TestSQLInjectionProtection:
 class TestPathTraversalProtection:
     """Test path traversal attack prevention"""
 
-    def test_log_viewer_path_traversal_blocked(self):
-        """GET /api/debug/logs/../../../etc/passwd is blocked"""
-        _pending_security_coverage("debug log file path traversal")
+    def test_log_viewer_path_traversal_blocked(self, monkeypatch, tmp_path):
+        """GET /api/debug/logs/<filename> rejects path traversal attempts"""
+        import importlib
+        import web as web_module
+
+        # reload() replaces the module-global `app`; view functions of app
+        # instances bound by other test modules resolve `app` through the
+        # module dict, so the original instance must be restored afterwards.
+        original_app = web_module.app
+        monkeypatch.setenv("ANKERCTL_DEV_MODE", "true")
+        importlib.reload(web_module)
+
+        try:
+            flask_app = web_module.app
+            client = flask_app.test_client()
+            flask_app.config["api_key"] = API_KEY
+            flask_app.config["login"] = True
+            flask_app.config["config"] = FakeConfigManager(_base_config())
+            flask_app.config["printer_index"] = 0
+            monkeypatch.setattr(web_module, "_log_dir", str(tmp_path))
+            (tmp_path / "web.log").write_text("hello\n")
+
+            dotdot = client.get(
+                "/api/debug/logs/..web.log", headers=_auth_headers()
+            )
+            encoded = client.get(
+                "/api/debug/logs/..%2F..%2Fetc%2Fpasswd", headers=_auth_headers()
+            )
+            legit = client.get("/api/debug/logs/web.log", headers=_auth_headers())
+        finally:
+            monkeypatch.setenv("ANKERCTL_DEV_MODE", "false")
+            importlib.reload(web_module)
+            web_module.app = original_app
+
+        assert dotdot.status_code == 400
+        assert dotdot.get_json()["error"] == "Invalid filename"
+        # encoded slashes must never reach the file system: either the guard
+        # rejects the decoded filename (400) or routing refuses the path (404)
+        assert encoded.status_code != 200
+        assert legit.status_code == 200
+        assert legit.get_json()["content"] == "hello\n"
 
     def test_timelapse_filename_path_traversal(self):
         """Timelapse download with ../ in filename is blocked"""
@@ -410,6 +448,61 @@ class TestSecurityIntegration:
 
         assert responses
         assert all(status == 401 for _, status in responses), responses
+
+    def test_setup_endpoints_require_auth_when_api_key_already_configured(self, tmp_path):
+        """A pre-configured API key (e.g. ANKERCTL_API_KEY set before first
+        boot, as in a Docker deployment) must be honored even during the
+        setup window, i.e. before any printer/account is configured.
+
+        There used to be a blanket setup-path exemption keyed only on
+        "no printer configured yet" that ignored whether an API key had
+        already been set, letting anyone on the LAN complete first-run setup
+        (and thus take over the instance) during that window. That exemption
+        has been removed — this test guards against it coming back."""
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        app.config["login"] = None  # no printer/account configured yet
+        try:
+            responses = [
+                ("/api/ankerctl/config/upload", client.post("/api/ankerctl/config/upload").status_code),
+                (
+                    "/api/ankerctl/config/login",
+                    client.post(
+                        "/api/ankerctl/config/login",
+                        data={"login_email": "a@b.com", "login_password": "pw", "login_country": "us"},
+                    ).status_code,
+                ),
+                ("/api/ankerctl/config/import-slicer", client.post("/api/ankerctl/config/import-slicer").status_code),
+            ]
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        assert all(status == 401 for _, status in responses), responses
+
+    def test_every_entry_in_protected_get_paths_actually_requires_auth(self, tmp_path):
+        """Every path listed in the real _PROTECTED_GET_PATHS set must 401
+        without auth.
+
+        Unlike test_anonymous_user_cannot_access_protected_endpoints (which
+        checks a hand-picked sample), this iterates the actual set used by
+        _check_api_key() so a future edit that drops or typos an entry is
+        caught immediately instead of silently reopening a previously
+        protected endpoint. before_request auth checks run ahead of route
+        matching, so this holds even for dev-mode-only paths like
+        /api/debug/state when ANKERCTL_DEV_MODE is off."""
+        from web import _PROTECTED_GET_PATHS
+
+        assert _PROTECTED_GET_PATHS, "protected GET path set must not be empty"
+
+        client = app.test_client()
+        old_values, old_svc, old_filaments = _install_security_state(tmp_path)
+        try:
+            responses = [(path, client.get(path).status_code) for path in sorted(_PROTECTED_GET_PATHS)]
+        finally:
+            _restore_security_state(old_values, old_svc, old_filaments)
+
+        failures = [(path, status) for path, status in responses if status != 401]
+        assert not failures, f"protected GET paths did not require auth: {failures}"
 
     def test_authenticated_user_can_access_allowed_endpoints(self, tmp_path):
         """Authenticated user can access non-restricted endpoints"""

--- a/tests/test_service_crash_recovery.py
+++ b/tests/test_service_crash_recovery.py
@@ -208,30 +208,6 @@ class TestPartialUploadRecovery:
         pass
 
 
-class TestVideoServiceStallRecovery:
-    """Test VideoQueue stall detection and recovery"""
-
-    @patch('web.service.video.VideoQueue')
-    def test_video_stall_detection_triggers_soft_restart(self, mock_vq):
-        """No frames past the configured timeout triggers soft restart"""
-        from web.service.video import VideoQueue, _STALL_TIMEOUT
-
-        vq = VideoQueue()
-        vq.last_frame_at = time.time() - (_STALL_TIMEOUT + 1)
-
-        # worker_run should detect stall
-        # (Implementation-specific: check actual stall detection logic)
-        pass
-
-    def test_video_three_consecutive_failures_trigger_hard_restart(self):
-        """3 consecutive soft restart failures trigger ServiceRestartSignal"""
-        from web.service.video import _STALL_MAX_RETRIES
-
-        # Simulate 3 consecutive stall detections
-        # Should raise ServiceRestartSignal on 3rd failure
-        pass
-
-
 class TestServiceDependencyFailure:
     """Test service behavior when dependencies fail"""
 

--- a/tests/test_service_framework.py
+++ b/tests/test_service_framework.py
@@ -1,6 +1,7 @@
+import time
 from contextlib import contextmanager
 from queue import Queue
-from threading import Timer
+from threading import Event, Thread, Timer
 from types import SimpleNamespace
 
 import pytest
@@ -258,6 +259,53 @@ def test_service_start_failure_logging_suppresses_duplicate_tracebacks(monkeypat
         "DummyService: Failed to start worker: No printer IP found. Retrying in 1 second. (seen 5 times)",
     )
     assert len(records) == 3
+
+
+def test_concurrent_restart_leaves_service_running():
+    """Regression: two overlapping restart() calls must not leave the service
+    stopped. Without serialization, the second caller snapshots `wanted` while
+    the first caller's stop() is in flight (stale False), then its own
+    unconditional stop() lands after the first caller's start() — genuinely
+    stopping the service — and the stale snapshot skips the restart."""
+    svc = DummyService()
+    orig_stop = svc.stop
+    first_stop_done = Event()
+
+    def instrumented_stop():
+        if first_stop_done.is_set():
+            # Second restart's stop(): wait until the first restart has brought
+            # the service back up, forcing the racy interleaving deterministically.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if svc.state == RunState.Running and svc.wanted:
+                    break
+                time.sleep(0.01)
+        orig_stop()
+        first_stop_done.set()
+
+    try:
+        svc.start()
+        svc.await_ready()
+        svc.stop = instrumented_stop
+
+        def second_restart():
+            first_stop_done.wait(timeout=5.0)
+            svc.restart()
+
+        thread_a = Thread(target=svc.restart, daemon=True)
+        thread_b = Thread(target=second_restart, daemon=True)
+        thread_a.start()
+        thread_b.start()
+        thread_a.join(timeout=15.0)
+        thread_b.join(timeout=15.0)
+
+        assert not thread_a.is_alive()
+        assert not thread_b.is_alive()
+        assert svc.wanted is True
+        assert svc.state == RunState.Running
+    finally:
+        svc.stop = orig_stop
+        svc.shutdown()
 
 
 def test_service_restart_signal_default_delay():

--- a/tests/test_service_recovery_paths.py
+++ b/tests/test_service_recovery_paths.py
@@ -635,3 +635,135 @@ def test_pppp_worker_stop_safe_without_api():
     # Simulate state after a failed worker_start (no _api attribute)
     assert not hasattr(svc, "_api")
     svc.worker_stop()  # should not raise
+
+
+def test_force_close_api_sends_close_packet_when_connected():
+    """_force_close_api must notify the printer with a PktClose when the api
+    is Connected, so the printer releases its single PPPP session slot right
+    away instead of waiting out its own keepalive/timeout. This must stay a
+    best-effort, non-blocking raw UDP send (AnkerPPPPBaseApi.send()), not the
+    ack-waiting send_xzyh()/send_aabb() path, so it can't reintroduce the
+    freeze-hang this code used to guard against."""
+    from libflagship.pppp import PktClose
+    from web.service.pppp import PPPPService
+
+    sent = []
+
+    class FakeSock:
+        def shutdown(self, how):
+            pass
+
+        def close(self):
+            sent.append("sock_closed")
+
+    fake_api = SimpleNamespace(
+        state=PPPPState.Connected,
+        sock=FakeSock(),
+        send=lambda pkt: sent.append(pkt),
+    )
+
+    svc = PPPPService.__new__(PPPPService)
+    svc._api = fake_api
+
+    svc._force_close_api()
+
+    assert any(isinstance(item, PktClose) for item in sent)
+    assert "sock_closed" in sent
+    assert not hasattr(svc, "_api")
+    assert fake_api.state == PPPPState.Disconnected
+
+
+def test_force_close_api_skips_close_packet_when_not_connected():
+    """When the api is already Disconnected (e.g. mid freeze-recovery, the
+    exact scenario the original 'never send close' comment was protecting
+    against), _force_close_api must not attempt a send — sending would trip
+    AnkerPPPPBaseApi.send()'s own ConnectionError guard for Idle/Disconnected
+    states — and must still tear the socket down cleanly without raising."""
+    from web.service.pppp import PPPPService
+
+    sent = []
+
+    class FakeSock:
+        def shutdown(self, how):
+            pass
+
+        def close(self):
+            sent.append("sock_closed")
+
+    def _unexpected_send(pkt):
+        raise AssertionError("send() must not be called when api is not Connected")
+
+    fake_api = SimpleNamespace(
+        state=PPPPState.Disconnected,
+        sock=FakeSock(),
+        send=_unexpected_send,
+    )
+
+    svc = PPPPService.__new__(PPPPService)
+    svc._api = fake_api
+
+    svc._force_close_api()  # should not raise
+
+    assert "sock_closed" in sent
+    assert not hasattr(svc, "_api")
+
+
+def test_force_close_api_send_failure_does_not_block_socket_teardown():
+    """A raised exception from api.send() (e.g. a transient socket error)
+    must not prevent the unconditional socket teardown that follows — that
+    teardown is the real safety net, the close-packet send is only a
+    best-effort optimization."""
+    from web.service.pppp import PPPPService
+
+    sent = []
+
+    class FakeSock:
+        def shutdown(self, how):
+            pass
+
+        def close(self):
+            sent.append("sock_closed")
+
+    def _raising_send(pkt):
+        raise OSError("network is unreachable")
+
+    fake_api = SimpleNamespace(
+        state=PPPPState.Connected,
+        sock=FakeSock(),
+        send=_raising_send,
+    )
+
+    svc = PPPPService.__new__(PPPPService)
+    svc._api = fake_api
+
+    svc._force_close_api()  # should not raise despite send() failing
+
+    assert "sock_closed" in sent
+    assert not hasattr(svc, "_api")
+
+
+def test_reserve_session_waits_full_stop_timeout_before_yielding():
+    """reserve_session must give the shared service enough time to actually
+    stop (>= 15s wait) before the file-transfer path connects — an actively
+    streaming video session can take longer than 5s to release its hold."""
+    from web.service.pppp import reserve_session
+
+    events = []
+    fake_svc = SimpleNamespace(
+        wanted=True,
+        stop=lambda: events.append(("stop", None)),
+        await_stopped=lambda timeout=None: events.append(("await_stopped", timeout)),
+        start=lambda: events.append(("start", None)),
+    )
+
+    old_svc = app.svc
+    app.svc = SimpleNamespace(svcs={"pppp": fake_svc})
+    try:
+        with reserve_session(printer_index=0):
+            events.append(("yield", None))
+    finally:
+        app.svc = old_svc
+
+    assert [name for name, _ in events] == ["stop", "await_stopped", "yield", "start"]
+    wait_timeout = dict(events)["await_stopped"]
+    assert wait_timeout is not None and wait_timeout >= 15.0

--- a/tests/test_settings_and_notifications_api.py
+++ b/tests/test_settings_and_notifications_api.py
@@ -169,6 +169,49 @@ def test_notifications_settings_get_update_and_test(monkeypatch):
     assert created_configs and created_configs[0]["server_url"] == "https://notify.example"
 
 
+def test_notifications_test_rejects_malformed_nested_fields(monkeypatch):
+    client = app.test_client()
+    old, old_svc, _cfg, _mqtt = _install_app_state()
+
+    posts = []
+    monkeypatch.setattr(
+        "web.AppriseClient._post",
+        lambda self, title, body, attachments=None: posts.append((title, body)) or (True, "sent"),
+    )
+
+    try:
+        tested = client.post(
+            "/api/notifications/test",
+            json={"apprise": {"events": "not-a-dict", "progress": "also-not-a-dict"}},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+    finally:
+        _restore_app_state(old, old_svc)
+
+    assert tested.status_code != 500
+    assert tested.get_json() is not None
+    assert tested.status_code == 200
+    assert posts
+
+
+def test_notifications_settings_update_normalizes_malformed_nested_fields():
+    client = app.test_client()
+    old, old_svc, cfg, _mqtt = _install_app_state()
+
+    try:
+        updated = client.post(
+            "/api/notifications/settings",
+            json={"apprise": {"events": "not-a-dict", "progress": "also-not-a-dict"}},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+    finally:
+        _restore_app_state(old, old_svc)
+
+    assert updated.status_code == 200
+    assert isinstance(cfg.notifications["apprise"]["events"], dict)
+    assert isinstance(cfg.notifications["apprise"]["progress"], dict)
+
+
 def test_timelapse_and_mqtt_settings_endpoints_reload_services():
     client = app.test_client()
     reload_calls = []
@@ -207,6 +250,31 @@ def test_timelapse_and_mqtt_settings_endpoints_reload_services():
     assert reload_calls[1][0] == "ha"
     assert hasattr(reload_calls[0][1], "open")
     assert hasattr(reload_calls[1][1], "modify")
+
+
+def test_mqtt_settings_rejects_non_integer_port():
+    client = app.test_client()
+    old, old_svc, cfg, _mqtt = _install_app_state()
+    original_port = cfg.home_assistant["mqtt_port"]
+
+    try:
+        bad = client.post(
+            "/api/settings/mqtt",
+            json={"home_assistant": {"mqtt_port": "not-a-number"}},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+        out_of_range = client.post(
+            "/api/settings/mqtt",
+            json={"home_assistant": {"mqtt_port": 70000}},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+    finally:
+        _restore_app_state(old, old_svc)
+
+    assert bad.status_code == 400
+    assert "mqtt_port" in bad.get_json()["error"]
+    assert out_of_range.status_code == 400
+    assert cfg.home_assistant["mqtt_port"] == original_port
 
 
 def test_camera_settings_endpoints_persist_per_printer():
@@ -397,8 +465,47 @@ def test_filament_service_settings_endpoints_persist_manual_and_legacy_modes():
     assert cfg.filament_service["swap_unload_length_mm"] == 55
     assert cfg.filament_service["swap_load_length_mm"] == 65
     assert cfg.filament_service["swap_home_pause_s"] == 42
-    assert cfg.filament_service["manual_swap_preheat_temp_c"] == 300
-    assert clamped.get_json()["filament_service"]["manual_swap_preheat_temp_c"] == 300
+    assert cfg.filament_service["manual_swap_preheat_temp_c"] == 260
+    assert clamped.get_json()["filament_service"]["manual_swap_preheat_temp_c"] == 260
+
+
+def test_filament_service_settings_route_reads_and_writes_all_metal_hotend():
+    client = app.test_client()
+    cfg = _base_config()
+    cfg.printers.append(_printer(sn="SN2", name="Printer 2"))
+    old, old_svc, cfg, _mqtt = _install_app_state(cfg=cfg)
+
+    try:
+        before = client.get(
+            "/api/settings/filament-service?printer_index=0",
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+        updated = client.post(
+            "/api/settings/filament-service?printer_index=0",
+            json={"filament_service": {"all_metal_hotend": True}},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+        first_printer = client.get(
+            "/api/settings/filament-service?printer_index=0",
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+        second_printer = client.get(
+            "/api/settings/filament-service?printer_index=1",
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+    finally:
+        _restore_app_state(old, old_svc)
+
+    assert before.status_code == 200
+    assert before.get_json()["filament_service"]["all_metal_hotend"] is False
+    assert updated.status_code == 200
+    assert updated.get_json()["filament_service"]["all_metal_hotend"] is True
+    assert first_printer.status_code == 200
+    assert first_printer.get_json()["filament_service"]["all_metal_hotend"] is True
+    assert second_printer.status_code == 200
+    assert second_printer.get_json()["filament_service"]["all_metal_hotend"] is False
+    assert cfg.filament_service["per_printer"]["SN1"]["all_metal_hotend"] is True
+    assert "SN2" not in cfg.filament_service["per_printer"]
 
 
 def test_filament_service_advanced_command_config_creates_and_opens(tmp_path, monkeypatch):

--- a/tests/test_timelapse_service.py
+++ b/tests/test_timelapse_service.py
@@ -642,6 +642,7 @@ def test_timelapse_take_snapshot_retries_and_restores_light(monkeypatch, tmp_pat
     assert len(captures) == 1
     assert captures[0]["ffmpeg_path"] == "resolved-ffmpeg"
     assert captures[0]["api_key"] == "secret-key"
+    assert captures[0]["extra_headers"] == "X-Api-Key: secret-key\r\n"
     assert captures[0]["for_timelapse"] is True
     assert captures[0]["camera_settings"]["effective_source"] == "printer"
     assert light_calls == [True, False]
@@ -1033,3 +1034,139 @@ def test_timelapse_runtime_state_reports_recovery(tmp_path):
     cleared = svc.get_runtime_state()
     assert cleared["recovering"] is False
     assert cleared["detail"] is None
+
+
+def test_start_capture_finalizes_stale_current_dir_for_different_filename(monkeypatch, tmp_path):
+    """A capture left open for job_a (finish/fail never called, simulating a
+    missed MQTT event across a reconnect) must be archived, not silently
+    overwritten, when start_capture() is called for a genuinely new job_b."""
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    stale_dir = str(tmp_path / _IN_PROGRESS_SUBDIR / "stale_job_a")
+    os.makedirs(stale_dir, exist_ok=True)
+    svc._current_dir = stale_dir
+    svc._current_filename = "job_a.gcode"
+    svc._frame_count = 1
+
+    class FakeThread:
+        def __init__(self, target=None, daemon=None, name=None):
+            pass
+
+        def start(self):
+            pass
+
+    finalized = []
+    monkeypatch.setattr("web.service.timelapse._resolve_ffmpeg_path", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(
+        TimelapseService,
+        "_resolve_capture_camera",
+        lambda self: {"effective_source": web.camera.CAMERA_SOURCE_PRINTER},
+    )
+    monkeypatch.setattr(TimelapseService, "_enable_video_for_timelapse", lambda self: None)
+    monkeypatch.setattr(TimelapseService, "_stop_capture_thread", lambda self: None)
+    monkeypatch.setattr("web.service.timelapse.threading.Thread", FakeThread)
+    monkeypatch.setattr(
+        svc, "_finalize_now",
+        lambda d, f, c, **kw: finalized.append((d, f, c, kw.get("suffix"))),
+    )
+
+    svc.start_capture("job_b.gcode")
+
+    assert finalized == [(stale_dir, "job_a.gcode", 1, "_recovered")]
+    assert svc._current_filename == "job_b.gcode"
+    assert svc._current_dir != stale_dir
+    assert svc._frame_count == 0
+
+
+def test_start_capture_discards_stale_current_dir_without_frames(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    stale_dir = str(tmp_path / _IN_PROGRESS_SUBDIR / "stale_empty")
+    os.makedirs(stale_dir, exist_ok=True)
+    svc._current_dir = stale_dir
+    svc._current_filename = "job_a.gcode"
+    svc._frame_count = 0
+
+    class FakeThread:
+        def __init__(self, target=None, daemon=None, name=None):
+            pass
+
+        def start(self):
+            pass
+
+    finalized = []
+    monkeypatch.setattr("web.service.timelapse._resolve_ffmpeg_path", lambda: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(
+        TimelapseService,
+        "_resolve_capture_camera",
+        lambda self: {"effective_source": web.camera.CAMERA_SOURCE_PRINTER},
+    )
+    monkeypatch.setattr(TimelapseService, "_enable_video_for_timelapse", lambda self: None)
+    monkeypatch.setattr(TimelapseService, "_stop_capture_thread", lambda self: None)
+    monkeypatch.setattr("web.service.timelapse.threading.Thread", FakeThread)
+    monkeypatch.setattr(
+        svc, "_finalize_now",
+        lambda d, f, c, **kw: finalized.append((d, f, c, kw.get("suffix"))),
+    )
+
+    svc.start_capture("job_b.gcode")
+
+    assert finalized == []
+    assert not os.path.isdir(stale_dir)
+    assert svc._current_filename == "job_b.gcode"
+
+
+def test_handle_mqtt_service_stopped_restores_light_when_capture_active(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    svc._current_dir = str(tmp_path / _IN_PROGRESS_SUBDIR / "active")
+    svc._current_filename = "cube.gcode"
+    svc._frame_count = 3
+    svc._light_mode = "session"
+    svc._light_was_on = False
+
+    light_calls = []
+    monkeypatch.setattr(web, "get_video_service", lambda idx: None)
+    monkeypatch.setattr(web, "set_printer_light_state", lambda state, idx: light_calls.append((state, idx)))
+
+    svc.handle_mqtt_service_stopped()
+
+    assert light_calls == [(False, 0)]
+    assert svc._light_was_on is None
+
+
+def test_handle_mqtt_service_stopped_noop_without_active_capture(monkeypatch, tmp_path):
+    """Regression guard: with no capture active, the light must NOT be touched —
+    _disable_video_for_timelapse() would force it off (default restore=False)."""
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+    assert svc._current_dir is None
+    svc._light_mode = "session"
+
+    light_calls = []
+    monkeypatch.setattr(web, "get_video_service", lambda idx: None)
+    monkeypatch.setattr(web, "set_printer_light_state", lambda state, idx: light_calls.append((state, idx)))
+
+    svc.handle_mqtt_service_stopped()
+
+    assert light_calls == []
+
+
+def test_prune_passes_hold_dedicated_prune_lock(monkeypatch, tmp_path):
+    cfg = FakeConfigManager(tmp_path)
+    svc = TimelapseService(cfg, captures_dir=tmp_path)
+
+    locked_during = []
+    real_listdir = os.listdir
+
+    def spy_listdir(path):
+        locked_during.append(svc._prune_lock.locked())
+        return real_listdir(path)
+
+    monkeypatch.setattr("web.service.timelapse.os.listdir", spy_listdir)
+
+    svc._prune_old_videos()
+    svc._prune_old_snapshot_collections()
+
+    assert locked_during
+    assert all(locked_during)

--- a/tests/test_web_config_and_filetransfer.py
+++ b/tests/test_web_config_and_filetransfer.py
@@ -65,6 +65,15 @@ def test_config_import_handles_invalid_login_and_api_errors(monkeypatch):
         config_import(valid_login, object())
 
 
+def test_config_import_rejects_oversized_login_file():
+    from web.config import MAX_LOGIN_FILE_BYTES
+
+    oversized = SimpleNamespace(stream=io.BytesIO(b"a" * (MAX_LOGIN_FILE_BYTES + 1)))
+
+    with pytest.raises(ConfigImportError, match="too large"):
+        config_import(oversized, object())
+
+
 def test_config_login_handles_captcha_and_success(monkeypatch):
     imported = []
     fetch_calls = []

--- a/tests/test_web_helpers_and_api.py
+++ b/tests/test_web_helpers_and_api.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from cli.model import Account, Config, Printer
 from libflagship import resolve_root_dir
 from web import _AccessLogNoiseFilter, _ConsoleLogBuffer, _PrinterAlertBuffer
@@ -18,11 +20,13 @@ from web import (
     _filament_service_length,
     _filament_service_temp,
     _format_signed_mm,
+    _hotend_nozzle_max_c,
     _probe_printer_storage_files,
     _parse_z_offset_mm,
     _resolve_apprise,
     _safe_same_site_redirect_target,
     _serialize_z_offset_state,
+    _set_printer_z_offset,
     _z_offset_mm_to_steps,
     _z_offset_steps_to_mm,
     app,
@@ -96,6 +100,37 @@ def test_filament_and_z_offset_helpers():
     assert _format_signed_mm(-0.12) == "-0.12"
     assert _parse_z_offset_mm({"offset": "0.456"}, "offset") == 0.46
     assert _serialize_z_offset_state({"steps": 25, "source": "mqtt"})["display"] == "0.25 mm"
+
+
+def test_hotend_nozzle_max_defaults_to_standard():
+    cfg = Config(
+        account=Account(auth_token="token", region="eu", user_id="user-1", email="user@example.com"),
+        printers=[_printer("SN1", "Printer")],
+    )
+
+    assert _hotend_nozzle_max_c(cfg, printer_index=0) == 260
+
+
+def test_hotend_nozzle_max_returns_all_metal_when_enabled():
+    cfg = Config(
+        account=Account(auth_token="token", region="eu", user_id="user-1", email="user@example.com"),
+        printers=[_printer("SN1", "Printer")],
+    )
+    cfg.filament_service["per_printer"]["SN1"] = {"all_metal_hotend": True}
+
+    assert _hotend_nozzle_max_c(cfg, printer_index=0) == 300
+    # Unresolvable printer index falls back to the safer standard ceiling.
+    assert _hotend_nozzle_max_c(cfg, printer_index=5) == 260
+
+
+def test_set_printer_z_offset_rejects_out_of_range_targets():
+    # Bound check must fire before any MQTT interaction, so a bare
+    # namespace without refresh/send methods is enough here.
+    mqtt = SimpleNamespace()
+    with pytest.raises(ValueError):
+        _set_printer_z_offset(mqtt, 50.0)
+    with pytest.raises(ValueError):
+        _set_printer_z_offset(mqtt, -50.0)
 
 
 def test_resolve_apprise_drops_progress_max_value():
@@ -443,6 +478,120 @@ def test_api_console_logs_returns_recent_entries(monkeypatch):
     assert response.status_code == 200
     assert response.get_json()["entries"] == [{"id": 42, "text": "[*] printer ready"}]
     assert calls == [(25, 10)]
+
+
+def test_switch_active_printer_locked_by_env_var_returns_403():
+    cfg = Config(
+        account=Account(auth_token="token", region="eu", user_id="user-1", email="user@example.com"),
+        printers=[_printer("SN1", "Printer One"), _printer("SN2", "Printer Two")],
+    )
+    manager = FakeConfigManager(cfg)
+    client = app.test_client()
+
+    old_values = {
+        "config": app.config.get("config"),
+        "printer_index": app.config.get("printer_index"),
+        "printer_index_locked": app.config.get("printer_index_locked"),
+        "login": app.config.get("login"),
+        "api_key": app.config.get("api_key"),
+    }
+    app.config["config"] = manager
+    app.config["printer_index"] = 0
+    app.config["printer_index_locked"] = True
+    app.config["login"] = True
+    app.config["api_key"] = "secret-key-123456"
+
+    try:
+        resp = client.post(
+            "/api/printers/active",
+            json={"index": 1},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+        assert resp.status_code == 403
+        assert app.config["printer_index"] == 0
+        assert cfg.active_printer_index != 1
+    finally:
+        for key, value in old_values.items():
+            app.config[key] = value
+
+
+def test_switch_active_printer_to_unsupported_model_returns_403():
+    cfg = Config(
+        account=Account(auth_token="token", region="eu", user_id="user-1", email="user@example.com"),
+        printers=[_printer("SN1", "Printer One"), _printer("SN2", "UV Printer", model="V8260")],
+    )
+    manager = FakeConfigManager(cfg)
+    services = FakeServices()
+    client = app.test_client()
+
+    old_values = {
+        "config": app.config.get("config"),
+        "printer_index": app.config.get("printer_index"),
+        "printer_index_locked": app.config.get("printer_index_locked"),
+        "video_supported": app.config.get("video_supported"),
+        "login": app.config.get("login"),
+        "unsupported_device": app.config.get("unsupported_device"),
+        "api_key": app.config.get("api_key"),
+    }
+    old_svc = app.svc
+    app.config["config"] = manager
+    app.config["printer_index"] = 0
+    app.config["printer_index_locked"] = False
+    app.config["video_supported"] = True
+    app.config["login"] = True
+    app.config["unsupported_device"] = False
+    app.config["api_key"] = "secret-key-123456"
+    app.svc = services
+
+    try:
+        resp = client.post(
+            "/api/printers/active",
+            json={"index": 1},
+            headers={"X-Api-Key": "secret-key-123456"},
+        )
+        assert resp.status_code == 403
+        assert app.config["printer_index"] == 0
+        assert cfg.active_printer_index != 1
+    finally:
+        app.svc = old_svc
+        for key, value in old_values.items():
+            app.config[key] = value
+
+
+def test_unsupported_device_gate_is_scoped_to_requested_printer_index():
+    """Regression: /api/printer/* must gate on the printer_index a request
+    targets, not just whichever printer is globally "active". A blocked
+    device (e.g. a eufyMake E1 mixed into the same account) must not shadow
+    requests for a different, fully-supported printer."""
+    cfg = Config(
+        account=Account(auth_token="token", region="eu", user_id="user-1", email="user@example.com"),
+        printers=[_printer("SN1", "UV Printer", model="V8260"), _printer("SN2", "Printer Two")],
+    )
+    manager = FakeConfigManager(cfg)
+    client = app.test_client()
+
+    old_values = {
+        "config": app.config.get("config"),
+        "printer_index": app.config.get("printer_index"),
+        "login": app.config.get("login"),
+        "unsupported_device": app.config.get("unsupported_device"),
+        "api_key": app.config.get("api_key"),
+    }
+    app.config["config"] = manager
+    app.config["printer_index"] = 0  # active printer is the unsupported one
+    app.config["login"] = True
+    app.config["unsupported_device"] = True
+    app.config["api_key"] = None
+
+    try:
+        blocked = client.get("/api/printer/alerts")
+        allowed = client.get("/api/printer/alerts?printer_index=1")
+
+        assert blocked.status_code == 503
+        assert allowed.status_code == 200
+    finally:
+        for key, value in old_values.items():
+            app.config[key] = value
 
 
 def test_api_printers_and_switch_active_printer(monkeypatch):

--- a/tests/test_websockets_and_debug.py
+++ b/tests/test_websockets_and_debug.py
@@ -271,6 +271,31 @@ def test_ctrl_light_uses_active_pppp_without_videoqueue():
     ]
 
 
+def test_ctrl_survives_unexpected_error_and_keeps_processing():
+    light_calls = []
+    videoqueue = SimpleNamespace(
+        saved_video_profile_id="hd",
+        api_light_state=lambda enabled: light_calls.append(enabled),
+    )
+    services = FakeServices(
+        svcs={"videoqueue": videoqueue},
+        refs={"videoqueue": 0},
+    )
+    old_values, old_svc = _install_app_state(web_module, svc=services)
+
+    try:
+        ctrl_sock = FakeSock(receives=[
+            RuntimeError("boom"),
+            json.dumps({"light": True}),
+            None,
+        ])
+        _ws_handler(web_module, "ctrl")(ctrl_sock)
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
+
+    assert light_calls == [True]
+
+
 def test_nonzero_printer_services_do_not_fallback_to_legacy_instances():
     viewer_events = []
     printer_two_video = SimpleNamespace(
@@ -329,6 +354,66 @@ def test_nonzero_printer_services_do_not_fallback_to_legacy_instances():
     assert resolved_video is printer_two_video
     assert resolved_video_name == web_module.video_service_name(1)
     assert resolved_pppp_name == web_module.pppp_service_name(1)
+
+
+def test_ws_video_uses_requested_printer_camera_support_not_active_printer():
+    """Regression: /ws/video must gate on the REQUESTED printer_index's camera
+    support, not app.config['video_supported'], which only reflects whichever
+    printer is globally active."""
+    cfg = _base_config()
+    cfg.printers[0].model = "V8110"  # active printer has no camera
+    cfg.printers[1].model = "V8111"  # requested printer has a camera
+
+    printer_two_video = SimpleNamespace(
+        saved_video_profile_id="hd",
+        viewer_connected=lambda: None,
+        viewer_disconnected=lambda: None,
+    )
+    services = FakeServices(
+        streams={web_module.video_service_name(1): [SimpleNamespace(data=b"printer-two-frame")]},
+        borrowed={web_module.video_service_name(1): printer_two_video},
+        svcs={web_module.video_service_name(1): printer_two_video},
+        refs={web_module.video_service_name(1): 0},
+    )
+    old_values, old_svc = _install_app_state(
+        web_module, svc=services, config=FakeConfigManager(cfg),
+        printer_index=0, video_supported=False,
+    )
+    try:
+        with web_module.app.test_request_context("/ws/video?printer_index=1"):
+            sock = FakeSock(close_after_sends=1)
+            _ws_handler(web_module, "video")(sock)
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
+
+    assert sock.sent == [b"printer-two-frame"]
+
+
+def test_ws_mqtt_uses_requested_printer_unsupported_status_not_active_printer():
+    """Regression: /ws/mqtt (and /ws/pppp-state, /ws/ctrl) must gate on
+    whether the REQUESTED printer_index is an unsupported model, not
+    app.config['unsupported_device'], which only reflects whichever printer
+    is globally active."""
+    cfg = _base_config()
+    cfg.printers[0].model = "V8260"  # active printer is unsupported (blocked)
+    cfg.printers[1].model = "V8111"  # requested printer is fully supported
+
+    services = FakeServices(
+        streams={web_module.mqtt_service_name(1): [{"hello": "mqtt-1"}]},
+        svcs={web_module.mqtt_service_name(1): SimpleNamespace(name="mqtt-1")},
+    )
+    old_values, old_svc = _install_app_state(
+        web_module, svc=services, config=FakeConfigManager(cfg),
+        printer_index=0, unsupported_device=True,
+    )
+    try:
+        with web_module.app.test_request_context("/ws/mqtt?printer_index=1"):
+            sock = FakeSock(close_after_sends=1)
+            _ws_handler(web_module, "mqtt")(sock)
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
+
+    assert sock.sent == [json.dumps({"hello": "mqtt-1"})]
 
 
 def test_pppp_probe_helper_and_state_websocket_emit_status(monkeypatch):
@@ -548,6 +633,144 @@ def test_dev_debug_routes_register_and_dispatch(monkeypatch):
     assert restart_calls == [True]
 
 
+def test_dev_debug_bed_leveling_blocked_while_printing(monkeypatch):
+    monkeypatch.setenv("ANKERCTL_DEV_MODE", "true")
+    importlib.reload(web_module)
+
+    try:
+        app = web_module.app
+        client = app.test_client()
+        mqtt_name = web_module.mqtt_service_name(0)
+        app.svc = SimpleNamespace(
+            svcs={mqtt_name: SimpleNamespace(is_printing=True)},
+            refs={mqtt_name: 1},
+        )
+        app.config["api_key"] = API_KEY
+        app.config["login"] = True
+        app.config["config"] = FakeConfigManager(_base_config())
+        app.config["printer_index"] = 0
+
+        response = client.get("/api/debug/bed-leveling", headers={"X-Api-Key": API_KEY})
+    finally:
+        monkeypatch.setenv("ANKERCTL_DEV_MODE", "false")
+        importlib.reload(web_module)
+
+    assert response.status_code == 409
+    assert "while printing" in response.get_json()["error"]
+
+
+def test_debug_printer_report_blocked_while_printing(monkeypatch):
+    monkeypatch.setenv("ANKERCTL_DEV_MODE", "true")
+    importlib.reload(web_module)
+
+    try:
+        app = web_module.app
+        client = app.test_client()
+        report_calls = []
+        mqtt_name = web_module.mqtt_service_name(0)
+        app.svc = SimpleNamespace(
+            svcs={mqtt_name: SimpleNamespace(is_printing=True)},
+            refs={mqtt_name: 1},
+        )
+        app.config["api_key"] = API_KEY
+        app.config["login"] = True
+        app.config["config"] = FakeConfigManager(_base_config())
+        app.config["printer_index"] = 0
+
+        monkeypatch.setattr(
+            "web._read_printer_report",
+            lambda name, printer_index=None, client=None: report_calls.append(name) or {},
+        )
+
+        response = client.get(
+            "/api/debug/printer-report/settings", headers={"X-Api-Key": API_KEY}
+        )
+    finally:
+        monkeypatch.setenv("ANKERCTL_DEV_MODE", "false")
+        importlib.reload(web_module)
+
+    assert response.status_code == 409
+    assert "while printing" in response.get_json()["error"]
+    assert report_calls == []
+
+
+def test_debug_simulate_lifecycle_blocked_while_printing(monkeypatch):
+    monkeypatch.setenv("ANKERCTL_DEV_MODE", "true")
+    importlib.reload(web_module)
+
+    try:
+        app = web_module.app
+        client = app.test_client()
+        simulated = []
+        mqtt_name = web_module.mqtt_service_name(0)
+        mqtt = SimpleNamespace(
+            is_printing=True,
+            simulate_event=lambda event_type, payload: simulated.append((event_type, payload)),
+        )
+        app.svc = SimpleNamespace(
+            borrow=lambda name: _borrow_debug(mqtt if name == mqtt_name else None),
+            svcs={mqtt_name: mqtt},
+            refs={mqtt_name: 1},
+        )
+        app.config["api_key"] = API_KEY
+        app.config["login"] = True
+        app.config["config"] = FakeConfigManager(_base_config())
+        app.config["printer_index"] = 0
+
+        blocked = client.post(
+            "/api/debug/simulate",
+            json={"type": "finish", "payload": {"filename": "cube.gcode"}},
+            headers={"X-Api-Key": API_KEY},
+        )
+        allowed = client.post(
+            "/api/debug/simulate",
+            json={"type": "progress", "payload": {"progress": 42}},
+            headers={"X-Api-Key": API_KEY},
+        )
+    finally:
+        monkeypatch.setenv("ANKERCTL_DEV_MODE", "false")
+        importlib.reload(web_module)
+
+    assert blocked.status_code == 409
+    assert "real print" in blocked.get_json()["error"]
+    assert allowed.status_code == 200
+    assert simulated == [("progress", {"progress": 42})]
+
+
+def test_debug_state_uses_requested_printer_index(monkeypatch):
+    monkeypatch.setenv("ANKERCTL_DEV_MODE", "true")
+    importlib.reload(web_module)
+
+    try:
+        app = web_module.app
+        client = app.test_client()
+        mqtt_zero = SimpleNamespace(get_state=lambda: {"printer": 0})
+        mqtt_one = SimpleNamespace(get_state=lambda: {"printer": 1})
+        borrowed = {
+            web_module.mqtt_service_name(0): mqtt_zero,
+            web_module.mqtt_service_name(1): mqtt_one,
+        }
+        app.svc = SimpleNamespace(
+            borrow=lambda name: _borrow_debug(borrowed.get(name)),
+            svcs={name: svc for name, svc in borrowed.items()},
+            refs={name: 1 for name in borrowed},
+        )
+        app.config["api_key"] = API_KEY
+        app.config["login"] = True
+        app.config["config"] = FakeConfigManager(_base_config())
+        app.config["printer_index"] = 0
+
+        response = client.get(
+            "/api/debug/state?printer_index=1", headers={"X-Api-Key": API_KEY}
+        )
+    finally:
+        monkeypatch.setenv("ANKERCTL_DEV_MODE", "false")
+        importlib.reload(web_module)
+
+    assert response.status_code == 200
+    assert response.get_json() == {"printer": 1}
+
+
 def test_ws_ctrl_rejects_without_api_key():
     """WebSocket handlers must reject unauthenticated connections when
     an API key is configured, sending {"error": "unauthorized"} before closing."""
@@ -597,6 +820,65 @@ def test_ws_ctrl_allows_with_session():
     # Should have received ankerctl handshake + video_profile + processed light command
     assert any('"ankerctl"' in s for s in sock.sent)
     assert light_calls == [True]
+
+
+def test_all_ws_routes_reject_without_api_key():
+    """Every websocket route must call _validate_ws_auth() and reject a
+    connection when an API key is configured but the caller has no session
+    cookie or X-Api-Key header.
+
+    Flask's before_request middleware runs for websocket routes but does not
+    block unauthenticated GETs on them, so each handler calls
+    _validate_ws_auth() inline. A route that omits this call is a full,
+    silent auth bypass — this test exists to catch exactly that regression
+    across all five ws routes, not just /ws/ctrl.
+    """
+    services = FakeServices()
+    old_values, old_svc = _install_app_state(
+        web_module, svc=services, api_key=API_KEY
+    )
+
+    try:
+        with web_module.app.test_request_context():
+            for name in ("mqtt", "video", "pppp_state", "upload", "ctrl"):
+                sock = FakeSock()
+                _ws_handler(web_module, name)(sock)
+                assert len(sock.sent) == 1, f"ws route '{name}' sent {len(sock.sent)} messages, expected 1 rejection"
+                msg = json.loads(sock.sent[0])
+                assert msg == {"error": "unauthorized"}, f"ws route '{name}' did not reject an unauthenticated connection"
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
+
+
+def test_sock_server_options_configures_ping_interval():
+    """Regression guard: without a ping/pong keepalive, half-open clients
+    (laptop sleep, network partition) leave zombie server threads and
+    service queue taps alive indefinitely."""
+    assert web_module.app.config.get("SOCK_SERVER_OPTIONS", {}).get("ping_interval")
+
+
+def test_ws_route_apikey_query_param_does_not_redirect():
+    """A WS handshake with a valid ?apikey= must not get a redirect —
+    the WebSocket handshake never follows redirects, so this would
+    silently break any programmatic client using the documented
+    apikey-query-param pattern."""
+    services = FakeServices()
+    old_values, old_svc = _install_app_state(web_module, svc=services, api_key=API_KEY)
+    try:
+        resp = web_module.app.test_client().get("/ws/mqtt", query_string={"apikey": API_KEY})
+        assert resp.status_code != 302
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
+
+
+def test_validate_ws_auth_accepts_apikey_query_param():
+    services = FakeServices()
+    old_values, old_svc = _install_app_state(web_module, svc=services, api_key=API_KEY)
+    try:
+        with web_module.app.test_request_context("/ws/mqtt?apikey=" + API_KEY):
+            assert web_module._validate_ws_auth(FakeSock()) is True
+    finally:
+        _restore_app_state(web_module, old_values, old_svc)
 
 
 @contextmanager

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -292,7 +292,9 @@ if not app.secret_key:
 app.svc = ServiceManager()
 app.filament_swap_lock = threading.Lock()
 app.filament_swap_state = {}
+app.filament_swap_threads = {}
 app.pppp_probe_lock = threading.Lock()
+app.printer_switch_lock = threading.Lock()
 
 
 def _default_pppp_probe_state():
@@ -453,6 +455,32 @@ def _printer_video_supported(cfg=None, printer_index=None):
     return bool(camera_settings.get("printer_supported"))
 
 
+def _printer_is_unsupported(cfg=None, printer_index=None):
+    """Whether the printer at printer_index (default: active) is an unsupported model.
+
+    Scoped per-printer so a blocked device (e.g. a eufyMake E1 mixed into the same
+    Anker account) doesn't shadow requests for a different, fully-supported printer.
+    """
+    active_index = app.config.get("printer_index", 0)
+    if cfg is None and (printer_index is None or printer_index == active_index):
+        override = app.config.get("unsupported_device")
+        if override is not None:
+            return bool(override)
+
+    if cfg is None:
+        config = app.config.get("config")
+        if not config:
+            return False
+        with config.open() as opened_cfg:
+            return _printer_is_unsupported(opened_cfg, printer_index=printer_index)
+
+    idx = _service_printer_index(printer_index)
+    printers = getattr(cfg, "printers", []) or []
+    if 0 <= idx < len(printers):
+        return printers[idx].model in UNSUPPORTED_PRINTERS
+    return False
+
+
 def _get_pppp_probe_state(printer_index=None, create=True):
     printer_index = 0 if printer_index is None else int(printer_index)
     probe = getattr(app, "pppp_probe", None)
@@ -596,6 +624,9 @@ app.record_printer_alert = _record_printer_alert
 # Resolve log directory once: honour env var, fall back to None on bare metal
 _log_dir = os.getenv("ANKERCTL_LOG_DIR") or ("/logs" if os.path.isdir("/logs") else None)
 
+# Ping/pong keepalive: without it, half-open clients (laptop sleep, network
+# partition) leave zombie WS threads and service queue taps alive indefinitely.
+app.config["SOCK_SERVER_OPTIONS"] = {"ping_interval": 25}
 sock = Sock(app)
 
 PRINTERS_WITHOUT_CAMERA = sorted(web.camera.PRINTERS_WITHOUT_CAMERA)
@@ -1072,7 +1103,7 @@ FILAMENT_SERVICE_HEAT_TOLERANCE_C = 5
 FILAMENT_SERVICE_TEMP_MAX_AGE_S = float(os.getenv("FILAMENT_SERVICE_TEMP_MAX_AGE_S", 15.0))
 FILAMENT_SERVICE_MANUAL_SWAP_DEFAULT_TEMP_C = 180
 FILAMENT_SERVICE_MANUAL_SWAP_MIN_TEMP_C = 130
-FILAMENT_SERVICE_MANUAL_SWAP_MAX_TEMP_C = 300
+FILAMENT_SWAP_CANCEL_JOIN_TIMEOUT_S = 2.0
 _FILAMENT_SWAP_RUNNING_PHASES = frozenset({
     "homing",
     "heating_unload",
@@ -1128,9 +1159,60 @@ FILAMENT_SWAP_ADVANCED_CONFIG_DEFAULT = {
 Z_OFFSET_STEP_MM = 0.01
 Z_OFFSET_REFRESH_TIMEOUT_S = 5.0
 Z_OFFSET_CONFIRM_TIMEOUT_S = 8.0
+# No documented safe range exists; +/-2mm is a conservative bound that still
+# covers any realistic first-layer correction while preventing bed crashes.
+Z_OFFSET_MIN_MM = -2.0
+Z_OFFSET_MAX_MM = 2.0
+GCODE_CONSOLE_MAX_LINES = 200
 
 
-def _filament_service_temp(profile):
+def _printer_sn(cfg, printer_index):
+    printers = getattr(cfg, "printers", None) or []
+    if not (0 <= printer_index < len(printers)):
+        return None
+    return getattr(printers[printer_index], "sn", None)
+
+
+def _hotend_all_metal_enabled(cfg, printer_index):
+    printer_sn = _printer_sn(cfg, printer_index)
+    if not printer_sn:
+        return False
+    fs_config = merge_dict_defaults(
+        getattr(cfg, "filament_service", None), cli.model.default_filament_service_config()
+    )
+    per_printer = fs_config.get("per_printer")
+    if not isinstance(per_printer, dict):
+        return False
+    entry = per_printer.get(printer_sn)
+    return bool(entry.get("all_metal_hotend")) if isinstance(entry, dict) else False
+
+
+def _hotend_nozzle_max_c(cfg=None, printer_index=None):
+    """Return the nozzle temperature ceiling for the given printer's hotend.
+
+    260C for the stock hotend, 300C if the printer's all_metal_hotend
+    per-printer setting is enabled. Falls back to the standard (lower,
+    safer) ceiling if the printer/config can't be resolved.
+    """
+    printer_index = _service_printer_index(printer_index)
+
+    def _resolve(cfg):
+        if not cfg:
+            return cli.model.HOTEND_STANDARD_NOZZLE_MAX_C
+        if _hotend_all_metal_enabled(cfg, printer_index):
+            return cli.model.HOTEND_ALL_METAL_NOZZLE_MAX_C
+        return cli.model.HOTEND_STANDARD_NOZZLE_MAX_C
+
+    if cfg is not None:
+        return _resolve(cfg)
+    config = app.config.get("config")
+    if not config:
+        return cli.model.HOTEND_STANDARD_NOZZLE_MAX_C
+    with config.open() as opened_cfg:
+        return _resolve(opened_cfg)
+
+
+def _filament_service_temp(profile, printer_index=None):
     temp = (
         profile.get("nozzle_temp_other_layer")
         or profile.get("nozzle_temp_first_layer")
@@ -1143,7 +1225,7 @@ def _filament_service_temp(profile):
         temp = 0
     if temp <= 0:
         raise ValueError("Filament profile has no usable nozzle temperature")
-    return temp
+    return max(0, min(temp, _hotend_nozzle_max_c(printer_index=printer_index)))
 
 
 def _filament_service_bool(value):
@@ -1196,10 +1278,12 @@ def _filament_service_setting_seconds(settings, key, default=FILAMENT_SERVICE_SW
         return round(default, 2)
 
 
-def _normalize_filament_service_settings(settings):
+def _normalize_filament_service_settings(settings, printer_index=None, cfg=None):
     normalized = dict(settings or {})
     normalized["allow_legacy_swap"] = _filament_service_bool(normalized.get("allow_legacy_swap"))
-    normalized["manual_swap_preheat_temp_c"] = _filament_service_manual_swap_temp(normalized)
+    normalized["manual_swap_preheat_temp_c"] = _filament_service_manual_swap_temp(
+        normalized, printer_index=printer_index, cfg=cfg
+    )
     normalized["quick_move_length_mm"] = _filament_service_setting_length(normalized, "quick_move_length_mm")
     normalized["swap_prime_length_mm"] = _filament_service_setting_length(
         normalized,
@@ -1550,6 +1634,9 @@ def _filament_swap_state_set_if_absent(state):
         printer_index = _service_printer_index(state.get("printer_index"))
         if states.get(printer_index) is not None:
             return None
+        thread = app.filament_swap_threads.get(printer_index)
+        if thread is not None and thread.is_alive():
+            return None
         state["printer_index"] = printer_index
         states[printer_index] = state
         return dict(state)
@@ -1586,9 +1673,11 @@ def _filament_swap_state_clear(token=None, printer_index=None):
         return dict(state)
 
 
-def _filament_swap_start_background(target, token):
+def _filament_swap_start_background(target, token, printer_index):
     thread = threading.Thread(target=target, args=(token,), daemon=True)
     thread.start()
+    with app.filament_swap_lock:
+        app.filament_swap_threads[_service_printer_index(printer_index)] = thread
     return thread
 
 
@@ -1802,13 +1891,13 @@ def _send_filament_service_nozzle_target(mqtt, target_temp_c, should_continue=No
     return last_target
 
 
-def _filament_service_manual_swap_temp(settings):
+def _filament_service_manual_swap_temp(settings, printer_index=None, cfg=None):
     raw_temp = settings.get("manual_swap_preheat_temp_c", FILAMENT_SERVICE_MANUAL_SWAP_DEFAULT_TEMP_C)
     try:
         temp_c = int(raw_temp)
     except (TypeError, ValueError):
         temp_c = FILAMENT_SERVICE_MANUAL_SWAP_DEFAULT_TEMP_C
-    return max(FILAMENT_SERVICE_MANUAL_SWAP_MIN_TEMP_C, min(FILAMENT_SERVICE_MANUAL_SWAP_MAX_TEMP_C, temp_c))
+    return max(FILAMENT_SERVICE_MANUAL_SWAP_MIN_TEMP_C, min(_hotend_nozzle_max_c(cfg, printer_index=printer_index), temp_c))
 
 
 def _run_legacy_swap_unload(token):
@@ -2007,6 +2096,21 @@ def _run_legacy_swap_unload(token):
             message=f"Automatic unload failed: {exc}",
             error=str(exc),
         )
+    except Exception as exc:
+        log.exception("Filament swap unload worker crashed unexpectedly")
+        _filament_swap_state_update(
+            token,
+            printer_index=printer_index,
+            phase="error",
+            message=f"Automatic unload failed: {exc}",
+            error=str(exc),
+        )
+        try:
+            with borrow_mqtt(printer_index) as mqtt:
+                if mqtt:
+                    mqtt.send_gcode(_format_filament_swap_command("cooldown_nozzle", required=True))
+        except Exception:
+            pass
 
 
 def _run_legacy_swap_load(token):
@@ -2098,6 +2202,21 @@ def _run_legacy_swap_load(token):
             message=f"Automatic load / purge failed: {exc}",
             error=str(exc),
         )
+    except Exception as exc:
+        log.exception("Filament swap load worker crashed unexpectedly")
+        _filament_swap_state_update(
+            token,
+            printer_index=printer_index,
+            phase="error",
+            message=f"Automatic load / purge failed: {exc}",
+            error=str(exc),
+        )
+        try:
+            with borrow_mqtt(printer_index) as mqtt:
+                if mqtt:
+                    mqtt.send_gcode(_format_filament_swap_command("cooldown_nozzle", required=True))
+        except Exception:
+            pass
 
 
 def _z_offset_steps_to_mm(steps):
@@ -2139,6 +2258,8 @@ def _parse_z_offset_mm(payload, key):
 
 
 def _set_printer_z_offset(mqtt, target_mm, current=None):
+    if not (Z_OFFSET_MIN_MM <= target_mm <= Z_OFFSET_MAX_MM):
+        raise ValueError(f"target_mm must be between {Z_OFFSET_MIN_MM} and {Z_OFFSET_MAX_MM} mm")
     target_steps = _z_offset_mm_to_steps(target_mm)
     if current is None:
         current = mqtt.refresh_z_offset(timeout=Z_OFFSET_REFRESH_TIMEOUT_S)
@@ -2207,11 +2328,14 @@ from web.service.filament import FilamentStore
 def _validate_ws_auth(sock):
     """Check API key auth for WebSocket routes.
 
-    Flask's before_request middleware does not run for WebSocket routes,
-    so each handler must call this explicitly.  Auth succeeds if ANY of:
+    Flask's before_request runs for WebSocket routes too, but doesn't block
+    unauthenticated GETs (WS paths aren't in _PROTECTED_GET_PATHS) — so each
+    handler must call this explicitly to enforce auth when a key is
+    configured.  Auth succeeds if ANY of:
       - No API key is configured (backwards compatible)
       - Session cookie has authenticated=True
       - X-Api-Key header matches the configured key
+      - ?apikey= query parameter matches the configured key
 
     Returns True if authorized, False otherwise.  On failure, sends an
     error JSON message and the caller should return to close the socket.
@@ -2223,6 +2347,9 @@ def _validate_ws_auth(sock):
         return True
     header_key = request.headers.get("X-Api-Key")
     if header_key and secrets.compare_digest(header_key, api_key):
+        return True
+    query_key = request.args.get("apikey")
+    if query_key and secrets.compare_digest(query_key, api_key):
         return True
     try:
         sock.send(json.dumps({"error": "unauthorized"}))
@@ -2236,12 +2363,14 @@ def mqtt(sock):
     """
     Handles receiving and sending messages on the 'mqttqueue' stream service through websocket
     """
-    if not app.config["login"] or app.config.get("unsupported_device"):
+    if not app.config["login"]:
+        return
+    printer_index = _requested_printer_index()
+    if _printer_is_unsupported(printer_index=printer_index):
         return
     if not _validate_ws_auth(sock):
         return
 
-    printer_index = _requested_printer_index()
     # Cancel any reconnect back-off — the user just opened a browser tab,
     # which means they expect the connection to be live.
     _mqtt_svc_ref = get_mqtt_service(printer_index)
@@ -2271,12 +2400,14 @@ def video(sock):
     video_enabled is set True on connect and cleared when the last client disconnects,
     so multiple tabs can independently enable/disable without interfering.
     """
-    if not app.config["login"] or not app.config.get("video_supported") or app.config.get("unsupported_device"):
+    if not app.config["login"]:
+        return
+    printer_index = _requested_printer_index()
+    if not _printer_video_supported(printer_index=printer_index) or _printer_is_unsupported(printer_index=printer_index):
         return
     if not _validate_ws_auth(sock):
         return
 
-    printer_index = _requested_printer_index()
     vq = get_video_service(printer_index)
     if not vq:
         return
@@ -2406,13 +2537,16 @@ def pppp_state(sock):
       "connected"    — service running and PPPP handshake complete, or probe succeeded
       "disconnected" — service was connected but the connection was lost, or probe failed
     """
-    if not app.config["login"] or app.config.get("unsupported_device"):
+    if not app.config["login"]:
         log.info("Websocket connection rejected: no printer configured (use 'config import' or 'config login')")
+        return
+    printer_index = _requested_printer_index()
+    if _printer_is_unsupported(printer_index=printer_index):
+        log.info("Websocket connection rejected: printer_index=%s is an unsupported device", printer_index)
         return
     if not _validate_ws_auth(sock):
         return
 
-    printer_index = _requested_printer_index()
     log.info("Starting PPPP state websocket handler for printer_index=%s", printer_index)
 
     last_status = None
@@ -2571,14 +2705,16 @@ def ctrl(sock):
     """
     Handles controlling of light and video quality through websocket
     """
-    if not app.config["login"] or app.config.get("unsupported_device"):
+    if not app.config["login"]:
+        return
+    printer_index = _requested_printer_index()
+    if _printer_is_unsupported(printer_index=printer_index):
         return
     if not _validate_ws_auth(sock):
         return
 
     # send a response on connect, to let the client know the connection is ready
     sock.send(json.dumps({"ankerctl": 1}))
-    printer_index = _requested_printer_index()
     vq = get_video_service(printer_index)
     if vq:
         profile_id = getattr(vq, "saved_video_profile_id", None)
@@ -2596,6 +2732,9 @@ def ctrl(sock):
             break
         except (json.JSONDecodeError, TypeError) as exc:
             log.warning(f"/ws/ctrl: malformed message, ignoring: {exc}")
+            continue
+        except Exception as exc:
+            log.warning(f"/ws/ctrl: unexpected error, ignoring: {exc}")
             continue
 
         if "light" in msg:
@@ -2631,9 +2770,9 @@ def video_download():
     """
     Handles the video streaming/downloading feature in the Flask app
     """
-    # Enforce API key auth when configured; timelapse client uses ?for_timelapse=1
-    # on the loopback interface and does not carry a session, so allow it only when
-    # the request comes from localhost.
+    # Enforce API key auth when configured. There is no localhost/origin trust:
+    # every caller (incl. the timelapse client) must present the key via session,
+    # X-Api-Key header, or ?apikey= query param.
     api_key = app.config.get("api_key")
     if api_key:
         _hdr = request.headers.get("X-Api-Key", "")
@@ -2839,46 +2978,49 @@ def app_api_set_active_printer():
         return jsonify({"error": "Missing or invalid 'index' parameter"}), 400
 
     config = app.config["config"]
-    with config.open() as cfg:
-        if not cfg or new_index < 0 or new_index >= len(cfg.printers):
-            return jsonify({"error": f"Printer index {new_index} out of range"}), 400
+    # Serializes concurrent switch requests so register()/unregister() (unlocked
+    # in ServiceManager) and the config read-modify-write can't interleave.
+    with app.printer_switch_lock:
+        with config.open() as cfg:
+            if not cfg or new_index < 0 or new_index >= len(cfg.printers):
+                return jsonify({"error": f"Printer index {new_index} out of range"}), 400
 
-        # Block switching to an unsupported device (e.g. eufyMake E1 UV printer)
-        if cfg.printers[new_index].model in UNSUPPORTED_PRINTERS:
-            return jsonify({
-                "error": f"Device {cfg.printers[new_index].model} is not supported by ankerctl"
-            }), 403
+            # Block switching to an unsupported device (e.g. eufyMake E1 UV printer)
+            if cfg.printers[new_index].model in UNSUPPORTED_PRINTERS:
+                return jsonify({
+                    "error": f"Device {cfg.printers[new_index].model} is not supported by ankerctl"
+                }), 403
 
-        printer = cfg.printers[new_index]
-        video_supported = printer.model not in PRINTERS_WITHOUT_CAMERA
-        unsupported = printer.model in UNSUPPORTED_PRINTERS
+            printer = cfg.printers[new_index]
+            video_supported = printer.model not in PRINTERS_WITHOUT_CAMERA
+            unsupported = printer.model in UNSUPPORTED_PRINTERS
 
-    old_index = app.config["printer_index"]
-    if new_index == old_index:
-        return jsonify({"status": "ok", "message": "Already active"})
+        old_index = app.config["printer_index"]
+        if new_index == old_index:
+            return jsonify({"status": "ok", "message": "Already active"})
 
-    # Update in-memory state
-    app.config["printer_index"] = new_index
-    app.config["video_supported"] = video_supported
-    app.config["unsupported_device"] = unsupported
+        # Update in-memory state
+        app.config["printer_index"] = new_index
+        app.config["video_supported"] = video_supported
+        app.config["unsupported_device"] = unsupported
 
-    # Persist selection to config file
-    with config.modify() as cfg:
-        cfg.active_printer_index = new_index
+        # Persist selection to config file
+        with config.modify() as cfg:
+            cfg.active_printer_index = new_index
 
-    rich_service_manager = (
-        hasattr(app.svc, "svcs")
-        and hasattr(app.svc, "register")
-        and hasattr(app.svc, "unregister")
-    )
-    if rich_service_manager:
-        # Per-printer video/PPPP services stay attached to their own printer so
-        # background timelapses can continue even when the UI switches printers.
-        register_services(app)
-    else:
-        restart_all = getattr(app.svc, "restart_all", None)
-        if restart_all is not None:
-            restart_all(await_ready=False)
+        rich_service_manager = (
+            hasattr(app.svc, "svcs")
+            and hasattr(app.svc, "register")
+            and hasattr(app.svc, "unregister")
+        )
+        if rich_service_manager:
+            # Per-printer video/PPPP services stay attached to their own printer so
+            # background timelapses can continue even when the UI switches printers.
+            register_services(app)
+        else:
+            restart_all = getattr(app.svc, "restart_all", None)
+            if restart_all is not None:
+                restart_all(await_ready=False)
 
     log.info(f"Switched active printer: index {old_index} -> {new_index} ({printer.name})")
     return jsonify({"status": "ok", "printer": {"index": new_index, "name": printer.name, "sn": printer.sn}})
@@ -3089,6 +3231,14 @@ def app_api_files_local():
     # Snapshot the requested printer index at request time so the upload targets
     # the page's printer even if another tab switches the global active printer.
     printer_index = _requested_printer_index()
+
+    # Upload-only requests are harmless during a print; only block requests
+    # that would start a new print on top of the active job.
+    if not no_act:
+        with borrow_mqtt(printer_index) as mqtt:
+            if mqtt.is_printing or mqtt.has_pending_print_start or mqtt.is_preparing_print:
+                return {"error": "Printer is already busy with another print job"}, 409
+
     with app.config["config"].open() as cfg:
         rate_limit_mbps, rate_limit_source = cli.util.resolve_upload_rate_mbps_with_source(cfg)
 
@@ -3268,6 +3418,7 @@ def app_api_notifications_settings_update():
         notifications = _resolve_notifications(cfg)
         apprise_config = _resolve_apprise(cfg)
         apprise_config = _deep_update(apprise_config, apprise_payload)
+        apprise_config = merge_dict_defaults(apprise_config, default_apprise_config())
         notifications["apprise"] = apprise_config
         cfg.notifications = notifications
 
@@ -3291,6 +3442,7 @@ def app_api_notifications_test():
 
     if apprise_payload is not None:
         apprise_config = _deep_update(apprise_config, apprise_payload)
+        apprise_config = merge_dict_defaults(apprise_config, default_apprise_config())
 
     # Use explicit settings for snapshot generation test
     from web.notifications import AppriseNotifier
@@ -3454,6 +3606,15 @@ def app_api_settings_mqtt_update():
     if not isinstance(ha_payload, dict):
         return {"error": "Invalid home_assistant payload"}, 400
 
+    if "mqtt_port" in ha_payload:
+        try:
+            mqtt_port = int(ha_payload["mqtt_port"])
+        except (TypeError, ValueError):
+            return {"error": "mqtt_port must be an integer"}, 400
+        if not (1 <= mqtt_port <= 65535):
+            return {"error": "mqtt_port must be between 1 and 65535"}, 400
+        ha_payload["mqtt_port"] = mqtt_port
+
     with config.modify() as cfg:
         if not cfg:
             return {"error": "No printers configured"}, 400
@@ -3476,10 +3637,14 @@ def app_api_settings_mqtt_update():
 @app.get("/api/settings/filament-service")
 def app_api_settings_filament_service():
     config = app.config["config"]
+    printer_index = _requested_printer_index()
     with config.open() as cfg:
         if not cfg:
             return {"error": "No printers configured"}, 400
-        filament_config = _normalize_filament_service_settings(_resolve_filament_service_settings(cfg))
+        filament_config = _normalize_filament_service_settings(
+            _resolve_filament_service_settings(cfg), printer_index=printer_index, cfg=cfg
+        )
+        filament_config["all_metal_hotend"] = _hotend_all_metal_enabled(cfg, printer_index)
     return {"filament_service": filament_config}
 
 
@@ -3494,6 +3659,10 @@ def app_api_settings_filament_service_update():
     if not isinstance(fs_payload, dict):
         return {"error": "Invalid filament_service payload"}, 400
 
+    printer_index = _requested_printer_index()
+    all_metal_hotend = None
+    if "all_metal_hotend" in fs_payload:
+        all_metal_hotend = _filament_service_bool(fs_payload.pop("all_metal_hotend"))
     if "allow_legacy_swap" in fs_payload:
         fs_payload["allow_legacy_swap"] = _filament_service_bool(fs_payload["allow_legacy_swap"])
     if "manual_swap_preheat_temp_c" in fs_payload:
@@ -3519,10 +3688,28 @@ def app_api_settings_filament_service_update():
 
         current = _resolve_filament_service_settings(cfg)
         new_config = _deep_update(current, fs_payload)
-        new_config = _normalize_filament_service_settings(new_config)
+        if all_metal_hotend is not None:
+            printer_sn = _printer_sn(cfg, printer_index)
+            if not printer_sn:
+                return {"error": "No printer at requested printer_index"}, 400
+            per_printer = new_config.get("per_printer")
+            if not isinstance(per_printer, dict):
+                per_printer = {}
+            entry = per_printer.get(printer_sn)
+            entry = dict(entry) if isinstance(entry, dict) else {}
+            entry["all_metal_hotend"] = all_metal_hotend
+            per_printer[printer_sn] = entry
+            new_config["per_printer"] = per_printer
+        # Assign before normalizing so the manual-swap clamp sees an
+        # all_metal_hotend value changed in this same request.
         cfg.filament_service = new_config
+        new_config = _normalize_filament_service_settings(new_config, printer_index=printer_index, cfg=cfg)
+        cfg.filament_service = new_config
+        response_all_metal = _hotend_all_metal_enabled(cfg, printer_index)
 
-    return {"status": "ok", "filament_service": new_config}
+    result = dict(new_config)
+    result["all_metal_hotend"] = response_all_metal
+    return {"status": "ok", "filament_service": result}
 
 
 @app.get("/api/settings/filament-service/advanced")
@@ -3559,7 +3746,26 @@ def app_api_settings_filament_service_advanced_open():
 
 
 # GCode prefixes that are unsafe to send while a print is active
-_UNSAFE_GCODE_PREFIXES = {"G0", "G1", "G28", "G29", "G91", "G90"}
+_UNSAFE_GCODE_PREFIXES = {"G0", "G1", "G2", "G3", "G28", "G29", "G90", "G91", "G92", "M18", "M84"}
+
+
+def _gcode_unsafe_while_printing(line):
+    parts = line.upper().split()
+    if not parts:
+        return False
+    if parts[0] in _UNSAFE_GCODE_PREFIXES:
+        return True
+    if parts[0] == "M420":
+        # M420 S0 disables bed-mesh compensation mid-print; M420 V (query) is
+        # harmless and used by the bed-leveling feature, so only block S0.
+        rest = parts[1:]
+        for i, tok in enumerate(rest):
+            if tok == "S0":
+                return True
+            if tok == "S" and i + 1 < len(rest) and rest[i + 1] == "0":
+                return True
+    return False
+
 
 @app.post("/api/printer/gcode")
 def app_api_printer_gcode():
@@ -3575,12 +3781,19 @@ def app_api_printer_gcode():
     lines = cli.util.normalize_gcode_lines(gcode)
     if not lines:
         return {"error": "No executable gcode lines found"}, 400
+    if len(lines) > GCODE_CONSOLE_MAX_LINES:
+        return {
+            "error": (
+                f"Too many gcode lines ({len(lines)}); use the file upload/print "
+                f"feature for larger jobs (max {GCODE_CONSOLE_MAX_LINES} lines here)"
+            )
+        }, 400
 
     normalized_gcode = "\n".join(lines)
 
     with borrow_mqtt(printer_index) as mqtt:
         if mqtt.is_printing:
-            unsafe = [l for l in lines if l.split()[0].upper() in _UNSAFE_GCODE_PREFIXES]
+            unsafe = [l for l in lines if _gcode_unsafe_while_printing(l)]
             if unsafe:
                 return {"error": "Motion commands blocked while printing"}, 409
         mqtt.send_gcode(normalized_gcode)
@@ -3619,6 +3832,12 @@ def app_api_printer_control():
         return {"error": "Invalid control value"}, 400
 
     with borrow_mqtt(printer_index) as mqtt:
+        if value == 0 and not (
+            mqtt.is_printing
+            or mqtt.has_pending_print_start
+            or mqtt.is_preparing_print
+        ):
+            return {"error": "No active print to restart"}, 409
         mqtt.send_print_control(value)
 
     return {"status": "ok"}
@@ -3690,6 +3909,8 @@ def app_api_printer_z_offset_set():
     with borrow_mqtt(printer_index) as mqtt:
         try:
             return _set_printer_z_offset(mqtt, target_mm)
+        except ValueError as exc:
+            return {"error": str(exc)}, 400
         except TimeoutError as exc:
             return {"error": str(exc)}, 504
 
@@ -3713,6 +3934,8 @@ def app_api_printer_z_offset_nudge():
                 "display": f"{delta_mm:+.2f} mm",
             }
             return result
+        except ValueError as exc:
+            return {"error": str(exc)}, 400
         except TimeoutError as exc:
             return {"error": str(exc)}, 504
 
@@ -3765,7 +3988,12 @@ def _read_bed_leveling_grid(printer_index=None):
     for line in combined.splitlines():
         match = bl_pattern.search(line)
         if match:
-            values = [float(v) for v in match.group(1).split() if v]
+            try:
+                values = [float(v) for v in match.group(1).split() if v]
+            except ValueError:
+                # Truncated MQTT responses can glue values together (e.g. "-0.767-0.642")
+                log.warning(f"bed-leveling: could not parse grid row: {line!r}")
+                continue
             if values:
                 grid.append(values)
 
@@ -3780,16 +4008,17 @@ def _read_bed_leveling_grid(printer_index=None):
         "max": max(all_values),
         "rows": len(grid),
         "cols": max(len(row) for row in grid),
+        "printer_index": printer_index,
     }
 
-    # Persist grid to log directory as a timestamped .bed file
+    # Persist grid to log directory as a timestamped, printer-scoped .bed file
     if _log_dir:
         bed_dir = os.path.join(_log_dir, "bed_leveling")
         try:
             from datetime import datetime
             os.makedirs(bed_dir, exist_ok=True)
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-            bed_path = os.path.join(bed_dir, f"{ts}.bed")
+            bed_path = os.path.join(bed_dir, f"{ts}_p{printer_index}.bed")
             with open(bed_path, "w") as f:
                 json.dump(data, f)
             log.info(f"bed-leveling: saved grid to {bed_path}")
@@ -3990,22 +4219,25 @@ def _collect_printer_gcode_output(client, gcode, *, window, drain):
     }
 
 
-def _read_printer_report(name, printer_index=None):
+def _read_printer_report(name, printer_index=None, client=None):
     import cli.mqtt as cli_mqtt
 
     if name not in _PRINTER_REPORT_COMMANDS:
         raise KeyError(name)
 
     report = _PRINTER_REPORT_COMMANDS[name]
-    config = app.config.get("config")
-    if not config:
-        raise ConnectionError("No configuration loaded")
+    owns_client = client is None
 
-    printer_index = _service_printer_index(printer_index)
-    insecure = app.config.get("insecure", False)
+    if owns_client:
+        config = app.config.get("config")
+        if not config:
+            raise ConnectionError("No configuration loaded")
+        printer_index = _service_printer_index(printer_index)
+        insecure = app.config.get("insecure", False)
 
     try:
-        client = cli_mqtt.mqtt_open(config, printer_index, insecure)
+        if owns_client:
+            client = cli_mqtt.mqtt_open(config, printer_index, insecure)
         output = _collect_printer_gcode_output(
             client,
             report["gcode"],
@@ -4013,7 +4245,7 @@ def _read_printer_report(name, printer_index=None):
             drain=report["drain"],
         )
     finally:
-        if "client" in locals():
+        if owns_client and client is not None:
             _disconnect_mqtt_client(client)
 
     return {
@@ -4060,12 +4292,33 @@ def _read_printer_settings_summary(printer_index=None):
             except TimeoutError:
                 live_z_offset = mqtt.get_z_offset_state()
 
-    reports = {}
-    for name in ("settings", "probe_offset", "babystep"):
+    import cli.mqtt as cli_mqtt
+
+    # One shared connection for all three reports instead of paying the full
+    # connect/login handshake per report. If the shared open fails, fall back
+    # to per-report connections so error handling matches previous behavior.
+    shared_client = None
+    config = app.config.get("config")
+    if config:
         try:
-            reports[name] = _read_printer_report(name, printer_index=printer_index)
-        except Exception as exc:
-            reports[name] = {"name": name, "error": str(exc)}
+            shared_client = cli_mqtt.mqtt_open(
+                config, printer_index, app.config.get("insecure", False)
+            )
+        except Exception:
+            shared_client = None
+
+    reports = {}
+    try:
+        for name in ("settings", "probe_offset", "babystep"):
+            try:
+                reports[name] = _read_printer_report(
+                    name, printer_index=printer_index, client=shared_client
+                )
+            except Exception as exc:
+                reports[name] = {"name": name, "error": str(exc)}
+    finally:
+        if shared_client is not None:
+            _disconnect_mqtt_client(shared_client)
 
     commands = _extract_report_commands(
         reports.get("settings", {}).get("cleaned_output", ""),
@@ -4131,6 +4384,11 @@ def app_api_printer_bed_leveling():
     Do not call this during an active print.
     """
     printer_index = _requested_printer_index()
+    # get_mqtt_service (not borrow_mqtt): read-only check that must not start
+    # a stopped service or fail when no service is registered yet.
+    mqtt_svc = get_mqtt_service(printer_index)
+    if mqtt_svc is not None and getattr(mqtt_svc, "is_printing", False):
+        return {"error": "Cannot read bed leveling data while printing"}, 409
     data, err = _read_bed_leveling_grid(printer_index=printer_index)
     if err is not None:
         return err
@@ -4140,6 +4398,9 @@ def app_api_printer_bed_leveling():
 @app.get("/api/printer/settings-summary")
 def app_api_printer_settings_summary():
     printer_index = _requested_printer_index()
+    mqtt_svc = get_mqtt_service(printer_index)
+    if mqtt_svc is not None and getattr(mqtt_svc, "is_printing", False):
+        return {"error": "Cannot read printer settings while printing"}, 409
     try:
         return _read_printer_settings_summary(printer_index=printer_index)
     except TimeoutError as exc:
@@ -4168,17 +4429,27 @@ def app_api_printer_alerts():
 
 @app.get("/api/printer/bed-leveling/last")
 def app_api_printer_bed_leveling_last():
-    """Return the most recently saved bed leveling grid from the log directory."""
+    """Return the most recently saved bed leveling grid for the requested printer."""
     import glob
+    import re
     if not _log_dir:
         return {"error": "No log directory configured (set ANKERCTL_LOG_DIR)"}, 404
+    printer_index = _requested_printer_index()
     bed_dir = os.path.join(_log_dir, "bed_leveling")
-    files = sorted(glob.glob(os.path.join(bed_dir, "*.bed")))
+    files = sorted(glob.glob(os.path.join(bed_dir, f"*_p{printer_index}.bed")))
+    if not files:
+        # Legacy files predate per-printer tracking (no _pN suffix); keep them
+        # visible as a fallback so pre-fix installs don't lose saved data.
+        suffixed = re.compile(r"_p\d+\.bed$")
+        files = sorted(
+            f for f in glob.glob(os.path.join(bed_dir, "*.bed"))
+            if not suffixed.search(f)
+        )
     if not files:
         return {"error": "No saved bed leveling data found"}, 404
     with open(files[-1]) as f:
         data = json.load(f)
-    data["saved_at"] = os.path.basename(files[-1]).replace(".bed", "")
+    data["saved_at"] = re.sub(r"(?:_p\d+)?\.bed$", "", os.path.basename(files[-1]))
     return data
 
 
@@ -4555,6 +4826,8 @@ def app_api_history_clear():
         except (TypeError, ValueError):
             clear_printer_index = requested_printer_index
     with borrow_mqtt(requested_printer_index) as mqtt:
+        if mqtt.history.has_active_entry(printer_index=clear_printer_index):
+            return {"error": "Cannot clear history while a print is in progress"}, 409
         mqtt.history.clear(printer_index=clear_printer_index)
     return {"status": "ok"}
 
@@ -4645,8 +4918,11 @@ def app_api_history_reprint(entry_id):
     with app.config["config"].open() as cfg:
         rate_limit_mbps, rate_limit_source = cli.util.resolve_upload_rate_mbps_with_source(cfg)
 
-    with open(archive_path, "rb") as fh:
-        archive_bytes = fh.read()
+    try:
+        with open(archive_path, "rb") as fh:
+            archive_bytes = fh.read()
+    except FileNotFoundError:
+        return {"error": "Archived GCode is no longer available"}, 404
 
     with app.svc.borrow("filetransfer") as ft:
         if not ft:
@@ -4729,8 +5005,8 @@ def app_api_filaments_apply(profile_id):
     nozzle = profile.get("nozzle_temp_first_layer") or profile.get("nozzle_temp_other_layer") or profile.get("nozzle_temp", 0)
     bed    = profile.get("bed_temp_first_layer") or profile.get("bed_temp_other_layer") or profile.get("bed_temp", 0)
     try:
-        nozzle = max(0, min(int(nozzle), 350))
-        bed    = max(0, min(int(bed), 130))
+        nozzle = max(0, min(int(nozzle), _hotend_nozzle_max_c(printer_index=printer_index)))
+        bed    = max(0, min(int(bed), cli.model.HOTEND_BED_MAX_C))
     except (TypeError, ValueError):
         return {"error": "Invalid temperature values in filament profile"}, 422
     gcode = f"M104 S{nozzle}\nM140 S{bed}"
@@ -4766,7 +5042,7 @@ def app_api_filament_service_preheat():
     payload = request.get_json(silent=True) or {}
     try:
         profile = _filament_service_profile(payload, "profile_id")
-        temp_c = _filament_service_temp(profile)
+        temp_c = _filament_service_temp(profile, printer_index=printer_index)
         gcode = f"M104 S{temp_c}"
         with borrow_mqtt(printer_index) as mqtt:
             _assert_filament_service_ready(mqtt)
@@ -4802,10 +5078,12 @@ def app_api_filament_service_move():
         config = app.config["config"]
         with config.open() as cfg:
             filament_settings = _normalize_filament_service_settings(
-                _resolve_filament_service_settings(cfg) if cfg else cli.model.default_filament_service_config()
+                _resolve_filament_service_settings(cfg) if cfg else cli.model.default_filament_service_config(),
+                printer_index=printer_index,
+                cfg=cfg,
             )
         profile = _filament_service_profile(payload, "profile_id")
-        temp_c = _filament_service_temp(profile)
+        temp_c = _filament_service_temp(profile, printer_index=printer_index)
         raw_length_mm = payload.get("length_mm", filament_settings["quick_move_length_mm"])
         length_mm = _filament_service_length({"length_mm": raw_length_mm}, "length_mm")
         delta_mm = length_mm if action == "extrude" else -length_mm
@@ -4858,14 +5136,16 @@ def app_api_filament_service_swap_start():
     with config.open() as cfg:
         if not cfg:
             return {"error": "No printers configured"}, 400
-        filament_settings = _normalize_filament_service_settings(_resolve_filament_service_settings(cfg))
+        filament_settings = _normalize_filament_service_settings(
+            _resolve_filament_service_settings(cfg), printer_index=printer_index, cfg=cfg
+        )
 
     allow_legacy_swap = _filament_service_bool(filament_settings.get("allow_legacy_swap"))
     if "allow_legacy_swap" in payload:
         allow_legacy_swap = _filament_service_bool(payload.get("allow_legacy_swap"))
-    manual_swap_preheat_temp_c = _filament_service_manual_swap_temp(filament_settings)
+    manual_swap_preheat_temp_c = _filament_service_manual_swap_temp(filament_settings, printer_index=printer_index)
     if "manual_swap_preheat_temp_c" in payload:
-        manual_swap_preheat_temp_c = _filament_service_manual_swap_temp(payload)
+        manual_swap_preheat_temp_c = _filament_service_manual_swap_temp(payload, printer_index=printer_index)
 
     unload_profile = None
     load_profile = None
@@ -4901,8 +5181,8 @@ def app_api_filament_service_swap_start():
         try:
             unload_profile = _filament_service_profile(payload, "unload_profile_id")
             load_profile = _filament_service_profile(payload, "load_profile_id")
-            unload_temp_c = _filament_service_temp(unload_profile)
-            load_temp_c = _filament_service_temp(load_profile)
+            unload_temp_c = _filament_service_temp(unload_profile, printer_index=printer_index)
+            load_temp_c = _filament_service_temp(load_profile, printer_index=printer_index)
             prime_length_mm = _filament_service_length(
                 {"prime_length_mm": payload.get("prime_length_mm", filament_settings["swap_prime_length_mm"])},
                 "prime_length_mm",
@@ -4994,7 +5274,7 @@ def app_api_filament_service_swap_start():
         with borrow_mqtt(printer_index) as mqtt:
             _assert_filament_service_ready(mqtt)
             if allow_legacy_swap:
-                _filament_swap_start_background(_run_legacy_swap_unload, swap_state["token"])
+                _filament_swap_start_background(_run_legacy_swap_unload, swap_state["token"], printer_index)
             else:
                 mqtt.send_gcode(f"M104 S{manual_swap_preheat_temp_c}")
     except RuntimeError as exc:
@@ -5074,7 +5354,7 @@ def app_api_filament_service_swap_confirm():
         )
         return {"error": str(exc)}, 503
 
-    _filament_swap_start_background(_run_legacy_swap_load, swap_state["token"])
+    _filament_swap_start_background(_run_legacy_swap_load, swap_state["token"], printer_index)
     current_state = _filament_swap_state_get(swap_state["token"], printer_index=printer_index)
     if current_state is None:
         return {
@@ -5102,6 +5382,17 @@ def app_api_filament_service_swap_cancel():
         return {"error": "Swap token mismatch"}, 409
     printer_index = _service_printer_index(swap_state.get("printer_index", printer_index))
     cancelled_swap = _filament_swap_state_clear(swap_state["token"], printer_index=printer_index)
+    # Wait for the background worker to notice the cancellation so its final
+    # GCode sends cannot interleave with a swap started right after this call.
+    with app.filament_swap_lock:
+        swap_thread = app.filament_swap_threads.get(printer_index)
+    if swap_thread is not None:
+        if swap_thread.is_alive():
+            swap_thread.join(timeout=FILAMENT_SWAP_CANCEL_JOIN_TIMEOUT_S)
+        if not swap_thread.is_alive():
+            with app.filament_swap_lock:
+                if app.filament_swap_threads.get(printer_index) is swap_thread:
+                    app.filament_swap_threads.pop(printer_index, None)
     try:
         with borrow_mqtt(printer_index) as mqtt:
             if mqtt:
@@ -5503,7 +5794,8 @@ def webserver(config, printer_index, host, port, insecure=False, **kwargs):
 if os.getenv("ANKERCTL_DEV_MODE", "false").lower() == "true":
     @app.get("/api/debug/state")
     def app_api_debug_state():
-        with borrow_mqtt() as mqtt:
+        printer_index = _requested_printer_index()
+        with borrow_mqtt(printer_index) as mqtt:
             if not mqtt:
                 return {"error": "Service unavailable"}, 503
             return mqtt.get_state()
@@ -5512,7 +5804,8 @@ if os.getenv("ANKERCTL_DEV_MODE", "false").lower() == "true":
     def app_api_debug_config():
         payload = request.get_json(silent=True) or {}
         debug_logging = payload.get("debug_logging")
-        with borrow_mqtt() as mqtt:
+        printer_index = _requested_printer_index()
+        with borrow_mqtt(printer_index) as mqtt:
             if not mqtt:
                 return {"error": "Service unavailable"}, 503
             if debug_logging is not None:
@@ -5524,7 +5817,11 @@ if os.getenv("ANKERCTL_DEV_MODE", "false").lower() == "true":
         payload = request.get_json(silent=True) or {}
         event_type = payload.get("type")
         event_payload = payload.get("payload") or {}
-        with borrow_mqtt() as mqtt:
+        printer_index = _requested_printer_index()
+        mqtt_svc = get_mqtt_service(printer_index)
+        if event_type in ("start", "finish", "fail") and mqtt_svc is not None and getattr(mqtt_svc, "is_printing", False):
+            return {"error": "Cannot simulate print lifecycle events while a real print is in progress"}, 409
+        with borrow_mqtt(printer_index) as mqtt:
             if not mqtt:
                 return {"error": "Service unavailable"}, 503
             mqtt.simulate_event(event_type, event_payload)
@@ -5611,15 +5908,23 @@ if os.getenv("ANKERCTL_DEV_MODE", "false").lower() == "true":
 
         Delegates to _read_bed_leveling_grid() for the actual work.
         """
-        data, err = _read_bed_leveling_grid()
+        printer_index = _requested_printer_index()
+        mqtt_svc = get_mqtt_service(printer_index)
+        if mqtt_svc is not None and getattr(mqtt_svc, "is_printing", False):
+            return {"error": "Cannot read bed leveling data while printing"}, 409
+        data, err = _read_bed_leveling_grid(printer_index=printer_index)
         if err is not None:
             return err
         return data
 
     @app.get("/api/debug/printer-report/<name>")
     def app_api_debug_printer_report(name):
+        printer_index = _requested_printer_index()
+        mqtt_svc = get_mqtt_service(printer_index)
+        if mqtt_svc is not None and getattr(mqtt_svc, "is_printing", False):
+            return {"error": "Cannot read printer report while printing"}, 409
         try:
-            return _read_printer_report(name)
+            return _read_printer_report(name, printer_index=printer_index)
         except KeyError:
             return {"error": f"Unknown printer report: {name}"}, 404
         except TimeoutError as exc:
@@ -5677,14 +5982,16 @@ _PROTECTED_GET_PATHS = {
     "/api/history",
     "/api/timelapses",
     "/api/timelapse-snapshots",
+    # Live filename/task/preview_url/progress state, same sensitivity as the
+    # already-protected /api/debug/state and /api/history
+    "/api/printer/runtime-state",
+    # Proxies an outbound HTTP fetch of an externally-influenced preview_url
+    # (see _fetch_remote_image) — unauthenticated access makes this an SSRF
+    # trigger, not just a data leak
+    "/api/files/printer/thumbnail",
 }
 
 # POST endpoints needed for initial printer setup (config import / login)
-_SETUP_PATHS = {
-    "/api/ankerctl/config/upload",
-    "/api/ankerctl/config/login",
-}
-
 # URL path prefixes that send commands to the printer and must be blocked
 # when the active device is not supported (e.g. eufyMake E1 UV printer).
 # Any request whose path starts with one of these prefixes is rejected.
@@ -5716,11 +6023,11 @@ def _block_unsupported_device():
     This guard runs before auth so that the 503 is returned even on
     unauthenticated requests — the device must simply never be commanded.
     Static assets and config/setup paths are always allowed so the UI
-    remains reachable for configuration changes.
+    remains reachable for configuration changes. Scoped to the requested
+    printer_index (not just whichever printer is globally "active"), so a
+    blocked device mixed into the same account doesn't shadow requests for
+    a different, fully-supported printer.
     """
-    if not app.config.get("unsupported_device"):
-        return None
-
     path = request.path
 
     # Always allow static assets
@@ -5729,7 +6036,8 @@ def _block_unsupported_device():
 
     # Block printer-control paths
     if any(path.startswith(prefix) for prefix in _PRINTER_CONTROL_PREFIXES):
-        return jsonify({"error": "Active device is not supported by ankerctl"}), 503
+        if _printer_is_unsupported(printer_index=_requested_printer_index()):
+            return jsonify({"error": "Active device is not supported by ankerctl"}), 503
 
     return None
 
@@ -5761,7 +6069,11 @@ def _check_api_key():
 
     Read-only requests (GET) are allowed without auth so the WebUI
     stays accessible.  The API key is only required for mutations.
-    Setup endpoints are exempted when no printer is configured yet.
+
+    There is no setup-time exemption: if an operator has already configured
+    an API key (env var or config file) before first-run setup, that key is
+    required for the setup endpoints too. If no key is configured at all,
+    the early return above already allows everything, including setup.
     """
     api_key = app.config.get("api_key")
     if not api_key:
@@ -5776,11 +6088,12 @@ def _check_api_key():
     # strip the key from the visible URL and set a session cookie instead.
     # API endpoints and /video are accessed by programmatic clients (HA, ffmpeg,
     # Frigate) that don't persist session cookies across redirects, so skip the
-    # redirect entirely and let the request proceed directly.
+    # redirect entirely and let the request proceed directly.  WebSocket
+    # handshakes never follow redirects, so /ws/* must be exempt too.
     url_key = request.args.get("apikey")
     if url_key and secrets.compare_digest(url_key, api_key):
         session["authenticated"] = True
-        if request.path.startswith("/api/") or request.path == "/video":
+        if request.path.startswith("/api/") or request.path == "/video" or request.path.startswith("/ws/"):
             return None
         from flask import redirect
         params = {key: values for key, values in request.args.lists() if key != "apikey"}
@@ -5799,11 +6112,19 @@ def _check_api_key():
         request.path.startswith("/api/timelapse/")
         or request.path.startswith("/api/timelapse-snapshot/")
     )
-    if request.method in ("GET", "HEAD", "OPTIONS") and request.path not in _PROTECTED_GET_PATHS and not is_debug_path and not is_timelapse_path:
-        return None
-
-    # Allow setup endpoints when no printer is configured yet
-    if not app.config.get("login") and request.path in _SETUP_PATHS:
+    # /api/history/<id>/thumbnail proxies the same outbound preview_url fetch
+    # as /api/files/printer/thumbnail; the id varies so it can't live in
+    # _PROTECTED_GET_PATHS as an exact match.
+    is_history_thumbnail_path = (
+        request.path.startswith("/api/history/") and request.path.endswith("/thumbnail")
+    )
+    if (
+        request.method in ("GET", "HEAD", "OPTIONS")
+        and request.path not in _PROTECTED_GET_PATHS
+        and not is_debug_path
+        and not is_timelapse_path
+        and not is_history_thumbnail_path
+    ):
         return None
 
     # --- From here on, auth is required ---

--- a/web/config.py
+++ b/web/config.py
@@ -87,6 +87,11 @@ def config_show(config: object):
     return config_output
 
 
+MAX_LOGIN_FILE_BYTES = 8 * 1024 * 1024  # real login.json/leveldb caches are tiny; the generic
+                                          # upload size cap (UPLOAD_MAX_MB, default 512MB) exists
+                                          # for GCode uploads and is far too permissive here.
+
+
 def config_import(login_file: object, config: object):
     """
     Loads the configuration from the API. login_file is a file object containing the user's login information,
@@ -100,8 +105,14 @@ def config_import(login_file: object, config: object):
     - config_output: A formatted string containing the configuration information.
     """
     # get the login data
+    raw = login_file.stream.read(MAX_LOGIN_FILE_BYTES + 1)
+    if len(raw) > MAX_LOGIN_FILE_BYTES:
+        raise ConfigImportError(
+            f"Login file is too large (must be under {MAX_LOGIN_FILE_BYTES // (1024 * 1024)}MB)"
+        )
+
     try:
-        cache = libflagship.logincache.load(login_file.stream.read())
+        cache = libflagship.logincache.load(raw)
     except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as err:
         raise ConfigImportError(f"Failed to parse login file or slicer cache: {err}")
 

--- a/web/lib/service.py
+++ b/web/lib/service.py
@@ -78,6 +78,10 @@ class Service(Thread):
         self._ready_event = Event()
         self._stopped_event = Event()
         self._stopped_event.set()   # starts in stopped state
+        # Serialize overlapping restart() calls: a stale `wanted` snapshot taken
+        # before another thread's stop()/start() sequence can otherwise leave
+        # the service stopped after two concurrent restarts.
+        self._restart_lock = Lock()
         # S-4: snapshot-based handler dispatch to avoid holding lock during callbacks
         self._handlers_lock = Lock()
         self._handlers_snapshot = ()
@@ -113,13 +117,14 @@ class Service(Thread):
         self._event.set()
 
     def restart(self):
-        log.info(f"{self.name}: Requesting restart")
-        wanted = self.wanted
-        self.stop()
-        self.await_stopped()
-        if wanted:
-            self.start()
-            self.await_ready()
+        with self._restart_lock:
+            log.info(f"{self.name}: Requesting restart")
+            wanted = self.wanted
+            self.stop()
+            self.await_stopped()
+            if wanted:
+                self.start()
+                self.await_ready()
 
     def shutdown(self):
         if self.state != RunState.Stopped:
@@ -197,7 +202,7 @@ class Service(Thread):
         except Exception as E:
             if self.wanted:
                 self._log_start_failure(E, retrying=True)
-                self._holdoff.reset(delay=1)
+                self._holdoff.reset(delay=getattr(E, "delay", 1))
             else:
                 self._log_start_failure(E, retrying=False)
                 self.state = RunState.Stopped

--- a/web/notifications.py
+++ b/web/notifications.py
@@ -407,4 +407,7 @@ class AppriseNotifier:
                 if light_changed:
                     log.info("Apprise snapshot: Restoring light state")
                     restore_state = original_light_state if original_light_state is not None else False
-                    vq.api_light_state(restore_state)
+                    try:
+                        vq.api_light_state(restore_state)
+                    except Exception as err:
+                        log.warning(f"Apprise snapshot: failed to restore light state: {err}")

--- a/web/service/filament.py
+++ b/web/service/filament.py
@@ -7,6 +7,8 @@ import sqlite3
 import threading
 import logging
 
+from cli.model import HOTEND_ALL_METAL_NOZZLE_MAX_C, HOTEND_BED_MAX_C
+
 log = logging.getLogger(__name__)
 
 # Fields that are displayed in the UI and must be sanitized against XSS
@@ -34,6 +36,30 @@ def _normalize_required_name(value):
     if not value:
         raise ValueError("name is required")
     return value
+
+
+# Profiles are printer-agnostic, so validate against the most permissive
+# hardware ceiling (all-metal hotend). The per-printer ceiling is enforced
+# at apply/preheat/swap time in the web routes.
+_TEMP_BOUNDS = {
+    "nozzle_temp_other_layer": (0, HOTEND_ALL_METAL_NOZZLE_MAX_C),
+    "nozzle_temp_first_layer": (0, HOTEND_ALL_METAL_NOZZLE_MAX_C),
+    "bed_temp_other_layer": (0, HOTEND_BED_MAX_C),
+    "bed_temp_first_layer": (0, HOTEND_BED_MAX_C),
+}
+
+
+def _validate_temps(safe):
+    """Reject out-of-range temperature fields present in the input dict."""
+    for field, (low, high) in _TEMP_BOUNDS.items():
+        if field not in safe or safe[field] is None:
+            continue
+        try:
+            value = int(safe[field])
+        except (TypeError, ValueError):
+            raise ValueError(f"{field} must be a number")
+        if value < low or value > high:
+            raise ValueError(f"{field} must be between {low} and {high}")
 
 
 _SCHEMA = """
@@ -442,6 +468,7 @@ class FilamentStore:
             if field in safe:
                 safe[field] = _sanitize_text(safe[field])
         safe["name"] = _normalize_required_name(safe.get("name"))
+        _validate_temps(safe)
         cols = ", ".join(safe.keys())
         placeholders = ", ".join("?" for _ in safe)
         with self._lock:
@@ -469,6 +496,7 @@ class FilamentStore:
                 safe[field] = _sanitize_text(safe[field])
         if "name" in safe:
             safe["name"] = _normalize_required_name(safe["name"])
+        _validate_temps(safe)
         if not safe:
             return self.get(profile_id)
         assignments = ", ".join(f"{k} = ?" for k in safe)

--- a/web/service/filetransfer.py
+++ b/web/service/filetransfer.py
@@ -11,6 +11,7 @@ from libflagship.ppppapi import FileUploadInfo, PPPPError
 import cli.util
 import cli.pppp
 from cli.util import patch_gcode_time, extract_filament_info, extract_layer_count
+from .pppp import reserve_session
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +22,14 @@ from ..notifications import AppriseNotifier, format_bytes
 class FileTransferService(Service):
 
     REPLY_TIMEOUT = 10.0
+    # Generous window for the initial connect, since it now retries (see
+    # cli.pppp.pppp_open) instead of failing on the printer's first
+    # rejection — the printer can need a few seconds to free its PPPP
+    # session slot after reserve_session() stops the shared video session.
+    # Field data showed a genuinely active video stream can hold the
+    # printer's session slot for well over 25s; uploads are not
+    # latency-sensitive, so a slow success beats a hard failure.
+    CONNECT_TIMEOUT = 60.0
     PROGRESS_INTERVAL = 0.25
 
     def worker_init(self):
@@ -116,65 +125,66 @@ class FileTransferService(Service):
                 "start_print": start_print_flag,
             })
         effective_printer_index = printer_index if printer_index is not None else app.config.get("printer_index", 0)
-        try:
-            api = cli.pppp.pppp_open(
-                app.config["config"],
-                effective_printer_index,
-                timeout=self.REPLY_TIMEOUT,
-                dumpfile=pppp_dump,
-            )
-        except Exception as e:
-            self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
-            raise ConnectionError(f"No pppp connection to printer: {e}") from e
-        try:
-            cli.pppp.pppp_send_file(
-                api,
-                fui,
-                data,
-                rate_limit_mbps=rate_limit_mbps,
-                progress_cb=progress_cb,
-                show_progress=False,
-            )
-            if start_print:
-                log.info("File upload complete. Requesting print start of job.")
-                api.aabb_request(b"", frametype=FileTransfer.END, timeout=15.0)
-                try:
-                    with borrow_mqtt(printer_index) as mqtt:
-                        try:
-                            mqtt.mark_pending_print_start(upload_name, archive_info=archive_info)
-                        except TypeError:
-                            mqtt.mark_pending_print_start(upload_name)
-                except Exception as e:
-                    log.warning(f"Could not mark pending print start in mqttqueue: {e}")
+        with reserve_session(effective_printer_index):
+            try:
+                api = cli.pppp.pppp_open(
+                    app.config["config"],
+                    effective_printer_index,
+                    timeout=self.CONNECT_TIMEOUT,
+                    dumpfile=pppp_dump,
+                )
+            except Exception as e:
+                self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
+                raise ConnectionError(f"No pppp connection to printer: {e}") from e
+            try:
+                cli.pppp.pppp_send_file(
+                    api,
+                    fui,
+                    data,
+                    rate_limit_mbps=rate_limit_mbps,
+                    progress_cb=progress_cb,
+                    show_progress=False,
+                )
+                if start_print:
+                    log.info("File upload complete. Requesting print start of job.")
+                    api.aabb_request(b"", frametype=FileTransfer.END, timeout=15.0)
+                    try:
+                        with borrow_mqtt(printer_index) as mqtt:
+                            try:
+                                mqtt.mark_pending_print_start(upload_name, archive_info=archive_info)
+                            except TypeError:
+                                mqtt.mark_pending_print_start(upload_name)
+                    except Exception as e:
+                        log.warning(f"Could not mark pending print start in mqttqueue: {e}")
+                else:
+                    log.info("File upload complete (upload-only)")
+            except ConnectionError as e:
+                log.error(f"Could not send print job: {e}")
+                self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
+                raise
+            except (PPPPError, OSError, EOFError, TimeoutError) as e:
+                log.error(f"Could not send print job: {e}")
+                self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
+                raise ConnectionError(f"PPPP transfer failed: {e}") from e
+            except Exception as e:
+                log.error(f"Could not send print job: {e}")
+                self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
+                raise
             else:
-                log.info("File upload complete (upload-only)")
-        except ConnectionError as e:
-            log.error(f"Could not send print job: {e}")
-            self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
-            raise
-        except (PPPPError, OSError, EOFError, TimeoutError) as e:
-            log.error(f"Could not send print job: {e}")
-            self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
-            raise ConnectionError(f"PPPP transfer failed: {e}") from e
-        except Exception as e:
-            log.error(f"Could not send print job: {e}")
-            self._notify_upload({"status": "error", "name": upload_name, "error": str(e), "start_print": start_print_flag})
-            raise
-        else:
-            if start_print:
-                log.info("Successfully sent print job")
-            else:
-                log.info("Successfully uploaded file")
-            self._notify_upload({
-                "status": "done",
-                "name": upload_name,
-                "size": fui.size,
-                "sent": fui.size,
-                "start_print": start_print_flag,
-            })
-            self._notify_apprise_upload(upload_name, fui.size, start_print)
-        finally:
-            api.stop()
+                if start_print:
+                    log.info("Successfully sent print job")
+                else:
+                    log.info("Successfully uploaded file")
+                self._notify_upload({
+                    "status": "done",
+                    "name": upload_name,
+                    "size": fui.size,
+                    "sent": fui.size,
+                    "start_print": start_print_flag,
+                })
+                self._notify_apprise_upload(upload_name, fui.size, start_print)
+            finally:
+                api.stop()
 
     def _notify_apprise_upload(self, filename, size_bytes, start_print):
         payload = {

--- a/web/service/filetransfer.py
+++ b/web/service/filetransfer.py
@@ -10,7 +10,7 @@ from libflagship.ppppapi import FileUploadInfo, PPPPError
 
 import cli.util
 import cli.pppp
-from cli.util import patch_gcode_time, extract_layer_count
+from cli.util import patch_gcode_time, extract_filament_info, extract_layer_count
 
 log = logging.getLogger(__name__)
 
@@ -57,15 +57,26 @@ class FileTransferService(Service):
         archive_info=None,
     ):
         layer_count = extract_layer_count(raw)
+        filament_info = extract_filament_info(raw)
         data = patch_gcode_time(raw)
         start_print_flag = bool(start_print)
-        if layer_count is not None:
+        if layer_count is not None or filament_info:
             try:
                 with borrow_mqtt(printer_index) as mqtt:
-                    mqtt.set_gcode_layer_count(layer_count)
-                log.info(f"GCode layer count from header: {layer_count}")
+                    if layer_count is not None:
+                        mqtt.set_gcode_layer_count(layer_count)
+                    if filament_info:
+                        mqtt.set_gcode_filament_info(**filament_info)
+                if layer_count is not None:
+                    log.info(f"GCode layer count from header: {layer_count}")
+                if filament_info:
+                    log.info(
+                        "GCode filament metadata: vendor=%r type=%r",
+                        filament_info.get("vendor"),
+                        filament_info.get("type"),
+                    )
             except Exception as e:
-                log.warning(f"Could not store layer count in mqttqueue: {e}")
+                log.warning(f"Could not store GCode metadata in mqttqueue: {e}")
         user_id = "-"
         try:
             with app.config["config"].open() as cfg:

--- a/web/service/history.py
+++ b/web/service/history.py
@@ -225,11 +225,13 @@ class PrintHistory:
             with self._connect() as conn:
                 if self._retention_days > 0:
                     cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=self._retention_days)).isoformat()
-                    conn.execute("DELETE FROM print_history WHERE started_at < ?", (cutoff,))
+                    # status filter: the shared DB means another printer's long-running
+                    # print may exceed retention age while still active — never prune it.
+                    conn.execute("DELETE FROM print_history WHERE started_at < ? AND status != 'started'", (cutoff,))
 
                 if self._max_entries > 0:
                     conn.execute("""
-                        DELETE FROM print_history WHERE id NOT IN (
+                        DELETE FROM print_history WHERE status != 'started' AND id NOT IN (
                             SELECT id FROM print_history ORDER BY id DESC LIMIT ?
                         )
                     """, (self._max_entries,))
@@ -777,33 +779,55 @@ class PrintHistory:
                     log.info("History: deleted %d selected entr%s", deleted, "y" if deleted == 1 else "ies")
                 return deleted
 
+    def _has_active_entry_locked(self, conn, printer_index=None):
+        sql = "SELECT 1 FROM print_history WHERE status='started'"
+        params = ()
+        if printer_index is not None:
+            sql += " AND printer_index=?"
+            params = (int(printer_index),)
+        return conn.execute(sql + " LIMIT 1", params).fetchone() is not None
+
+    def has_active_entry(self, printer_index=None):
+        """Return True if an in-progress (status='started') entry exists.
+
+        When printer_index is provided, only that printer's rows are checked.
+        """
+        with self._lock:
+            with self._connect() as conn:
+                return self._has_active_entry_locked(conn, printer_index)
+
     def clear(self, printer_index=None):
         """Delete history entries.
 
         When printer_index is provided, only rows for that printer are removed.
-        Legacy rows with NULL printer_index are preserved.
+        Legacy rows with NULL printer_index are preserved. In-progress entries
+        (status='started') and their archived files are never deleted.
         """
         with self._lock:
             with self._connect() as conn:
-                if printer_index is None:
+                delete_archive_dir = False
+                # Fast path: nothing is printing anywhere, so wipe table + archive dir.
+                if printer_index is None and not self._has_active_entry_locked(conn):
                     conn.execute("DELETE FROM print_history")
                     log.info("Print history cleared")
                     delete_archive_dir = True
                 else:
-                    scoped_index = int(printer_index)
+                    if printer_index is None:
+                        where = "status != 'started'"
+                        params = ()
+                    else:
+                        where = "printer_index=? AND status != 'started'"
+                        params = (int(printer_index),)
                     archive_relpaths = [
                         row[0]
                         for row in conn.execute(
                             "SELECT DISTINCT archive_relpath FROM print_history "
-                            "WHERE printer_index=? AND archive_relpath IS NOT NULL AND archive_relpath != ''",
-                            (scoped_index,),
+                            f"WHERE {where} AND archive_relpath IS NOT NULL AND archive_relpath != ''",
+                            params,
                         ).fetchall()
                         if row[0]
                     ]
-                    conn.execute(
-                        "DELETE FROM print_history WHERE printer_index=?",
-                        (scoped_index,),
-                    )
+                    conn.execute(f"DELETE FROM print_history WHERE {where}", params)
                     if archive_relpaths:
                         still_referenced = {
                             row[0]
@@ -818,7 +842,9 @@ class PrintHistory:
                             [relpath for relpath in archive_relpaths if relpath not in still_referenced]
                         )
                     self._delete_unreferenced_archives(conn)
-                    log.info("Print history cleared for printer %d", scoped_index)
-                    delete_archive_dir = False
+                    if printer_index is None:
+                        log.info("Print history cleared (in-progress entries preserved)")
+                    else:
+                        log.info("Print history cleared for printer %d", int(printer_index))
         if delete_archive_dir and self._archive_dir and os.path.isdir(self._archive_dir):
             shutil.rmtree(self._archive_dir, ignore_errors=True)

--- a/web/service/homeassistant.py
+++ b/web/service/homeassistant.py
@@ -99,42 +99,60 @@ class HomeAssistantService:
         cfg = config.home_assistant
         new_enabled = cfg.get("enabled", False)
         new_host = cfg.get("mqtt_host", _DEFAULT_HOST)
-        new_port = int(cfg.get("mqtt_port", _DEFAULT_PORT))
+        try:
+            new_port = int(cfg.get("mqtt_port", _DEFAULT_PORT))
+        except (TypeError, ValueError) as err:
+            log.warning(
+                f"HA MQTT: invalid mqtt_port in config ({err!r}), keeping current port {self._port}"
+            )
+            new_port = self._port
         new_user = cfg.get("mqtt_username", "")
         new_password = cfg.get("mqtt_password", "")
         new_discovery_prefix = cfg.get("discovery_prefix", _DEFAULT_DISCOVERY_PREFIX)
         # topic prefix is not in config model yet? Defaults to ankerctl
         new_topic_prefix = os.getenv("HA_MQTT_TOPIC_PREFIX", _DEFAULT_TOPIC_PREFIX)
 
-        # check if restart needed
-        need_restart = False
-        if self._client: # Only if currently running
-            if (self._host != new_host or 
-                self._port != new_port or 
-                self._user != new_user or 
-                self._password != new_password or
-                self._discovery_prefix != new_discovery_prefix or
-                self._topic_prefix != new_topic_prefix):
-                need_restart = True
-            if self._enabled and not new_enabled:
-                self.stop() # Just stop
-                need_restart = False
+        # Decide what action to take under the lock, but perform the actual
+        # stop()/start() calls after releasing it — those methods acquire
+        # self._lock themselves and it is a plain Lock, not reentrant.
+        with self._lock:
+            need_restart = False
+            action = None
+            if self._client:  # Only if currently running
+                if (self._host != new_host or
+                    self._port != new_port or
+                    self._user != new_user or
+                    self._password != new_password or
+                    self._discovery_prefix != new_discovery_prefix or
+                    self._topic_prefix != new_topic_prefix):
+                    need_restart = True
+                if self._enabled and not new_enabled:
+                    action = "stop"
+                    need_restart = False
 
-        self._enabled = new_enabled
-        self._host = new_host
-        self._port = new_port
-        self._user = new_user
-        self._password = new_password
-        self._discovery_prefix = new_discovery_prefix
-        self._topic_prefix = new_topic_prefix
-        # Env vars take precedence over config file values
-        self._ha_base_url = (os.getenv("HA_BASE_URL") or cfg.get("ha_base_url", "")).rstrip("/")
-        self._ha_token = os.getenv("HA_TOKEN") or cfg.get("ha_token", "")
+            self._enabled = new_enabled
+            self._host = new_host
+            self._port = new_port
+            self._user = new_user
+            self._password = new_password
+            self._discovery_prefix = new_discovery_prefix
+            self._topic_prefix = new_topic_prefix
+            # Env vars take precedence over config file values
+            self._ha_base_url = (os.getenv("HA_BASE_URL") or cfg.get("ha_base_url", "")).rstrip("/")
+            self._ha_token = os.getenv("HA_TOKEN") or cfg.get("ha_token", "")
 
-        if need_restart and self._enabled:
+            if action is None:
+                if need_restart and self._enabled:
+                    action = "restart"
+                elif self._enabled and not self._client:
+                    action = "start"
+
+        if action == "stop":
+            self.stop()
+        elif action == "restart":
             self.stop()
             self.start()
-        elif self._enabled and not self._client:
+        elif action == "start":
             self.start()
 
     @property
@@ -154,66 +172,68 @@ class HomeAssistantService:
         integration. paho's background thread retries with exponential
         backoff.
         """
-        if not self._enabled:
-            return
-        if self._client:
-            return
+        with self._lock:
+            if not self._enabled:
+                return
+            if self._client:
+                return
 
-        log.info(f"HA MQTT: connecting to {self._host}:{self._port}")
-        if hasattr(paho_mqtt, "CallbackAPIVersion"):
-            self._client = paho_mqtt.Client(paho_mqtt.CallbackAPIVersion.VERSION1, client_id=f"ankerctl-{self._printer_sn}", clean_session=True)
-        else:
-            self._client = paho_mqtt.Client(client_id=f"ankerctl-{self._printer_sn}", clean_session=True)
+            log.info(f"HA MQTT: connecting to {self._host}:{self._port}")
+            if hasattr(paho_mqtt, "CallbackAPIVersion"):
+                self._client = paho_mqtt.Client(paho_mqtt.CallbackAPIVersion.VERSION1, client_id=f"ankerctl-{self._printer_sn}", clean_session=True)
+            else:
+                self._client = paho_mqtt.Client(client_id=f"ankerctl-{self._printer_sn}", clean_session=True)
 
-        if self._user:
-            self._client.username_pw_set(self._user, self._password)
+            if self._user:
+                self._client.username_pw_set(self._user, self._password)
 
-        self._client.on_connect = self._on_connect
-        self._client.on_disconnect = self._on_disconnect
-        self._client.on_message = self._on_message
+            self._client.on_connect = self._on_connect
+            self._client.on_disconnect = self._on_disconnect
+            self._client.on_message = self._on_message
 
-        # Bound reconnect backoff so brief broker outages recover quickly
-        # but sustained unreachability doesn't hammer the network.
-        self._client.reconnect_delay_set(min_delay=1, max_delay=60)
+            # Bound reconnect backoff so brief broker outages recover quickly
+            # but sustained unreachability doesn't hammer the network.
+            self._client.reconnect_delay_set(min_delay=1, max_delay=60)
 
-        # Set LWT (Last Will and Testament) so HA marks device offline
-        avail_topic = self._availability_topic()
-        self._client.will_set(avail_topic, payload="offline", qos=1, retain=True)
+            # Set LWT (Last Will and Testament) so HA marks device offline
+            avail_topic = self._availability_topic()
+            self._client.will_set(avail_topic, payload="offline", qos=1, retain=True)
 
-        try:
-            self._client.connect_async(self._host, self._port, keepalive=60)
-        except ValueError as err:
-            # Invalid host/port syntax — genuine misconfiguration.
-            log.error(f"HA MQTT: invalid broker configuration: {err}")
-            self._client = None
-            return
-        except OSError as err:
-            # Broker unreachable right now (ConnectionRefused, NetworkUnreachable, etc.).
-            # Log a warning but proceed to loop_start() so paho retries automatically.
-            log.warning(f"HA MQTT: initial connect failed ({err}), will retry via background loop")
+            try:
+                self._client.connect_async(self._host, self._port, keepalive=60)
+            except ValueError as err:
+                # Invalid host/port syntax — genuine misconfiguration.
+                log.error(f"HA MQTT: invalid broker configuration: {err}")
+                self._client = None
+                return
+            except OSError as err:
+                # Broker unreachable right now (ConnectionRefused, NetworkUnreachable, etc.).
+                # Log a warning but proceed to loop_start() so paho retries automatically.
+                log.warning(f"HA MQTT: initial connect failed ({err}), will retry via background loop")
 
-        self._client.loop_start()
+            self._client.loop_start()
 
     def stop(self):
         """Disconnect from the HA MQTT broker and mark device offline."""
-        self._unregister_ha_mjpeg_camera()
+        with self._lock:
+            self._unregister_ha_mjpeg_camera()
 
-        if not self._client:
-            return
+            if not self._client:
+                return
 
-        self._stop_event.set()
-        if self._availability_thread and self._availability_thread.is_alive():
-            self._availability_thread.join(timeout=5)
+            self._stop_event.set()
+            if self._availability_thread and self._availability_thread.is_alive():
+                self._availability_thread.join(timeout=5)
 
-        try:
-            self._publish(self._availability_topic(), "offline", retain=True)
-            self._client.disconnect()
-            self._client.loop_stop()
-        except Exception as err:
-            log.warning(f"HA MQTT: disconnect error: {err}")
-        finally:
-            self._client = None
-            self._connected = False
+            try:
+                self._publish(self._availability_topic(), "offline", retain=True)
+                self._client.disconnect()
+                self._client.loop_stop()
+            except Exception as err:
+                log.warning(f"HA MQTT: disconnect error: {err}")
+            finally:
+                self._client = None
+                self._connected = False
 
     # ------------------------------------------------------------------
     # Callbacks
@@ -570,7 +590,15 @@ class HomeAssistantService:
         flask_port = os.getenv("FLASK_PORT") or "4470"
 
         params = f"printer_index={self._printer_index}"
-        api_key = os.getenv("ANKERCTL_API_KEY", "")
+        # app.config["api_key"] holds the resolved key (env var or config file);
+        # the env var alone misses keys set via the Setup UI / config set-password.
+        try:
+            import web
+
+            api_key = web.app.config.get("api_key") or ""
+        except Exception:
+            api_key = ""
+        api_key = api_key or os.getenv("ANKERCTL_API_KEY", "")
         if api_key:
             params += f"&apikey={api_key}"
 
@@ -627,7 +655,7 @@ class HomeAssistantService:
             return
         if isinstance(entries, list):
             for entry in entries:
-                if entry.get("domain") == "mjpeg" and "ankerctl" in entry.get("title", ""):
+                if entry.get("domain") == "mjpeg" and entry.get("title", "") == camera_name:
                     self._ha_mjpeg_entry_id = entry.get("entry_id")
                     log.debug(f"HA REST: existing MJPEG camera entry found ({self._ha_mjpeg_entry_id}), skipping")
                     return

--- a/web/service/homeassistant.py
+++ b/web/service/homeassistant.py
@@ -57,6 +57,7 @@ class HomeAssistantService:
             "nozzle_temp_target": None,
             "bed_temp": None,
             "bed_temp_target": None,
+            "fan_speed": None,
             "print_speed": None,
             "print_layer": None,
             "print_filename": None,
@@ -297,7 +298,7 @@ class HomeAssistantService:
 
         Accepts keyword arguments matching state keys:
             print_progress, print_status, nozzle_temp, nozzle_temp_target,
-            bed_temp, bed_temp_target, print_speed, print_layer,
+            bed_temp, bed_temp_target, fan_speed, print_speed, print_layer,
             print_filename, time_elapsed, time_remaining,
             mqtt_connected, pppp_connected, light
         """
@@ -416,6 +417,13 @@ class HomeAssistantService:
                 "unit": "\u00b0C",
                 "device_class": "temperature",
                 "value_template": "{{ value_json.bed_temp_target | default(0) }}",
+            },
+            {
+                "id": "fan_speed",
+                "name": "Part Cooling Fan",
+                "unit": "%",
+                "icon": "mdi:fan",
+                "value_template": "{{ value_json.fan_speed | default(0) }}",
             },
             {
                 "id": "print_speed",

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -180,6 +180,9 @@ class MqttQueue(Service):
         self._filament_change_step_len = None
         self._filament_issue = None
         self._filament_issue_code = None
+        self._filament_vendor = None
+        self._filament_type = None
+        self._filament_metadata_source = None
         self._pause_reason = None
         self._filament_runout_pending = False
         self._filament_runout_pending_at = 0.0
@@ -200,6 +203,12 @@ class MqttQueue(Service):
     def set_gcode_layer_count(self, count: int):
         """Store the layer count extracted from a GCode header for UI display."""
         self._gcode_layer_count = count
+
+    def set_gcode_filament_info(self, vendor=None, type=None):
+        """Store slicer filament metadata for the next print."""
+        self._filament_vendor = self._clean_filament_metadata(vendor)
+        self._filament_type = self._clean_filament_metadata(type)
+        self._filament_metadata_source = "gcode" if self._filament_vendor or self._filament_type else None
 
     def reset_reconnect_backoff(self):
         """Cancel any reconnect back-off and attempt connection immediately.
@@ -248,6 +257,9 @@ class MqttQueue(Service):
         self._last_print_schedule_filename = None
         self._last_print_schedule_seen_at = 0.0
         self._pending_prepare_state_logged = False
+        self._filament_vendor = None
+        self._filament_type = None
+        self._filament_metadata_source = None
         self._clear_timelapse_start_offer()
         self._pause_reason = None
         self._filament_runout_pending = False
@@ -480,6 +492,34 @@ class MqttQueue(Service):
 
     _FILENAME_SANITIZE_RE = re.compile(r'[^\w.\-]')
     _MULTI_DOT_RE = re.compile(r'\.{2,}')
+    _FILAMENT_TYPE_FROM_FILENAME_RE = re.compile(
+        r"(?:^|[_\-\s.])(PLA|PETG|ABS|ASA|TPU|PC|PA|NYLON|PVA|HIPS)(?:$|[_\-\s.])",
+        re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _clean_filament_metadata(value):
+        cleaned = str(value or "").strip().strip('"').strip()
+        return cleaned or None
+
+    def _infer_filament_type_from_filename(self, filename):
+        if self._filament_metadata_source == "gcode":
+            return
+        match = self._FILAMENT_TYPE_FROM_FILENAME_RE.search(os.path.basename(str(filename or "")))
+        self._filament_vendor = None
+        self._filament_type = match.group(1).upper() if match else None
+        self._filament_metadata_source = "filename" if match else None
+
+    def _filament_material_label(self):
+        parts = [
+            value
+            for value in (
+                getattr(self, "_filament_vendor", None),
+                getattr(self, "_filament_type", None),
+            )
+            if value
+        ]
+        return " ".join(parts) if parts else None
 
     @staticmethod
     def _normalize_pending_archive_filename(filename):
@@ -525,6 +565,7 @@ class MqttQueue(Service):
         with self._state_lock:
             if filename:
                 self._last_filename = filename
+                self._infer_filament_type_from_filename(filename)
             if task_id:
                 self._last_task_id = task_id
             if archive_info and archive_info.get("archive_relpath"):
@@ -1507,6 +1548,7 @@ class MqttQueue(Service):
                     filename = self._last_filename
             else:
                 self._last_filename = filename
+                self._infer_filament_type_from_filename(filename)
             self._complete_deferred_print_start()
 
         pending_name = os.path.basename(self._pending_stored_file_path) if self._pending_stored_file_path else None
@@ -1707,6 +1749,10 @@ class MqttQueue(Service):
             "filament": {
                 "state": getattr(self, "_filament_state", "unknown"),
                 "label": FILAMENT_STATE_LABELS.get(getattr(self, "_filament_state", "unknown"), "Unknown"),
+                "material_label": self._filament_material_label(),
+                "vendor": getattr(self, "_filament_vendor", None),
+                "type": getattr(self, "_filament_type", None),
+                "metadata_source": getattr(self, "_filament_metadata_source", None),
                 "loaded": True if getattr(self, "_filament_state", "unknown") == "loaded" else None,
                 "issue": getattr(self, "_filament_issue", None),
                 "issue_label": FILAMENT_ISSUE_LABELS.get(getattr(self, "_filament_issue", None)),

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -149,12 +149,16 @@ class MqttQueue(Service):
                 printer = cfg.printers[self.printer_index]
                 printer_sn = getattr(printer, "sn", None)
                 printer_name = getattr(printer, "name", None) or "AnkerMake M5"
-        self._ha = HomeAssistantService(
-            app.config["config"],
-            printer_sn=printer_sn,
-            printer_name=printer_name,
-            printer_index=self.printer_index,
-        )
+        try:
+            self._ha = HomeAssistantService(
+                app.config["config"],
+                printer_sn=printer_sn,
+                printer_name=printer_name,
+                printer_index=self.printer_index,
+            )
+        except Exception as err:
+            log.error(f"HomeAssistantService init failed, HA integration disabled: {err}", exc_info=True)
+            self._ha = None
         # HomeAssistantService.__init__ calls reload_config() which calls start()
         # when enabled, so no explicit start() call is needed here.
         self._printer_name = printer_name or "AnkerMake M5"
@@ -227,7 +231,12 @@ class MqttQueue(Service):
             app.config["insecure"],
             mqtt_ca_cert,
         )
-        self._reset_print_state()
+        # A reconnect is a connection-layer event, not the end of a print: the
+        # printer's own state (task_id, filename, progress) self-heals from the
+        # next live telemetry, but filament vendor/type has no telemetry source
+        # to re-derive from (it's a one-shot value pushed from the GCode header
+        # at upload time), so it must not be wiped here or it is lost for good.
+        self._reset_print_state(preserve_filament_metadata=True)
         self._ha.start()
         self._ha.update_state(mqtt_connected=True)
         self._last_query = 0
@@ -236,7 +245,7 @@ class MqttQueue(Service):
             time.monotonic() + TIMELAPSE_START_PROMPT_BOOT_WINDOW_SEC
         )
 
-    def _reset_print_state(self):
+    def _reset_print_state(self, preserve_filament_metadata=False):
         self._state = PrintState.IDLE
         self._last_state_value = 0
         self._print_started_at = None
@@ -257,9 +266,10 @@ class MqttQueue(Service):
         self._last_print_schedule_filename = None
         self._last_print_schedule_seen_at = 0.0
         self._pending_prepare_state_logged = False
-        self._filament_vendor = None
-        self._filament_type = None
-        self._filament_metadata_source = None
+        if not preserve_filament_metadata:
+            self._filament_vendor = None
+            self._filament_type = None
+            self._filament_metadata_source = None
         self._clear_timelapse_start_offer()
         self._pause_reason = None
         self._filament_runout_pending = False
@@ -937,6 +947,8 @@ class MqttQueue(Service):
                 self._print_state_event.set()
 
     def worker_stop(self):
+        if getattr(self, "_timelapse", None):
+            self._timelapse.handle_mqtt_service_stopped()
         self._ha.update_state(mqtt_connected=False)
         self._ha.stop()
         if hasattr(self, "client"):
@@ -1928,6 +1940,9 @@ class MqttQueue(Service):
                 "totalLayer": total_layers,
             }
             self.notify(sim_payload)
+
+        else:
+            log.warning(f"simulate_event: unknown event type {event_type!r}")
 
     def send_gcode(self, gcode):
         if not gcode:

--- a/web/service/mqtt.py
+++ b/web/service/mqtt.py
@@ -169,6 +169,7 @@ class MqttQueue(Service):
         self._nozzle_temp_updated_at = 0.0
         self._bed_temp = None
         self._bed_temp_target = None
+        self._fan_speed = None
         self._z_offset_steps = None
         self._z_offset_updated_at = 0.0
         self._z_offset_seq = 0
@@ -1237,9 +1238,18 @@ class MqttQueue(Service):
                 self._bed_temp_target = self._normalize_temp(target)
                 ha_updates["bed_temp_target"] = self._bed_temp_target
 
+        # Part cooling fan speed (command 1005 = 0x03ed), reported as percent.
+        elif command_type == MqttMsgType.ZZ_MQTT_CMD_FAN_SPEED:
+            speed_raw = payload.get("value") if "value" in payload else payload.get("speed")
+            speed = self._safe_int(speed_raw)
+            if speed is not None:
+                self._fan_speed = max(0, min(100, speed))
+                ha_updates["fan_speed"] = self._fan_speed
+
         # Print speed (command 1006 = 0x03ee)
         elif command_type == MqttMsgType.ZZ_MQTT_CMD_PRINT_SPEED:
-            speed = self._safe_int(payload.get("value") or payload.get("speed"))
+            speed_raw = payload.get("value") if "value" in payload else payload.get("speed")
+            speed = self._safe_int(speed_raw)
             if speed is not None:
                 ha_updates["print_speed"] = speed
 
@@ -1689,6 +1699,9 @@ class MqttQueue(Service):
                 "nozzle_target": self._nozzle_temp_target,
                 "bed": self._bed_temp,
                 "bed_target": self._bed_temp_target,
+            },
+            "telemetry": {
+                "fan_speed": self._fan_speed,
             },
             "z_offset": self.get_z_offset_state(),
             "filament": {

--- a/web/service/pppp.py
+++ b/web/service/pppp.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 import threading
@@ -24,6 +25,75 @@ _CONNECT_DEADLINE_SEC = 8.0
 _REPEATED_LOG_COOLDOWN_SEC = 10.0
 _REPEATED_LOG_NOTICE_COUNT = 5
 _LOG_REPEAT_STATE_MAX = 256
+
+# Reconnect backoff for real link flakiness (e.g. brief printer WiFi drops).
+# Without this, a burst of remote CLOSEs/timeouts was retried every ~1s with
+# no growth, hammering the printer for minutes during an outage. A session
+# only "earns back" a clean slate once it has stayed up for a while — a
+# connect that succeeds and immediately drops again keeps escalating.
+_BACKOFF_BASE_SEC = 1.0
+_BACKOFF_CAP_SEC = 8.0
+_STABLE_CONNECTION_SEC = 10.0
+
+# The printer only accepts a single active PPPP session. File transfers open
+# their own dedicated connection (see filetransfer.py) instead of sharing
+# this service's, so without coordination a transfer starting while
+# video/timelapse holds a session causes both sides to race for the
+# printer's one session slot — seen as a "received CLOSE from remote peer"
+# reconnect storm on both ends and the transfer failing outright. These
+# per-service-name locks let a transfer reserve the slot: it stops this
+# service for the duration, and worker_start() below refuses to reconnect
+# while the reservation is held.
+_session_locks = {}
+_session_locks_guard = threading.Lock()
+
+
+def _get_session_lock(service_name):
+    with _session_locks_guard:
+        lock = _session_locks.get(service_name)
+        if lock is None:
+            lock = threading.Lock()
+            _session_locks[service_name] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def reserve_session(printer_index=None):
+    """Exclusively reserve a printer's PPPP session for a file transfer.
+
+    Stops the shared PPPPService for the printer (if it currently wants to
+    be running) so a dedicated file-transfer connection doesn't collide with
+    it, and restarts it afterward. See the module-level comment above
+    _session_locks for why this is necessary.
+    """
+    import web
+
+    service_name = web.resolve_pppp_service_name(printer_index)
+    lock = _get_session_lock(service_name)
+    svc = None
+    was_wanted = False
+    try:
+        with lock:
+            svc = getattr(app.svc, "svcs", {}).get(service_name)
+            was_wanted = bool(svc is not None and svc.wanted)
+            if was_wanted:
+                # Intentionally ignores app.svc.refs (unlike register_services):
+                # the printer only supports one PPPP session, so a file transfer
+                # must preempt video/timelapse holders. VideoQueue self-heals
+                # once the service restarts below.
+                svc.stop()
+                # Field data: an actively streaming video session can take
+                # longer than 5s to fully relinquish its hold; proceeding
+                # before the stop is confirmed makes the transfer connect
+                # against a still-occupied printer session slot.
+                svc.await_stopped(timeout=15.0)
+            yield
+    finally:
+        # Restart outside the lock: worker_start() probes this same lock, and
+        # starting while still holding it makes the service thread lose the
+        # race and eat its default holdoff (~1s) on every upload.
+        if was_wanted:
+            svc.start()
 
 
 def probe_pppp(config, printer_index) -> bool:
@@ -63,7 +133,32 @@ class PPPPService(Service):
         self._handler_lock = threading.Lock()
         self._log_repeat_state = OrderedDict()
         self._connected_event = threading.Event()
+        self._connect_failure_count = 0
+        self._connected_since = None
         super().__init__()
+
+    def _note_connection_lost(self):
+        """Update the reconnect-failure streak and return the backoff delay to use.
+
+        Resets the streak if the connection that was just lost had stayed up
+        for at least _STABLE_CONNECTION_SEC (a real recovery), otherwise
+        escalates it — so a rapid connect/drop/connect/drop cycle backs off
+        instead of hammering the printer every ~1s indefinitely.
+        """
+        connected_since = getattr(self, "_connected_since", None)
+        stable = (
+            connected_since is not None
+            and (datetime.now() - connected_since).total_seconds() >= _STABLE_CONNECTION_SEC
+        )
+        self._connected_since = None
+        if stable:
+            self._connect_failure_count = 0
+        else:
+            self._connect_failure_count = getattr(self, "_connect_failure_count", 0) + 1
+        return min(
+            _BACKOFF_BASE_SEC * (2 ** max(0, self._connect_failure_count - 1)),
+            _BACKOFF_CAP_SEC,
+        )
 
     def await_connected(self, timeout: float = 10.0) -> bool:
         """Block until the PPPP connection is established or *timeout* seconds elapse."""
@@ -79,10 +174,31 @@ class PPPPService(Service):
         if not hasattr(self, "_api"):
             return
         api = self._api
-        # Do not try to send a graceful close packet here. After a video freeze,
-        # that send path can block and leave PPPP half-stopped forever. Force the
-        # transport down locally so the service thread can complete its stop and
-        # be restarted cleanly.
+        # Best-effort notify the printer that this session is over, so it
+        # releases its single PPPP session slot immediately instead of
+        # waiting out its own internal keepalive/timeout. Without this, a
+        # file transfer starting right after (e.g. reserve_session() above)
+        # gets its connect attempts rejected with "received CLOSE from
+        # remote peer" for the printer's entire session timeout, because as
+        # far as the printer knows the old (video) session is still alive.
+        #
+        # This is safe to do even mid-freeze-recovery: unlike
+        # send_xzyh()/send_aabb(), which route through Channel.write() and
+        # can block waiting on a DRW ACK from the printer, AnkerPPPPBaseApi
+        # .send() is a raw, non-blocking sock.sendto() — it never waits for
+        # any response, so it cannot reintroduce the hang this code used to
+        # guard against. We only attempt it while the api still reports
+        # itself Connected; send() raises ConnectionError for Idle/
+        # Disconnected states, which is also the state an already-broken
+        # connection (e.g. one that triggered this force-close) is likely
+        # to be in already, so the guard doubles as a no-op skip in that
+        # case. The unconditional socket teardown below remains the actual
+        # safety net regardless of whether this send succeeds.
+        try:
+            if getattr(api, "state", None) == PPPPState.Connected:
+                api.send(PktClose())
+        except Exception:
+            pass
         try:
             api.state = PPPPState.Disconnected
         except Exception:
@@ -149,8 +265,18 @@ class PPPPService(Service):
         )
 
     def worker_start(self):
-        config = app.config["config"]
+        import web
+
         printer_index = getattr(self, "printer_index", app.config.get("printer_index", 0))
+        service_name = web.resolve_pppp_service_name(printer_index)
+        lock = _get_session_lock(service_name)
+        if not lock.acquire(blocking=False):
+            raise ConnectionError(
+                "PPPP session reserved for a file transfer; retrying shortly"
+            )
+        lock.release()
+
+        config = app.config["config"]
 
         deadline = datetime.now() + timedelta(seconds=_CONNECT_DEADLINE_SEC)
 
@@ -175,7 +301,10 @@ class PPPPService(Service):
                 printer.name,
                 printer.p2p_duid,
             )
-            raise ConnectionRefusedError("No printer IP found; ensure printer is online on the same network")
+            raise ServiceRestartSignal(
+                "No printer IP found; ensure printer is online on the same network",
+                delay=self._note_connection_lost(),
+            )
 
         api = AnkerPPPPAsyncApi.open_lan(Duid.from_string(printer.p2p_duid), host=ip_addr)
         if app.config["pppp_dump"]:
@@ -214,7 +343,9 @@ class PPPPService(Service):
                     ip_addr,
                     getattr(api, "state", None),
                 )
-                raise ConnectionRefusedError("Connection rejected by device")
+                raise ServiceRestartSignal(
+                    "Connection rejected by device", delay=self._note_connection_lost()
+                )
             try:
                 msg = api.recv(timeout=remaining)
                 api.process(msg)
@@ -230,7 +361,9 @@ class PPPPService(Service):
                     printer.name,
                     ip_addr,
                 )
-                raise ConnectionRefusedError("Connection rejected by device")
+                raise ServiceRestartSignal(
+                    "Connection rejected by device", delay=self._note_connection_lost()
+                )
 
         elapsed = (datetime.now() - started_at).total_seconds()
         log.info(
@@ -241,6 +374,7 @@ class PPPPService(Service):
         )
         self._api = api
         self._connected_event.set()
+        self._connected_since = datetime.now()
 
     def _drain_xzyh(self, chan):
         api = getattr(self, "_api", None)
@@ -306,7 +440,9 @@ class PPPPService(Service):
         api = getattr(self, "_api", None)
         if api is None:
             if getattr(self, "wanted", True):
-                raise ServiceRestartSignal("PPPP API missing while service is wanted", delay=0)
+                raise ServiceRestartSignal(
+                "PPPP API missing while service is wanted", delay=self._note_connection_lost()
+            )
             return
 
         # A stale/disconnected API object after video recovery is not a usable
@@ -314,7 +450,10 @@ class PPPPService(Service):
         # forever in a wanted-but-disconnected state.
         if getattr(api, "state", PPPPState.Connected) != PPPPState.Connected:
             if getattr(self, "wanted", True):
-                raise ServiceRestartSignal("PPPP API exists but is not connected while service is wanted", delay=0)
+                raise ServiceRestartSignal(
+                "PPPP API exists but is not connected while service is wanted",
+                delay=self._note_connection_lost(),
+            )
             return
 
         try:
@@ -322,7 +461,7 @@ class PPPPService(Service):
         except (ConnectionResetError, OSError):
             if not getattr(self, "wanted", True):
                 return
-            raise ServiceRestartSignal(delay=0)
+            raise ServiceRestartSignal(delay=self._note_connection_lost())
 
         # Drain all remaining UDP packets without blocking. The 10ms service
         # floor caps us at 100 poll() calls/second, but H.264 video needs many
@@ -339,12 +478,16 @@ class PPPPService(Service):
         api = getattr(self, "_api", None)
         if api is None:
             if getattr(self, "wanted", True):
-                raise ServiceRestartSignal("PPPP API disappeared during worker loop", delay=0)
+                raise ServiceRestartSignal(
+                "PPPP API disappeared during worker loop", delay=self._note_connection_lost()
+            )
             return
 
         if getattr(api, "state", PPPPState.Connected) != PPPPState.Connected:
             if getattr(self, "wanted", True):
-                raise ServiceRestartSignal("PPPP API disconnected during worker loop", delay=0)
+                raise ServiceRestartSignal(
+                "PPPP API disconnected during worker loop", delay=self._note_connection_lost()
+            )
             return
 
         chans = getattr(api, "chans", [])

--- a/web/service/timelapse.py
+++ b/web/service/timelapse.py
@@ -61,6 +61,9 @@ class TimelapseService:
             os.makedirs(self._captures_dir, exist_ok=True)
 
         self._lock = threading.Lock()
+        # Serializes prune passes across concurrent finalize threads —
+        # separate from self._lock so pruning never blocks capture start/stop.
+        self._prune_lock = threading.Lock()
         self._capture_thread = None
         self._stop_event = threading.Event()
         self._current_dir = None
@@ -540,6 +543,9 @@ class TimelapseService:
             log.warning("Timelapse: ffmpeg not available, skipping")
             return
 
+        stale_dir = None
+        stale_filename = None
+        stale_frame_count = 0
         with self._lock:
             self._capture_camera = self._resolve_capture_camera()
             if not self._capture_camera.get("effective_source"):
@@ -610,6 +616,16 @@ class TimelapseService:
             else:
                 # New capture or different file — discard any pending resume
                 self._cancel_pending_resume()
+                if self._current_dir is not None:
+                    # A previous capture was never finalized (e.g. the finish/
+                    # abort event was missed across an MQTT reconnect) —
+                    # recover its frames instead of orphaning the directory.
+                    if self._frame_count > 0:
+                        stale_dir = self._current_dir
+                        stale_filename = self._current_filename
+                        stale_frame_count = self._frame_count
+                    else:
+                        self._cleanup_dir(self._current_dir)
                 self._prepare_capture_services()
                 self._current_filename = filename
                 ts = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -635,6 +651,14 @@ class TimelapseService:
                 f"Timelapse: started capture for '{filename}' "
                 f"(interval={self._interval}s, source={camera_source})"
             )
+
+        # Assemble outside the lock — ffmpeg can take up to 120 s
+        if stale_dir:
+            log.warning(
+                f"Timelapse: previous capture for '{stale_filename}' was never "
+                f"finalized ({stale_frame_count} frames), recovering it"
+            )
+            self._finalize_now(stale_dir, stale_filename, stale_frame_count, suffix="_recovered")
 
     def finish_capture(self, final=False):
         """Stop capture and assemble video.
@@ -736,6 +760,21 @@ class TimelapseService:
                 suffix="_partial",
             )
 
+    def handle_mqtt_service_stopped(self):
+        """Restore light/video state when the MQTT service stops mid-capture.
+
+        Only acts when a capture is genuinely active — calling
+        _disable_video_for_timelapse() unconditionally would force the light
+        off even when timelapse never touched it (its _light_was_on default
+        of None restores to False).
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            if self._current_dir is None:
+                return
+            self._disable_video_for_timelapse()
+
     def _stop_capture_thread(self):
         if self._capture_thread and self._capture_thread.is_alive():
             self._stop_event.set()
@@ -783,6 +822,8 @@ class TimelapseService:
             host = "127.0.0.1"
         port = os.getenv("FLASK_PORT") or "4470"
         api_key = app.config.get("api_key")
+        # Pass the key via HTTP header so it never lands in ffmpeg's argv/URL
+        extra_headers = f"X-Api-Key: {api_key}\r\n" if api_key else None
 
         # Per-snapshot light control: turn on, wait for camera to adjust, then shoot
         vq = (
@@ -813,6 +854,7 @@ class TimelapseService:
                 api_key=api_key,
                 timeout=_SNAPSHOT_TIMEOUT,
                 for_timelapse=(effective_source == web.camera.CAMERA_SOURCE_PRINTER),
+                extra_headers=extra_headers,
             )
             self._set_recovery_state(False)
             self._frame_count += 1
@@ -1067,26 +1109,27 @@ class TimelapseService:
         """Remove oldest archived snapshot collections if over max count."""
         if self._max_videos <= 0:
             return
-        try:
-            base = self._snapshot_archive_base()
-            collections = sorted(
-                (
-                    os.path.join(base, name)
-                    for name in os.listdir(base)
-                    if os.path.isdir(os.path.join(base, name))
-                    and self._media_name_belongs_to_this_printer(
-                        name,
-                        self._read_meta(os.path.join(base, name)),
-                    )
-                ),
-                key=os.path.getmtime,
-            )
-            while len(collections) > self._max_videos:
-                oldest = collections.pop(0)
-                shutil.rmtree(oldest, ignore_errors=True)
-                log.info(f"Timelapse: pruned old snapshot collection {os.path.basename(oldest)}")
-        except OSError as err:
-            log.warning(f"Timelapse: snapshot prune failed: {err}")
+        with self._prune_lock:
+            try:
+                base = self._snapshot_archive_base()
+                collections = sorted(
+                    (
+                        os.path.join(base, name)
+                        for name in os.listdir(base)
+                        if os.path.isdir(os.path.join(base, name))
+                        and self._media_name_belongs_to_this_printer(
+                            name,
+                            self._read_meta(os.path.join(base, name)),
+                        )
+                    ),
+                    key=os.path.getmtime,
+                )
+                while len(collections) > self._max_videos:
+                    oldest = collections.pop(0)
+                    shutil.rmtree(oldest, ignore_errors=True)
+                    log.info(f"Timelapse: pruned old snapshot collection {os.path.basename(oldest)}")
+            except OSError as err:
+                log.warning(f"Timelapse: snapshot prune failed: {err}")
 
     def save_manual_snapshot(self, source_path, *, camera_settings=None, taken_at=None):
         """Persist a manually captured snapshot so it appears in the Snapshots tab."""
@@ -1294,28 +1337,29 @@ class TimelapseService:
         """Remove oldest videos if over max count."""
         if self._max_videos <= 0:
             return
-        try:
-            videos = sorted(
-                [
-                    f for f in os.listdir(self._captures_dir)
-                    if f.endswith(".mp4")
-                    and self._media_name_belongs_to_this_printer(f)
-                ],
-                key=lambda f: os.path.getmtime(os.path.join(self._captures_dir, f)),
-            )
-            while len(videos) > self._max_videos:
-                oldest = videos.pop(0)
-                os.remove(os.path.join(self._captures_dir, oldest))
-                removed_collections = self._delete_snapshot_collections_for_video(oldest)
-                if removed_collections:
-                    log.info(
-                        f"Timelapse: pruned old video {oldest} and snapshot collection(s) "
-                        f"{', '.join(removed_collections)}"
-                    )
-                else:
-                    log.info(f"Timelapse: pruned old video {oldest}")
-        except OSError as err:
-            log.warning(f"Timelapse: prune failed: {err}")
+        with self._prune_lock:
+            try:
+                videos = sorted(
+                    [
+                        f for f in os.listdir(self._captures_dir)
+                        if f.endswith(".mp4")
+                        and self._media_name_belongs_to_this_printer(f)
+                    ],
+                    key=lambda f: os.path.getmtime(os.path.join(self._captures_dir, f)),
+                )
+                while len(videos) > self._max_videos:
+                    oldest = videos.pop(0)
+                    os.remove(os.path.join(self._captures_dir, oldest))
+                    removed_collections = self._delete_snapshot_collections_for_video(oldest)
+                    if removed_collections:
+                        log.info(
+                            f"Timelapse: pruned old video {oldest} and snapshot collection(s) "
+                            f"{', '.join(removed_collections)}"
+                        )
+                    else:
+                        log.info(f"Timelapse: pruned old video {oldest}")
+            except OSError as err:
+                log.warning(f"Timelapse: prune failed: {err}")
 
     def list_videos(self):
         """Return list of available timelapse videos with metadata."""


### PR DESCRIPTION
## Summary

This PR grew from its original scope (fan telemetry on the print status card) into a full security/stability review pass plus live-hardware-driven PPPP hardening, done across several sessions. Commit history on this branch reflects the actual thematic grouping:

- **Fan telemetry** (original scope): fan speed shown on the print status card, telemetry card layout refined.
- **Security and stability review pass (Tasks #4-18)**: systematic pass across auth, config, printer control, camera, print history, filament service, timelapse, notifications, Home Assistant integration, bed leveling, and the debug tab. Several real bugs found and fixed, incl. a Z-offset input with no bounds check at all (nozzle could theoretically be driven into the bed), an API key leaking via ffmpeg argv on every timelapse snapshot, print history clear/prune able to delete an actively-printing job's record and archived file, and a single malformed HA `mqtt_port` value able to permanently hang the whole MQTT service. Each finding has a regression test.
- **Hotend temperature correction (Task #23)**: bounds were previously placeholder guesses; corrected to the real AnkerMake M5 spec (260°C/100°C stock, 300°C/100°C all-metal), with a per-printer "All-Metal Hotend" toggle now living in Setup -> Printer.
- **PPPP session handling and upload pipeline hardening**: the GCode-upload-during-active-video failure took four rounds of live-hardware retesting to fully fix -- connect timeout too short, an unbounded hang one layer deeper, the printer never being told a session ended so it held the slot for its own internal timeout, and finally a single-packet-drop intolerance on the handshake send. Confirmed working end-to-end on a real printer after the fourth round.

## Test plan

- [x] `python3 -m pytest tests/ -q` -- 519 passed, 15 skipped, no regressions
- [x] Live-tested against a real AnkerMake M5: upload while camera stream is active, filament metadata survives MQTT reconnect, Z-offset clamp, pause/resume/stop, HA MJPEG dedup after container restart
- [x] All-Metal Hotend toggle relocated and verified in Setup -> Printer

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>